### PR TITLE
feat: add packaged app runtime support

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -1,6 +1,6 @@
 # Baby Menu Design System
 
-A design system for **Baby Menu** — a macOS tray-bar Electron app that lives behind a system menu-bar icon. Click the tray icon and a small dark popover falls from the menu bar. Inside the popover, an embedded agent can edit the app's own source code at runtime to add widgets, and the user can interact with those widgets without ever leaving the menu surface.
+A design system for **Baby Menu** — a macOS tray-bar Electron app that lives behind a system menu-bar icon. Click the tray icon and a small dark popover falls from the menu bar. Inside the popover, an embedded agent can edit the active extension workspace at runtime to add widgets, and the user can interact with those widgets without ever leaving the menu surface.
 
 The visual direction is **Monochrome Lab** — terminal-elegant, near-black, mono type, one mint signal color. The popover should read as a calm command-line surface that happens to live in the macOS menu bar.
 
@@ -24,7 +24,7 @@ This system was built from the live codebase at:
 
 Key files referenced (paths in that repo):
 
-- `AGENTS.md` — architecture, three-process split, `GitChangeSession` invariants, recipe conventions.
+- `AGENTS.md` — architecture, three-process split, source-vs-packaged change-session invariants, recipe conventions.
 - `src/renderer/styles.css` — the original warm-paper palette (now replaced by this system's monochrome direction).
 - `src/renderer/App.tsx`, `src/renderer/agent/AgentChat.tsx`, `src/renderer/menu/MenuSurface.tsx`, `src/renderer/menu/WidgetHost.tsx` — the components being redesigned here.
 - `src/shared/contracts.ts` — `BabyMenuWidget`, `RefreshableBabyMenuWidget`, `GitSessionSnapshot`, `AgentChatResult` — the data contracts our redesign remains compatible with.

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -35,4 +35,4 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 ## Reference repo
 
-The live product code lives at https://github.com/kunchenguid/baby-menu. Read `AGENTS.md` and `src/shared/contracts.ts` there for the architectural ground truth (three-process Electron split, `GitChangeSession` invariants, widget contracts).
+The live product code lives at https://github.com/kunchenguid/baby-menu. Read `AGENTS.md` and `src/shared/contracts.ts` there for the architectural ground truth (three-process Electron split, source-vs-packaged change-session invariants, widget contracts).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: typecheck / test / build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,5 +102,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/baby-menu.rb
-          git commit -m "baby-menu ${VERSION_NUMBER}"
-          git push
+          if ! git diff --cached --quiet; then
+            git commit -m "baby-menu ${VERSION_NUMBER}"
+            git push
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,13 @@ jobs:
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" "$DMG_PATH" --title "$GITHUB_REF_NAME" --generate-notes --latest
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$DMG_PATH" --clobber
+            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --latest
+          else
+            gh release create "$GITHUB_REF_NAME" "$DMG_PATH" --title "$GITHUB_REF_NAME" --generate-notes --latest
+          fi
 
       - name: Compute SHA256
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Package macOS app
+        run: pnpm exec electron-builder --mac dir --universal
+
+      - name: Ad-hoc sign app
+        run: codesign --force --deep --sign - "release/mac-universal/Baby Menu.app"
+
+      - name: Create DMG
+        run: |
+          VERSION_NUMBER="${GITHUB_REF_NAME#v}"
+          DMG_NAME="Baby-Menu-${VERSION_NUMBER}-universal.dmg"
+          hdiutil create -volname "Baby Menu" \
+            -srcfolder "release/mac-universal/Baby Menu.app" \
+            -ov -format UDZO "release/${DMG_NAME}"
+          echo "VERSION_NUMBER=${VERSION_NUMBER}" >> "$GITHUB_ENV"
+          echo "DMG_NAME=${DMG_NAME}" >> "$GITHUB_ENV"
+          echo "DMG_PATH=release/${DMG_NAME}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" "$DMG_PATH" --title "$GITHUB_REF_NAME" --generate-notes --latest
+
+      - name: Compute SHA256
+        run: |
+          SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
+
+      - name: Update Homebrew Cask
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/kunchenguid/homebrew-tap.git" "$RUNNER_TEMP/homebrew-tap"
+          mkdir -p "$RUNNER_TEMP/homebrew-tap/Casks"
+          cat > "$RUNNER_TEMP/homebrew-tap/Casks/baby-menu.rb" << CASK_EOF
+          cask "baby-menu" do
+            version "${VERSION_NUMBER}"
+            sha256 "${SHA256}"
+
+            url "https://github.com/kunchenguid/baby-menu/releases/download/v#{version}/Baby-Menu-#{version}-universal.dmg"
+            name "Baby Menu"
+            desc "Menu-bar app that writes its own widgets"
+            homepage "https://github.com/kunchenguid/baby-menu"
+
+            depends_on macos: ">= :ventura"
+
+            app "Baby Menu.app"
+            uninstall quit: "com.kunchenguid.baby-menu"
+
+            postflight do
+              system_command "/usr/bin/xattr",
+                             args: ["-cr", "#{appdir}/Baby Menu.app"],
+                             must_succeed: false
+            end
+
+            zap trash: [
+              "~/.baby-menu",
+              "~/Library/Preferences/com.kunchenguid.baby-menu.plist",
+            ]
+          end
+          CASK_EOF
+          cd "$RUNNER_TEMP/homebrew-tap"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/baby-menu.rb
+          git commit -m "baby-menu ${VERSION_NUMBER}"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ Embedded agents launched from baby-menu should work from the active extension wo
 
 ## Commands
 
+- `pnpm start` - runs `electron-vite dev` directly with no extension workspace override. `BabyMenuAgentRuntime` falls back to the tracked `extensions/` directory, so the embedded agent edits real git-tracked files gated by `GitChangeSession`. Use this when iterating on or shipping changes to tracked extensions.
 - `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md` and `extensions/recipes/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
 - `pnpm dev:reset` - removes `extensions-dev/`, recreates it with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
 - `pnpm build` - build main, preload, and renderer bundles into `out/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Embedded agents launched from baby-menu should work from the active extension wo
 - `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md` and `extensions/recipes/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
 - `pnpm dev:reset` - removes `extensions-dev/`, recreates it with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
 - `pnpm build` - build main, preload, and renderer bundles into `out/`.
+- `pnpm package:mac` - builds the app, packages `release/mac-universal/Baby Menu.app`, and ad-hoc signs it for local testing.
+- `pnpm dist:mac` - runs `package:mac` and creates `release/Baby-Menu-<version>-universal.dmg`.
 - `pnpm test` - run all Vitest tests.
 - `pnpm test:e2e` - run only `tests/e2e-*.test.ts` (these spawn the real `acpx/runtime` against the `acp-mock` CLI in `node_modules/acp-mock/dist/cli.js`).
 - `pnpm typecheck` / `pnpm lint` - both run `tsc --noEmit` against `tsconfig.json`.
@@ -24,7 +26,8 @@ Use `pnpm` (declared `packageManager: pnpm@11.1.1`). Renderer dev server is pinn
 
 ## Architecture
 
-This is a macOS tray-bar Electron app whose distinguishing idea is that an embedded agent (running via `acpx/runtime`) edits this same repo at runtime; git is used as the accept/rollback mechanism.
+This is a macOS tray-bar Electron app whose distinguishing idea is that an embedded agent (running via `acpx/runtime`) edits the active extension workspace at runtime.
+Source mode uses git as the accept/rollback mechanism for tracked extensions; packaged mode edits `~/.baby-menu/extensions` and uses filesystem snapshots.
 
 Three processes, kept deliberately separate:
 
@@ -40,14 +43,20 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 
 `src/main/` module index:
 
-- `app.ts` - Electron lifecycle, popover window creation, wires tray + IPC. `package.json#main` points here via `out/main/index.js`.
+- `app.ts` - Electron lifecycle, popover window creation, packaged path setup, extension seeding, preferences, protocols, tray, and IPC. `package.json#main` points here via `out/main/index.js`.
+- `app-paths.ts` - resolves source paths versus packaged `~/.baby-menu` paths.
 - `tray.ts` - macOS tray icon and click handling (`createBabyMenuTray`).
 - `popover.ts` - popover `BrowserWindow` options (`createPopoverOptions`), bounds math (`calculatePopoverBounds`), and renderer URL/file loading (`loadPopoverRenderer`).
 - `ipc.ts` - registers all `ipcMain` handlers exposed via the preload bridge; the single place new generic IPC routes are added.
 - `agent-runtime.ts` - `BabyMenuAgentRuntime` wrapping `acpx/runtime`; gates every `send()` through a change session.
 - `agent-turn-log.ts` - structured per-turn transcript log used by the renderer and tests.
 - `git-change-session.ts` - the production Save/Rollback safety boundary (see below).
-- `dev-extension-change-session.ts` - the dev-mode Save/Rollback boundary for gitignored extension workspaces.
+- `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
+- `extension-seeder.ts` - seeds bundled extension templates into the packaged extension workspace.
+- `extension-module-compiler.ts` - compiles extension widget and server modules for production loading.
+- `widget-protocol.ts` - registers custom protocols for compiled widget modules and the renderer host shim.
+- `preferences.ts` - stores app preferences under the active app data root and applies login-item settings.
+- `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `recipe-loader.ts` - discovers and parses `recipes/*.html` from the active extension workspace.
 - `server-action-registry.ts` - dynamically loads extension server actions from the active extension workspace and exposes them through the generic capability bridge.
 
@@ -61,22 +70,26 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 
 `createPopoverOptions` enforces `frame:false`, `contextIsolation:true`, `nodeIntegration:false`, `skipTaskbar:true`, `alwaysOnTop:true`. Do not relax these without a reason.
 
-### Agent runtime + git change sessions
+### Agent runtime + change sessions
 
 `BabyMenuAgentRuntime` (`src/main/agent-runtime.ts`) wraps `acpx/runtime`. Every `send()` call:
 
-1. Resolves the active extension workspace with `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`.
-2. Uses `DevExtensionChangeSession` for dev extension workspaces such as `extensions-dev/`, snapshotting that directory so Save keeps the generated files and Rollback restores the pre-turn contents.
-3. Uses `GitChangeSession.begin(rootDir)` for the tracked `extensions/` workspace. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
-4. Lazily constructs the ACP runtime with `createFileSessionStore({ stateDir: .cache/baby-menu/acp-sessions })` and `permissionMode: "approve-all"`.
+1. Resolves the active extension workspace from runtime paths. Source mode honors `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`; packaged mode uses `~/.baby-menu/extensions` after seeding bundled templates.
+2. Uses `DevExtensionChangeSession` for snapshot workspaces such as `extensions-dev/` and packaged `~/.baby-menu/extensions`, so Save keeps generated files and Rollback restores the pre-turn contents.
+3. Uses `GitChangeSession.begin(rootDir)` only for the tracked source `extensions/` workspace. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
+4. Lazily constructs the ACP runtime with `createFileSessionStore({ stateDir })` under `.cache/baby-menu/acp-sessions` in source mode or `~/.baby-menu/cache/acp-sessions` in packaged mode, with `permissionMode: "approve-all"`.
 5. Uses a fixed `sessionKey: "baby-menu-agent-chat"` so the agent has a single persistent conversation.
 
 `GitChangeSession` (`src/main/git-change-session.ts`) is the safety boundary for Save/Rollback. Both operations refuse unless: the session started clean, the session is not already completed, and `HEAD` has not moved since the session began. `rollback()` runs `git reset --hard <recorded HEAD>` + `git clean -fd` - those destructive commands are only acceptable because of the preceding guards. Preserve this invariant.
+
+Packaged runtime state lives under `~/.baby-menu` and is not git-backed.
+Do not write generated extension files, compiled modules, preferences, logs, snapshots, or ACP session state into the `.app` bundle.
 
 ### Recipes and extensions
 
 - Recipes are HTML files in `recipes/` inside the active extension workspace. `recipe-loader.ts` discovers `*.html`, sorts them, and extracts the title from `<title>` or first `<h1>`. They are intentionally HTML so the embedded agent can read them from its cwd and use embedded interactive demos.
 - Extensions live in the active extension workspace under `<extension-id>/` and may include `widget.tsx`, `server.ts`, and local helper files.
+- Packaged widgets and server actions are compiled into `~/.baby-menu/cache` and loaded through custom protocols or cached modules; dev mode keeps Vite `/@fs` loading.
 - Widgets conform to `BabyMenuWidget` / `RefreshableBabyMenuWidget`. The `WidgetHost` owns refresh timing via `useWidgetRefresh` - widgets should not start their own polling.
 - New widgets and capabilities should be built as self-contained extensions behind the stable `window.babyMenu` bridge.
 - Extension server actions are discovered dynamically from the active extension workspace, so new or changed actions can be picked up without changing preload.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `ipc.ts` - registers all `ipcMain` handlers exposed via the preload bridge; the single place new generic IPC routes are added.
 - `agent-runtime.ts` - `BabyMenuAgentRuntime` wrapping `acpx/runtime`; gates every `send()` through a change session.
 - `agent-turn-log.ts` - structured per-turn transcript log used by the renderer and tests.
-- `git-change-session.ts` - the production Save/Rollback safety boundary (see below).
+- `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
 - `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
 - `extension-seeder.ts` - seeds bundled extension templates into the packaged extension workspace.
 - `extension-module-compiler.ts` - compiles extension widget and server modules for production loading.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ $ pnpm dev                  # tray icon appears in your menu bar
 
 **Homebrew Cask**
 
+Requires macOS 13 Ventura or newer.
+Baby Menu also needs a supported, already-authenticated agent CLI such as `claude`, `codex`, or `npx` on `PATH`; set `BABY_MENU_AGENT=<name>` before launch to choose one explicitly.
+
 ```sh
 brew install --cask kunchenguid/tap/baby-menu
 ```

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@
 
 Every menu-bar app ships a fixed set of widgets. Want your CPU temp next to your Claude usage next to your next calendar event? You either wait for someone to build it, glue together three different apps, or learn Electron.
 
-baby-menu flips that. The tray popover hosts a coding agent that edits this same repo at runtime. You ask for a widget in plain English, the agent writes the extension, and you click Save to keep it or Rollback to wipe it. Git is the undo button.
+baby-menu flips that. The tray popover hosts a coding agent that edits the active extension workspace at runtime. You ask for a widget in plain English, the agent writes the extension, and you click Save to keep it or Rollback to wipe it.
 
 - **Ask, don't configure** - "add a battery widget that shows charge and power source" - the agent ships the widget.
-- **Git-backed safety** - every turn runs inside a change session; Save commits, Rollback `git reset --hard`s back to where you started.
+- **Safe change sessions** - every turn runs inside a change session; source mode uses git, while packaged mode snapshots `~/.baby-menu/extensions`.
 - **Recipes over prompts** - non-trivial widgets live as self-contained HTML specs in `extensions/recipes/` so the agent implements them the same way every time.
 
 ## Quick Start
@@ -33,7 +33,20 @@ $ pnpm dev                  # tray icon appears in your menu bar
 
 ## Install
 
-baby-menu is a source-run project today, not a packaged release.
+**Homebrew Cask**
+
+```sh
+brew install --cask kunchenguid/tap/baby-menu
+```
+
+Update with:
+
+```sh
+brew update
+brew upgrade --cask baby-menu
+```
+
+The packaged app stores mutable extensions, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets.
 
 **From source**
 
@@ -56,17 +69,17 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
               │  send()
               ▼
    ┌─────────────────────┐       ┌──────────────────────┐
-   │  BabyMenuAgentRuntime├──────►│   GitChangeSession   │
-   │   wraps acpx/runtime │       │   (or Dev session    │
-   └──────────┬──────────┘       │    for extensions-dev)│
+   │  BabyMenuAgentRuntime├──────►│    Change Session    │
+   │   wraps acpx/runtime │       │   git or snapshot    │
+   └──────────┬──────────┘       │   by runtime mode    │
               │                   └──────────┬───────────┘
               │ edits files                  │ Save / Rollback
               ▼                              ▼
    ┌─────────────────────┐       ┌──────────────────────┐
-   │  extensions/<id>/   │       │   git reset --hard   │
-   │  widget.tsx         │◄──────┤   git clean -fd      │
-   │  server.ts          │       │   (only if HEAD      │
-   └──────────┬──────────┘       │    hasn't moved)     │
+   │ active extensions/  │       │   save snapshot or   │
+   │  widget.tsx         │◄──────┤   rollback files     │
+   │  server.ts          │       │   safely             │
+   └──────────┬──────────┘       │                      │
               │ hot-reload       └──────────────────────┘
               ▼
    ┌─────────────────────┐
@@ -78,7 +91,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 - **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem. Everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
 - **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria. The agent reads the matching recipe before implementing.
 - **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets via `window.babyMenu.capabilities.invoke(extensionId, action, input)`. No per-widget IPC channels.
-- **Dev mode is sandboxed** - `pnpm dev` copies `extensions/` into a gitignored `extensions-dev/` workspace, so the agent can iterate freely without dirtying the tracked tree.
+- **Runtime-specific extension roots** - `pnpm start` edits tracked `extensions/` with `GitChangeSession`; `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with snapshot Save/Rollback.
 
 ## Layout
 
@@ -91,6 +104,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | `extensions/<id>/`                | Tracked extensions (`widget.tsx`, `server.ts`)               |
 | `extensions/recipes/*.html`       | Self-contained widget specs the agent reads                  |
 | `extensions-dev/`                 | Gitignored dev workspace prepared by `scripts/dev.mjs`       |
+| `~/.baby-menu/extensions/`        | Packaged app extension workspace                             |
+| `~/.baby-menu/cache/`             | Packaged widget, server-action, snapshot, and agent caches    |
 | `tests/`                          | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)           |
 
 ## Environment Flags
@@ -108,6 +123,8 @@ pnpm start        # run Electron + renderer dev server against the real extensio
 pnpm dev          # same, but agent edits the gitignored extensions-dev/ sandbox
 pnpm dev:reset    # wipe extensions-dev/ and start fresh
 pnpm build        # build main + preload + renderer into out/
+pnpm package:mac  # build and create an ad-hoc-signed .app in release/mac-universal/
+pnpm dist:mac     # build the .app and create a universal DMG in release/
 pnpm test         # run all Vitest tests
 pnpm test:e2e     # only e2e tests (spawn real acpx/runtime against acp-mock)
 pnpm typecheck    # tsc --noEmit

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ brew upgrade --cask baby-menu
 ```
 
 The packaged app stores mutable extensions, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets.
+Use the `login on/off` toggle in the popover header to control whether baby-menu opens at login.
 
 **From source**
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+<h1 align="center">baby-menu</h1>
+<p align="center">
+  <a href="https://github.com/kunchenguid/baby-menu/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/kunchenguid/baby-menu/ci.yml?style=flat-square&label=ci" /></a>
+  <a href="https://img.shields.io/badge/platform-macOS-blue?style=flat-square"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS-blue?style=flat-square" /></a>
+  <a href="https://img.shields.io/badge/electron-42-9feaf9?style=flat-square"><img alt="Electron" src="https://img.shields.io/badge/electron-42-9feaf9?style=flat-square" /></a>
+  <a href="https://x.com/kunchenguid"><img alt="X" src="https://img.shields.io/badge/X-@kunchenguid-black?style=flat-square" /></a>
+  <a href="https://discord.gg/Wsy2NpnZDu"><img alt="Discord" src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord" /></a>
+</p>
+
+<h3 align="center">A menu-bar app that writes its own widgets while you watch.</h3>
+
+Every menu-bar app ships a fixed set of widgets. Want your CPU temp next to your Claude usage next to your next calendar event? You either wait for someone to build it, glue together three different apps, or learn Electron.
+
+baby-menu flips that. The tray popover hosts a coding agent that edits this same repo at runtime. You ask for a widget in plain English, the agent writes the extension, and you click Save to keep it or Rollback to wipe it. Git is the undo button.
+
+- **Ask, don't configure** - "add a battery widget that shows charge and power source" - the agent ships the widget.
+- **Git-backed safety** - every turn runs inside a change session; Save commits, Rollback `git reset --hard`s back to where you started.
+- **Recipes over prompts** - non-trivial widgets live as self-contained HTML specs in `extensions/recipes/` so the agent implements them the same way every time.
+
+## Quick Start
+
+```sh
+$ pnpm install              # installs deps and the pinned Electron binary
+$ pnpm dev                  # tray icon appears in your menu bar
+
+# click the tray icon, in the popover chat:
+> add a cpu temp widget that shows current temperature and fan status
+
+# agent writes extensions-dev/cpu-temp/widget.tsx and server.ts
+# the widget mounts live in the popover
+# click Save to keep it, or Rollback to throw the turn away
+```
+
+## Install
+
+baby-menu is a source-run project today, not a packaged release.
+
+**From source**
+
+```sh
+git clone https://github.com/kunchenguid/baby-menu.git
+cd baby-menu
+pnpm install
+pnpm dev
+```
+
+Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
+
+## How It Works
+
+```
+   ┌─────────────────────┐
+   │  macOS tray popover │   (React renderer, 360px wide)
+   │     + AgentChat     │
+   └──────────┬──────────┘
+              │  send()
+              ▼
+   ┌─────────────────────┐       ┌──────────────────────┐
+   │  BabyMenuAgentRuntime├──────►│   GitChangeSession   │
+   │   wraps acpx/runtime │       │   (or Dev session    │
+   └──────────┬──────────┘       │    for extensions-dev)│
+              │                   └──────────┬───────────┘
+              │ edits files                  │ Save / Rollback
+              ▼                              ▼
+   ┌─────────────────────┐       ┌──────────────────────┐
+   │  extensions/<id>/   │       │   git reset --hard   │
+   │  widget.tsx         │◄──────┤   git clean -fd      │
+   │  server.ts          │       │   (only if HEAD      │
+   └──────────┬──────────┘       │    hasn't moved)     │
+              │ hot-reload       └──────────────────────┘
+              ▼
+   ┌─────────────────────┐
+   │     WidgetHost      │
+   │  mounts new widget  │
+   └─────────────────────┘
+```
+
+- **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem. Everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
+- **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria. The agent reads the matching recipe before implementing.
+- **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets via `window.babyMenu.capabilities.invoke(extensionId, action, input)`. No per-widget IPC channels.
+- **Dev mode is sandboxed** - `pnpm dev` copies `extensions/` into a gitignored `extensions-dev/` workspace, so the agent can iterate freely without dirtying the tracked tree.
+
+## Layout
+
+| Path                              | What lives here                                              |
+| --------------------------------- | ------------------------------------------------------------ |
+| `src/main/`                       | Electron lifecycle, tray, popover, IPC, git, agent runtime   |
+| `src/preload/index.ts`            | The stable `window.babyMenu` bridge                          |
+| `src/renderer/`                   | React UI: `AgentChat` + `WidgetHost`                         |
+| `src/shared/contracts.ts`         | `BabyMenuApi`, `BabyMenuWidget`, `GitSessionSnapshot`, etc.  |
+| `extensions/<id>/`                | Tracked extensions (`widget.tsx`, `server.ts`)               |
+| `extensions/recipes/*.html`       | Self-contained widget specs the agent reads                  |
+| `extensions-dev/`                 | Gitignored dev workspace prepared by `scripts/dev.mjs`       |
+| `tests/`                          | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)           |
+
+## Environment Flags
+
+| Var                              | Effect                                                        |
+| -------------------------------- | ------------------------------------------------------------- |
+| `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up  |
+| `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)             |
+| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace                      |
+
+## Development
+
+```sh
+pnpm start        # run Electron + renderer dev server against the real extensions/ dir
+pnpm dev          # same, but agent edits the gitignored extensions-dev/ sandbox
+pnpm dev:reset    # wipe extensions-dev/ and start fresh
+pnpm build        # build main + preload + renderer into out/
+pnpm test         # run all Vitest tests
+pnpm test:e2e     # only e2e tests (spawn real acpx/runtime against acp-mock)
+pnpm typecheck    # tsc --noEmit
+pnpm lint         # tsc --noEmit (same as typecheck)
+```
+
+Use `pnpm start` when you want the embedded agent to edit tracked `extensions/` files (the `GitChangeSession` Save/Rollback boundary kicks in). Use `pnpm dev` when you want a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
+
+Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.
+
+TDD is required for bug fixes and new features. Tests live in `tests/` at the repo root, not co-located.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | -------------------------------- | ------------------------------------------------------------- |
 | `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up  |
 | `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)             |
-| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace                      |
+| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs    |
 
 ## Development
 

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -1,0 +1,848 @@
+# Baby Menu Distribution Strategy
+
+This document is a self-contained implementation proposal for distributing Baby Menu as a real macOS app without Developer ID signing or notarization.
+The target audience is a developer implementing packaging, runtime path changes, production extension loading, release automation, and Homebrew Cask distribution.
+
+## Goals
+
+- Ship Baby Menu as a macOS menu-bar app, not as a source checkout that users run with `pnpm start`.
+- Preserve the core product behavior where an embedded agent can create or edit widgets while the app is running.
+- Avoid a production Vite dev server.
+- Avoid Developer ID signing and notarization for now.
+- Install through a general Homebrew tap owned by Kun.
+- Support autostart on login.
+- Keep user-generated extensions and caches across app upgrades.
+- Keep Save and Rollback semantics safe for end users.
+
+## Non-Goals
+
+- Do not submit to the Mac App Store.
+- Do not use Sparkle or Electron auto-updaters initially.
+- Do not require users to clone this repository.
+- Do not require users to install Node or pnpm for the app itself.
+- Do not solve installation or authentication for external agent CLIs such as Claude, Codex, or Pi.
+- Do not support arbitrary npm dependencies inside generated extensions in the first packaged release.
+
+## Target User Install Command
+
+Use a general tap repository named `kunchenguid/homebrew-tap`.
+Homebrew maps this to the tap token `kunchenguid/tap`.
+
+The install command should be:
+
+```sh
+brew install --cask kunchenguid/tap/baby-menu
+```
+
+After installation, users should update with:
+
+```sh
+brew update
+brew upgrade --cask baby-menu
+```
+
+If the tap has not already been added, the fully qualified cask token should tap it implicitly.
+Users should not need to run a separate `brew tap` command.
+
+## Current Repo Constraints
+
+The current repo is source-run oriented.
+`package.json` has `start`, `dev`, and `build`, but no app packager, release workflow, cask, signing, notarization, or login-item support.
+
+The current production renderer path mostly exists.
+`src/main/popover.ts` loads `ELECTRON_RENDERER_URL` in dev and falls back to `loadFile()` in packaged mode.
+
+The current build output needs to be fixed before packaging.
+`pnpm build` currently creates `out/main` and `out/preload` under the repo, but the renderer output is written outside the repo at `../../out/renderer`.
+The packaged app expects `out/renderer/index.html` next to `out/main` and `out/preload`.
+
+The current runtime root is not package-safe.
+`src/shared/paths.ts` uses `process.cwd()` as the repo root, which is not reliable when a macOS app is launched from Finder, Spotlight, Homebrew, or a login item.
+
+The current widget loading path is dev-only.
+`src/main/widget-module-registry.ts` returns Vite `/@fs/...widget.tsx` module URLs, and `src/renderer/menu/WidgetHost.tsx` imports those URLs directly.
+This works in Vite dev mode, but it will not work from a production `file://` renderer.
+
+The current server-action path is not enough for packaged production.
+`src/main/server-action-registry.ts` dynamically imports extension `server.ts` files after copying them to cache.
+Packaged production should not rely on raw TypeScript imports being supported by Electron's embedded Node runtime.
+
+The current Save and Rollback path assumes either a tracked git repo or a dev extension workspace.
+A packaged app should not mutate files inside the `.app` bundle and should not require a user-data directory to be a git repo.
+
+## Recommended Architecture
+
+Use a packaged Electron shell with mutable extension state under `~/.baby-menu`.
+
+Runtime layout:
+
+```text
+/Applications/Baby Menu.app
+  Contents/
+    MacOS/Baby Menu
+    Resources/
+      app.asar or app/
+      extensions-template/
+        AGENTS.md
+        recipes/*.html
+        hello-world/widget.tsx
+
+~/.baby-menu/
+  extensions/
+    AGENTS.md
+    recipes/*.html
+    <user-extension>/widget.tsx
+    <user-extension>/server.ts
+  cache/
+    widgets/<hash>/*.mjs
+    server-actions/<hash>/*.mjs
+    acp-sessions/
+    snapshots/
+  logs/
+```
+
+Source development layout remains mostly unchanged:
+
+```text
+repo/
+  extensions/
+  extensions-dev/
+  .cache/
+```
+
+## Runtime Mode Matrix
+
+| Mode | Renderer | Extension Workspace | Change Session | Widget Loader |
+| --- | --- | --- | --- | --- |
+| `pnpm start` | Vite dev server | `repo/extensions` | `GitChangeSession` | Vite `/@fs` |
+| `pnpm dev` | Vite dev server | `repo/extensions-dev` | snapshot session | Vite `/@fs` |
+| Packaged app | `out/renderer/index.html` | `app.getPath("home")/.baby-menu/extensions` | snapshot session | compiled module protocol |
+
+## Packaged App Path Resolution
+
+Add a main-process path resolver instead of using `process.cwd()` as the universal root.
+
+Recommended new module:
+
+```ts
+// src/main/app-paths.ts
+import { app } from "electron";
+import { join } from "node:path";
+
+export type BabyMenuRuntimePaths = {
+  appDataRoot: string;
+  extensionsDir: string;
+  cacheDir: string;
+  agentStateDir: string;
+  devExtensionSnapshotDir: string;
+  bundledExtensionTemplateDir: string | null;
+};
+
+export function resolveBabyMenuRuntimePaths(): BabyMenuRuntimePaths {
+  if (!app.isPackaged) {
+    const root = process.cwd();
+    return {
+      appDataRoot: root,
+      extensionsDir: process.env.BABY_MENU_EXTENSIONS_DIR ?? join(root, "extensions"),
+      cacheDir: join(root, ".cache", "baby-menu"),
+      agentStateDir: join(root, ".cache", "baby-menu", "acp-sessions"),
+      devExtensionSnapshotDir: join(root, ".cache", "baby-menu", "dev-extension-snapshots"),
+      bundledExtensionTemplateDir: null,
+    };
+  }
+
+  const root = join(app.getPath("home"), ".baby-menu");
+  return {
+    appDataRoot: root,
+    extensionsDir: join(root, "extensions"),
+    cacheDir: join(root, "cache"),
+    agentStateDir: join(root, "cache", "acp-sessions"),
+    devExtensionSnapshotDir: join(root, "cache", "snapshots"),
+    bundledExtensionTemplateDir: join(process.resourcesPath, "extensions-template"),
+  };
+}
+```
+
+The exact shape can change, but the important design is that packaged mutable state lives under `~/.baby-menu`.
+Do not write generated extensions, caches, snapshots, or agent sessions into the `.app` bundle.
+
+## First Launch Seeding
+
+On packaged first launch, copy bundled extension templates into `~/.baby-menu/extensions` if the extension workspace does not exist.
+
+Seed these files:
+
+- `extensions/AGENTS.md`
+- `extensions/recipes/*.html`
+- `extensions/hello-world/widget.tsx`
+
+Do not overwrite existing user extensions during app upgrades.
+If recipes need to be updated on app upgrade, use a versioned seed strategy or copy only missing recipe files initially.
+For the first implementation, preserving existing user data is more important than automatic recipe replacement.
+
+## Change Sessions In Packaged Mode
+
+Packaged mode should use a filesystem snapshot session, not a git session.
+
+The existing `DevExtensionChangeSession` already has the right basic semantics:
+
+- Snapshot the extension workspace at the start of an agent turn.
+- Save means accept current files and delete the snapshot.
+- Rollback means restore the snapshot and delete it.
+
+Refactor the change-session selection so packaged `~/.baby-menu/extensions` uses a snapshot session.
+Only use `GitChangeSession` when the app is running from source and the active extension workspace is the tracked `repo/extensions` directory.
+
+Recommended rule:
+
+```text
+if packaged:
+  use SnapshotExtensionChangeSession
+else if active extensions dir equals repo/extensions:
+  use GitChangeSession
+else:
+  use SnapshotExtensionChangeSession
+```
+
+The renderer can keep showing Save and Rollback.
+In packaged mode, Save should return `{ ok: true }` without a commit hash.
+
+## Production Widget Compiler
+
+Packaged production cannot import raw `widget.tsx` files through Vite `/@fs` URLs.
+Add a production compiler and loader.
+
+Recommended approach:
+
+- Use TypeScript as a runtime dependency for transpilation.
+- Compile each extension `widget.tsx` or `widget.ts` into cached `.mjs` files under `~/.baby-menu/cache/widgets`.
+- Rewrite local imports so extensionless imports point at compiled `.mjs` files.
+- Rewrite React imports to custom host shim URLs.
+- Serve compiled widget modules through an Electron custom protocol.
+- Keep Vite `/@fs` URLs only in dev mode.
+
+This avoids shipping a production Vite server.
+It also avoids runtime native compiler issues from tools such as esbuild in a universal app.
+
+### Widget Compiler Inputs
+
+The compiler should support these extension files:
+
+- `widget.tsx`
+- `widget.jsx`
+- `widget.ts`
+- `widget.js`
+- local helper imports from the same extension directory
+
+For v1, generated widgets should not import arbitrary npm packages.
+They may import React APIs and local helper files.
+
+### Widget Compiler Output
+
+Example output:
+
+```text
+~/.baby-menu/cache/widgets/cpu-temp/<content-hash>/widget.mjs
+~/.baby-menu/cache/widgets/cpu-temp/<content-hash>/helpers.mjs
+```
+
+The widget module descriptor returned to the renderer should use a custom protocol URL, for example:
+
+```json
+{
+  "id": "cpu-temp.widget",
+  "extensionId": "cpu-temp",
+  "moduleUrl": "baby-menu-widget://cpu-temp/<content-hash>/widget.mjs"
+}
+```
+
+### React Host Shims
+
+The renderer should expose the React and JSX runtime used by the host app.
+This avoids bundling a second copy of React inside widget modules.
+Bundling a second React copy would break hooks in generated widgets.
+
+Renderer setup example:
+
+```ts
+import * as React from "react";
+import * as jsxRuntime from "react/jsx-runtime";
+
+window.__BABY_MENU_WIDGET_HOST__ = {
+  React,
+  jsxRuntime,
+};
+```
+
+Add a global type declaration for `window.__BABY_MENU_WIDGET_HOST__`.
+
+Register protocol modules that export from that host object:
+
+```ts
+// baby-menu-host://react/index.mjs
+const React = window.__BABY_MENU_WIDGET_HOST__.React;
+export const useState = React.useState;
+export const useEffect = React.useEffect;
+export const useRef = React.useRef;
+export default React;
+
+// baby-menu-host://react-jsx-runtime/index.mjs
+const runtime = window.__BABY_MENU_WIDGET_HOST__.jsxRuntime;
+export const jsx = runtime.jsx;
+export const jsxs = runtime.jsxs;
+export const Fragment = runtime.Fragment;
+```
+
+The compiler should rewrite imports like this:
+
+```ts
+import React from "react";
+import { useState } from "react";
+import { jsx } from "react/jsx-runtime";
+```
+
+to this:
+
+```ts
+import React from "baby-menu-host://react/index.mjs";
+import { useState } from "baby-menu-host://react/index.mjs";
+import { jsx } from "baby-menu-host://react-jsx-runtime/index.mjs";
+```
+
+### Electron Protocol Registration
+
+Register custom protocols before creating the renderer window.
+
+Use privileged schemes so dynamic imports work from a packaged renderer.
+
+Example direction:
+
+```ts
+import { protocol } from "electron";
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "baby-menu-widget",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+    },
+  },
+  {
+    scheme: "baby-menu-host",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      corsEnabled: true,
+    },
+  },
+]);
+```
+
+The `baby-menu-widget` handler must only serve files from the widget compiler cache.
+Validate and normalize paths before reading files.
+Do not expose arbitrary filesystem reads through the protocol.
+
+## Production Server Action Compiler
+
+Packaged production should compile extension `server.ts` files before importing them in the main process.
+
+Recommended approach:
+
+- Reuse the TypeScript transpilation path used by widgets.
+- Compile server action files into `~/.baby-menu/cache/server-actions/<hash>/*.mjs`.
+- Preserve or rewrite local imports to compiled `.mjs` files.
+- Leave Node built-in imports alone.
+- Reject or clearly error on unsupported external npm imports.
+
+The existing server action registry already discovers and reloads server action files.
+Keep that behavior, but change the loader so the import target is compiled JavaScript, not raw TypeScript.
+
+## Agent CLI Discovery In A GUI App
+
+Packaged macOS apps launched from Finder or login items usually do not inherit the user's interactive shell `PATH`.
+The app must handle this or it may fail to find `claude`, `codex`, `npx`, or other agent commands.
+
+Recommended behavior:
+
+- On startup, expand `process.env.PATH` with common Homebrew and user binary paths.
+- Include `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, and `~/.local/bin`.
+- Optionally ask the user's login shell for PATH with `/bin/zsh -lc 'print -r -- $PATH'` and merge it.
+- Keep `BABY_MENU_AGENT` override support.
+- Show a clear in-app error if no supported agent command can be found.
+
+This should be implemented before relying on autostart.
+Autostart launches are especially likely to have a minimal environment.
+
+## Autostart
+
+Use Electron's login-item API from the app, not the Homebrew cask.
+
+Recommended default:
+
+- Add a setting in the app UI for “Open Baby Menu at login”.
+- Persist the preference in user data.
+- Call `app.setLoginItemSettings({ openAtLogin: true })` when enabled.
+- Call `app.setLoginItemSettings({ openAtLogin: false })` when disabled.
+
+For a menu-bar utility, enabling autostart by default may be acceptable, but the least surprising implementation is to show a first-run prompt or settings toggle.
+Do not rely on a LaunchAgent from the cask unless a future background daemon is introduced.
+
+## Packaging Tool
+
+Use `electron-builder` initially.
+It fits the current Electron and electron-vite setup and can produce macOS `.app` bundles and DMGs.
+
+Add dev dependency:
+
+```sh
+pnpm add -D electron-builder
+```
+
+Move TypeScript to runtime dependencies if the packaged app uses it as the production extension compiler:
+
+```sh
+pnpm add typescript
+```
+
+Keep Electron itself as a dev dependency.
+The packaged app bundles Electron.
+
+## Build Config Fix
+
+Fix `electron.vite.config.ts` so renderer output is inside this repository at `out/renderer`.
+
+The build acceptance check should be:
+
+```text
+out/main/index.js
+out/preload/index.cjs
+out/renderer/index.html
+```
+
+Add or update a regression test that fails if renderer output is configured outside the repo.
+
+## Electron Builder Config
+
+Recommended starting config in `electron-builder.yml`:
+
+```yaml
+appId: com.kunchenguid.baby-menu
+productName: Baby Menu
+copyright: Copyright © 2026 Kun Chen
+
+directories:
+  output: release
+
+files:
+  - out/**
+  - package.json
+
+extraResources:
+  - from: extensions
+    to: extensions-template
+    filter:
+      - AGENTS.md
+      - recipes/**
+      - hello-world/**
+
+asar: true
+
+mac:
+  category: public.app-category.developer-tools
+  identity: null
+  hardenedRuntime: false
+  gatekeeperAssess: false
+
+dmg:
+  artifactName: Baby-Menu-${version}-universal.dmg
+```
+
+Set this environment variable in CI so electron-builder does not try to find a Developer ID identity:
+
+```sh
+CSC_IDENTITY_AUTO_DISCOVERY=false
+```
+
+If universal DMG creation is unreliable, ship separate architecture DMGs and use Homebrew cask `on_arm` and `on_intel` blocks.
+The universal DMG is preferred because it keeps the cask simpler.
+
+## Ad-Hoc Signing
+
+We are not doing Developer ID signing or notarization.
+Use ad-hoc signing after building the `.app` and before creating or finalizing the DMG.
+
+Example:
+
+```sh
+codesign --force --deep --sign - "release/mac-universal/Baby Menu.app"
+```
+
+Ad-hoc signing is not a trust signal to Gatekeeper.
+It is still useful because macOS expects Mach-O binaries inside app bundles to have coherent signatures.
+
+The Homebrew cask should clear quarantine after install with `xattr -cr`.
+This mirrors the historical Airlock distribution pattern.
+
+## Homebrew Tap
+
+Create a general tap repo:
+
+```text
+github.com/kunchenguid/homebrew-tap
+```
+
+Add this cask:
+
+```text
+Casks/baby-menu.rb
+```
+
+Recommended cask template:
+
+```ruby
+cask "baby-menu" do
+  version "0.1.0"
+  sha256 "REPLACE_WITH_RELEASE_DMG_SHA256"
+
+  url "https://github.com/kunchenguid/baby-menu/releases/download/v#{version}/Baby-Menu-#{version}-universal.dmg"
+  name "Baby Menu"
+  desc "Menu-bar app that writes its own widgets"
+  homepage "https://github.com/kunchenguid/baby-menu"
+
+  depends_on macos: ">= :ventura"
+
+  app "Baby Menu.app"
+
+  uninstall quit: "com.kunchenguid.baby-menu"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-cr", "#{appdir}/Baby Menu.app"],
+                   must_succeed: false
+  end
+
+  zap trash: [
+    "~/.baby-menu",
+    "~/Library/Preferences/com.kunchenguid.baby-menu.plist",
+  ]
+end
+```
+
+Validate the final bundle identifier before using the `uninstall quit` stanza.
+The bundle identifier should match `appId` from the packaging config.
+
+## Release Automation
+
+Use GitHub Releases as the source of release artifacts.
+Use the Homebrew tap only as install metadata.
+
+Recommended release workflow:
+
+1. A GitHub Actions workflow runs on a version tag such as `v0.1.0`.
+2. The workflow checks out the Baby Menu repo.
+3. It installs pnpm and Node.
+4. It runs `pnpm install --frozen-lockfile`.
+5. It runs `pnpm typecheck` and `pnpm test`.
+6. It runs `pnpm build`.
+7. It packages `Baby Menu.app`.
+8. It ad-hoc signs the app with `codesign --sign -`.
+9. It creates `Baby-Menu-${VERSION}-universal.dmg`.
+10. It uploads the DMG to the GitHub Release.
+11. It computes the DMG SHA256.
+12. It clones `kunchenguid/homebrew-tap` using a write token.
+13. It rewrites `Casks/baby-menu.rb` with the new version, URL, and SHA256.
+14. It commits `baby-menu ${VERSION}` to the tap repo.
+15. It pushes the tap update.
+
+Required GitHub secret:
+
+```text
+HOMEBREW_TAP_TOKEN
+```
+
+The token needs contents write access to `kunchenguid/homebrew-tap`.
+
+## Example Release Workflow Skeleton
+
+```yaml
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+      VERSION: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm test
+      - run: pnpm build
+
+      - name: Package macOS app
+        run: pnpm exec electron-builder --mac dir --universal
+
+      - name: Ad-hoc sign app
+        run: codesign --force --deep --sign - "release/mac-universal/Baby Menu.app"
+
+      - name: Create DMG
+        run: |
+          VERSION_NUMBER="${GITHUB_REF_NAME#v}"
+          DMG_NAME="Baby-Menu-${VERSION_NUMBER}-universal.dmg"
+          hdiutil create -volname "Baby Menu" \
+            -srcfolder "release/mac-universal/Baby Menu.app" \
+            -ov -format UDZO "release/${DMG_NAME}"
+          echo "VERSION_NUMBER=${VERSION_NUMBER}" >> "$GITHUB_ENV"
+          echo "DMG_NAME=${DMG_NAME}" >> "$GITHUB_ENV"
+          echo "DMG_PATH=release/${DMG_NAME}" >> "$GITHUB_ENV"
+
+      - name: Upload DMG
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" "$DMG_PATH" --clobber
+
+      - name: Compute SHA256
+        run: |
+          SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
+          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
+
+      - name: Update Homebrew Cask
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/kunchenguid/homebrew-tap.git" "$RUNNER_TEMP/homebrew-tap"
+          mkdir -p "$RUNNER_TEMP/homebrew-tap/Casks"
+          cat > "$RUNNER_TEMP/homebrew-tap/Casks/baby-menu.rb" << CASK_EOF
+          cask "baby-menu" do
+            version "${VERSION_NUMBER}"
+            sha256 "${SHA256}"
+
+            url "https://github.com/kunchenguid/baby-menu/releases/download/v#{version}/Baby-Menu-#{version}-universal.dmg"
+            name "Baby Menu"
+            desc "Menu-bar app that writes its own widgets"
+            homepage "https://github.com/kunchenguid/baby-menu"
+
+            depends_on macos: ">= :ventura"
+
+            app "Baby Menu.app"
+            uninstall quit: "com.kunchenguid.baby-menu"
+
+            postflight do
+              system_command "/usr/bin/xattr",
+                             args: ["-cr", "#{appdir}/Baby Menu.app"],
+                             must_succeed: false
+            end
+
+            zap trash: [
+              "~/.baby-menu",
+              "~/Library/Preferences/com.kunchenguid.baby-menu.plist",
+            ]
+          end
+          CASK_EOF
+          cd "$RUNNER_TEMP/homebrew-tap"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/baby-menu.rb
+          git commit -m "baby-menu ${VERSION_NUMBER}"
+          git push
+```
+
+The workflow skeleton is intentionally explicit.
+The exact electron-builder output path may differ and should be verified during implementation.
+
+## App Update Model
+
+Homebrew is the updater for v1.
+Do not add an in-app auto-updater yet.
+
+The app can show a “Check for updates” link or command later, but the initial guidance is:
+
+```sh
+brew update
+brew upgrade --cask baby-menu
+```
+
+User-generated extensions in `~/.baby-menu/extensions` must survive app upgrades.
+The app bundle should be replaceable without losing user state.
+
+## Security Model
+
+This distribution intentionally does not use Developer ID signing or notarization.
+Homebrew Cask plus `xattr -cr` is a pragmatic install path for developer-oriented users.
+
+Important constraints:
+
+- The cask must download over HTTPS from GitHub Releases.
+- The cask must pin the SHA256 of the DMG.
+- The production widget protocol must only serve compiled files from the widget cache.
+- The production compiler must not allow path traversal outside the extension workspace.
+- Renderer widgets must not gain filesystem or shell access.
+- Privileged work must remain behind extension-owned server actions invoked through `window.babyMenu.capabilities.invoke`.
+- External agent CLIs are user-installed and user-authenticated.
+- Do not commit tokens, credentials, or local secrets into releases or tap files.
+
+## Homebrew Cask Limitations
+
+This approach is intentionally not the same as mainstream notarized app distribution.
+
+Known limitations:
+
+- Users must have Homebrew.
+- Managed Macs may block unsigned or ad-hoc-signed apps.
+- Homebrew Cask policy could become less friendly to quarantine removal in custom taps.
+- Direct DMG downloads may still hit Gatekeeper friction unless users remove quarantine manually.
+- Official `Homebrew/homebrew-cask` inclusion is unlikely while relying on quarantine removal and ad-hoc signing.
+
+For Baby Menu's likely early users, these tradeoffs are acceptable.
+
+## Testing Checklist
+
+Before shipping the first cask release, test on a clean macOS user account.
+
+Required install tests:
+
+- `brew install --cask kunchenguid/tap/baby-menu` installs without a separate `brew tap` command.
+- `/Applications/Baby Menu.app` exists.
+- The app launches from Finder.
+- The app launches from Spotlight.
+- The app launches after login when autostart is enabled.
+- The app does not require a source checkout, Node, or pnpm.
+- Quarantine does not block launch after Homebrew installation.
+
+Required runtime tests:
+
+- The tray icon appears.
+- The renderer loads from `out/renderer/index.html` in packaged mode.
+- First launch seeds the extension workspace into `~/.baby-menu/extensions`.
+- Recipes are listed from the home dot-directory extension workspace.
+- The hello-world fallback renders before any generated widget exists.
+- The app can find an installed agent CLI when launched from Finder.
+- The app shows a clear error when no agent CLI is available.
+- An agent-created widget writes files under `~/.baby-menu/extensions`.
+- Save accepts generated files in packaged mode.
+- Rollback restores the pre-turn extension workspace in packaged mode.
+- A generated `widget.tsx` compiles into cache and renders without Vite.
+- A generated `server.ts` compiles into cache and can be invoked through capabilities.
+- Relaunching the app preserves generated widgets.
+- Upgrading the app preserves generated widgets.
+
+Required uninstall tests:
+
+- `brew uninstall --cask baby-menu` removes the app.
+- `brew uninstall --zap --cask baby-menu` removes app data paths declared in `zap`.
+- A disabled or removed app no longer starts at login.
+
+## Implementation Phases
+
+### Phase 1: Package The Existing App
+
+Deliverables:
+
+- Fix renderer build output to `out/renderer`.
+- Add electron-builder config.
+- Add package scripts for packaging.
+- Produce a local `.app` and DMG.
+- Ad-hoc sign the `.app`.
+- Confirm the packaged app opens and shows the existing UI.
+
+Acceptance criteria:
+
+- `pnpm build` creates `out/main`, `out/preload`, and `out/renderer` in the repo.
+- A local packaged app opens without a Vite dev server.
+- The tray icon appears.
+
+### Phase 2: Move Packaged State To Home Dot Directory
+
+Deliverables:
+
+- Add packaged path resolver based on `app.getPath("home")` and `~/.baby-menu`.
+- Seed extension templates on first packaged launch.
+- Use snapshot change sessions for packaged extensions.
+- Keep source-mode git sessions unchanged.
+- Add packaged-mode tests for path selection and change-session selection.
+
+Acceptance criteria:
+
+- Packaged mode never writes generated extension files into the `.app` bundle.
+- Save and Rollback work without a git repo.
+- Source `pnpm start` still uses `GitChangeSession` for tracked `extensions`.
+- Source `pnpm dev` still uses snapshot sessions for `extensions-dev`.
+
+### Phase 3: Add Production Extension Compilation
+
+Deliverables:
+
+- Add a TypeScript-based widget compiler.
+- Add a TypeScript-based server action compiler.
+- Add safe custom protocols for compiled widget modules and React host shims.
+- Keep Vite `/@fs` imports in dev mode.
+- Add tests for import rewriting, cache invalidation, and path safety.
+
+Acceptance criteria:
+
+- Packaged app renders a generated widget from `widget.tsx` without Vite.
+- Packaged app invokes a generated `server.ts` action without raw TypeScript imports.
+- Widget hooks use the host React copy and do not load a second React runtime.
+- Unsupported external imports fail with a clear developer-facing error.
+
+### Phase 4: Add Homebrew Cask Release Flow
+
+Deliverables:
+
+- Create `kunchenguid/homebrew-tap`.
+- Add `Casks/baby-menu.rb`.
+- Add a tag-triggered release workflow in this repo.
+- Upload a DMG to GitHub Releases.
+- Update the cask automatically with version, URL, and SHA256.
+
+Acceptance criteria:
+
+- A fresh user can run `brew install --cask kunchenguid/tap/baby-menu`.
+- The app installs to `/Applications`.
+- The app launches after install.
+- `brew upgrade --cask baby-menu` installs a newer release and preserves user data.
+
+## Airlock Precedent
+
+The archived `airlock-hq/homebrew-airlock` tap used this same broad strategy.
+It installed a versioned universal DMG from GitHub Releases.
+It installed the app with the Homebrew `app` stanza.
+It exposed bundled binaries with `binary` stanzas.
+It ran `xattr -cr` in `postflight` to clear quarantine.
+It updated the tap from the main repo release workflow.
+It used ad-hoc signing, not Developer ID signing or notarization.
+
+Baby Menu can follow the same distribution pattern, with one major difference.
+Baby Menu should not install a daemon from the cask unless a future daemon exists.
+Autostart should be managed by the app through Electron login-item APIs.
+
+## Final Recommendation
+
+Implement the packaged app plus production extension compiler first.
+Then ship through `kunchenguid/homebrew-tap` with a cask token of `baby-menu`.
+Use GitHub Releases for DMGs and Homebrew Cask for installation and upgrades.
+Use ad-hoc signing and `xattr -cr` for the no-Developer-ID path.
+Treat Developer ID signing and notarization as a future improvement, not a blocker for the first real distribution channel.

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -163,9 +163,10 @@ export function resolveBabyMenuRuntimePaths(): BabyMenuRuntimePaths {
 The exact shape can change, but the important design is that packaged mutable state lives under `~/.baby-menu`.
 Do not write generated extensions, caches, snapshots, or agent sessions into the `.app` bundle.
 
-## First Launch Seeding
+## Extension Template Seeding
 
-On packaged first launch, copy bundled extension templates into `~/.baby-menu/extensions` if the extension workspace does not exist.
+On packaged launch, copy bundled extension templates into `~/.baby-menu/extensions`.
+This runs on first launch and after upgrades so newly bundled recipes or extensions are added to existing workspaces.
 
 Seed these files:
 
@@ -173,8 +174,8 @@ Seed these files:
 - `extensions/recipes/*.html`
 - `extensions/hello-world/widget.tsx`
 
-Do not overwrite existing user extensions during app upgrades.
-If recipes need to be updated on app upgrade, use a versioned seed strategy or copy only missing recipe files initially.
+Do not overwrite existing user extensions or recipes during app upgrades.
+Only missing template files are copied into the workspace.
 For the first implementation, preserving existing user data is more important than automatic recipe replacement.
 
 ## Change Sessions In Packaged Mode

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -1,7 +1,7 @@
 # Baby Menu Distribution Strategy
 
-This document is a self-contained implementation proposal for distributing Baby Menu as a real macOS app without Developer ID signing or notarization.
-The target audience is a developer implementing packaging, runtime path changes, production extension loading, release automation, and Homebrew Cask distribution.
+This document records the distribution design for Baby Menu as a real macOS app without Developer ID signing or notarization.
+The implemented app now includes packaging, runtime path changes, production extension loading, release automation, and Homebrew Cask distribution wiring.
 
 ## Goals
 
@@ -44,31 +44,27 @@ brew upgrade --cask baby-menu
 If the tap has not already been added, the fully qualified cask token should tap it implicitly.
 Users should not need to run a separate `brew tap` command.
 
-## Current Repo Constraints
+## Current Implementation State
 
-The current repo is source-run oriented.
-`package.json` has `start`, `dev`, and `build`, but no app packager, release workflow, cask, signing, notarization, or login-item support.
+The repo now has source, packaged, and release paths.
+`package.json` includes `package:mac` for a local ad-hoc-signed `.app` and `dist:mac` for a universal DMG.
+`.github/workflows/release.yml` builds on `v*` tags, uploads the DMG to GitHub Releases, and updates `kunchenguid/homebrew-tap` when `HOMEBREW_TAP_TOKEN` is configured.
 
-The current production renderer path mostly exists.
-`src/main/popover.ts` loads `ELECTRON_RENDERER_URL` in dev and falls back to `loadFile()` in packaged mode.
+The production renderer path is wired for packaged mode.
+`src/main/popover.ts` loads `ELECTRON_RENDERER_URL` in dev and falls back to `loadFile()` for `out/renderer/index.html` in production.
+`pnpm build` creates `out/main`, `out/preload`, and `out/renderer` in the repo.
 
-The current build output needs to be fixed before packaging.
-`pnpm build` currently creates `out/main` and `out/preload` under the repo, but the renderer output is written outside the repo at `../../out/renderer`.
-The packaged app expects `out/renderer/index.html` next to `out/main` and `out/preload`.
+Packaged runtime state is package-safe.
+`src/main/app-paths.ts` resolves packaged mutable state under `~/.baby-menu`, seeds bundled extension templates into `~/.baby-menu/extensions`, and keeps source-mode paths unchanged.
 
-The current runtime root is not package-safe.
-`src/shared/paths.ts` uses `process.cwd()` as the repo root, which is not reliable when a macOS app is launched from Finder, Spotlight, Homebrew, or a login item.
+Production extension loading no longer depends on the Vite dev server.
+Widgets and server actions compile into `~/.baby-menu/cache` in packaged mode, while dev mode keeps Vite `/@fs` widget imports.
 
-The current widget loading path is dev-only.
-`src/main/widget-module-registry.ts` returns Vite `/@fs/...widget.tsx` module URLs, and `src/renderer/menu/WidgetHost.tsx` imports those URLs directly.
-This works in Vite dev mode, but it will not work from a production `file://` renderer.
+Save and Rollback support both source and packaged runtimes.
+Tracked source `extensions/` uses `GitChangeSession`; `extensions-dev/` and packaged `~/.baby-menu/extensions` use snapshot sessions.
 
-The current server-action path is not enough for packaged production.
-`src/main/server-action-registry.ts` dynamically imports extension `server.ts` files after copying them to cache.
-Packaged production should not rely on raw TypeScript imports being supported by Electron's embedded Node runtime.
-
-The current Save and Rollback path assumes either a tracked git repo or a dev extension workspace.
-A packaged app should not mutate files inside the `.app` bundle and should not require a user-data directory to be a git repo.
+Remaining operational setup is outside this repo.
+The external `kunchenguid/homebrew-tap` repository must exist, and the release workflow needs a `HOMEBREW_TAP_TOKEN` secret with permission to push cask updates.
 
 ## Recommended Architecture
 
@@ -757,7 +753,9 @@ Required uninstall tests:
 
 ## Implementation Phases
 
-### Phase 1: Package The Existing App
+These phases have been implemented in this repo unless noted otherwise.
+
+### Phase 1: Package The Existing App - implemented
 
 Deliverables:
 
@@ -774,7 +772,7 @@ Acceptance criteria:
 - A local packaged app opens without a Vite dev server.
 - The tray icon appears.
 
-### Phase 2: Move Packaged State To Home Dot Directory
+### Phase 2: Move Packaged State To Home Dot Directory - implemented
 
 Deliverables:
 
@@ -791,7 +789,7 @@ Acceptance criteria:
 - Source `pnpm start` still uses `GitChangeSession` for tracked `extensions`.
 - Source `pnpm dev` still uses snapshot sessions for `extensions-dev`.
 
-### Phase 3: Add Production Extension Compilation
+### Phase 3: Add Production Extension Compilation - implemented
 
 Deliverables:
 
@@ -808,7 +806,7 @@ Acceptance criteria:
 - Widget hooks use the host React copy and do not load a second React runtime.
 - Unsupported external imports fail with a clear developer-facing error.
 
-### Phase 4: Add Homebrew Cask Release Flow
+### Phase 4: Add Homebrew Cask Release Flow - implemented with external setup
 
 Deliverables:
 
@@ -817,6 +815,11 @@ Deliverables:
 - Add a tag-triggered release workflow in this repo.
 - Upload a DMG to GitHub Releases.
 - Update the cask automatically with version, URL, and SHA256.
+
+Remaining manual setup:
+
+- Ensure the external `kunchenguid/homebrew-tap` repository exists with the cask path.
+- Configure the `HOMEBREW_TAP_TOKEN` repository secret before publishing tagged releases.
 
 Acceptance criteria:
 

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -84,6 +84,7 @@ Runtime layout:
         hello-world/widget.tsx
 
 ~/.baby-menu/
+  preferences.json
   extensions/
     AGENTS.md
     recipes/*.html
@@ -452,6 +453,7 @@ mac:
   identity: null
   hardenedRuntime: false
   gatekeeperAssess: false
+  x64ArchFiles: Contents/Resources/app.asar.unpacked/node_modules/{@esbuild/**,esbuild/**}
 
 dmg:
   artifactName: Baby-Menu-${version}-universal.dmg

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -94,7 +94,7 @@ Runtime layout:
     server-actions/<hash>/*.mjs
     acp-sessions/
     snapshots/
-  logs/
+  .cache/baby-menu/agent-turns/
 ```
 
 Source development layout remains mostly unchanged:
@@ -615,10 +615,16 @@ jobs:
           echo "DMG_NAME=${DMG_NAME}" >> "$GITHUB_ENV"
           echo "DMG_PATH=release/${DMG_NAME}" >> "$GITHUB_ENV"
 
-      - name: Upload DMG
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "$GITHUB_REF_NAME" "$DMG_PATH" --clobber
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$DMG_PATH" --clobber
+            gh release edit "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --latest
+          else
+            gh release create "$GITHUB_REF_NAME" "$DMG_PATH" --title "$GITHUB_REF_NAME" --generate-notes --latest
+          fi
 
       - name: Compute SHA256
         run: |
@@ -662,8 +668,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Casks/baby-menu.rb
-          git commit -m "baby-menu ${VERSION_NUMBER}"
-          git push
+          if ! git diff --cached --quiet; then
+            git commit -m "baby-menu ${VERSION_NUMBER}"
+            git push
+          fi
 ```
 
 The workflow skeleton is intentionally explicit.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,30 @@
+appId: com.kunchenguid.baby-menu
+productName: Baby Menu
+copyright: Copyright © 2026 Kun Chen
+
+directories:
+  output: release
+
+files:
+  - out/**
+  - package.json
+
+extraResources:
+  - from: extensions
+    to: extensions-template
+    filter:
+      - AGENTS.md
+      - recipes/**
+      - hello-world/**
+
+asar: true
+
+mac:
+  category: public.app-category.developer-tools
+  identity: null
+  hardenedRuntime: false
+  gatekeeperAssess: false
+  x64ArchFiles: Contents/Resources/app.asar.unpacked/node_modules/{@esbuild/**,esbuild/**}
+
+dmg:
+  artifactName: Baby-Menu-${version}-universal.dmg

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
       },
     },
     build: {
-      outDir: "../../out/renderer",
+      outDir: resolve(__dirname, "out/renderer"),
     },
   },
 });

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -16,6 +16,11 @@ Common files are:
 - Additional local helper files used only by this extension.
 - Optional notes that make the extension understandable and shareable.
 
+Packaged Baby Menu compiles extension modules before loading them.
+Keep imports package-safe: widgets may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, and local helper files only.
+Server actions may import Node built-ins such as `node:fs` plus local helper files only.
+Do not add arbitrary npm package imports to extension code unless the host compiler is updated to support them.
+
 ## Recipes
 
 Recipe-backed widget specs live in `recipes/*.html` inside this extension workspace.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "baby-menu",
   "version": "0.1.0",
+  "description": "Menu-bar app that writes its own widgets",
+  "author": "Kun Chen",
   "private": true,
   "type": "module",
   "main": "out/main/index.js",
@@ -10,30 +12,34 @@
   },
   "scripts": {
     "postinstall": "install-electron",
+    "start": "electron-vite dev",
     "dev": "node scripts/dev.mjs",
     "dev:reset": "node scripts/dev.mjs --reset",
     "build": "electron-vite build",
+    "package:mac": "pnpm build && electron-builder --mac dir --universal && node scripts/adhoc-sign-mac-app.mjs \"release/mac-universal/Baby Menu.app\"",
+    "dist:mac": "pnpm package:mac && node scripts/create-dmg.mjs",
     "test": "vitest run tests",
     "test:e2e": "vitest run tests/e2e-*.test.ts",
     "lint": "tsc -p tsconfig.json --noEmit",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@vitejs/plugin-react": "6.0.2",
     "acpx": "0.7.0",
-    "electron-vite": "5.0.0",
     "react": "19.2.6",
-    "react-dom": "19.2.6"
+    "react-dom": "19.2.6",
+    "typescript": "6.0.3"
   },
   "devDependencies": {
     "@testing-library/react": "16.3.2",
     "@types/node": "25.8.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
     "acp-mock": "1.1.0",
     "electron": "42.1.0",
+    "electron-builder": "26.8.1",
+    "electron-vite": "5.0.0",
     "jsdom": "29.1.1",
-    "typescript": "6.0.3",
     "vite": "8.0.13",
     "vitest": "4.1.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,21 +8,18 @@ importers:
 
   .:
     dependencies:
-      '@vitejs/plugin-react':
-        specifier: 6.0.2
-        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))
       acpx:
         specifier: 0.7.0
         version: 0.7.0
-      electron-vite:
-        specifier: 5.0.0
-        version: 5.0.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
     devDependencies:
       '@testing-library/react':
         specifier: 16.3.2
@@ -36,26 +33,35 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 6.0.2
+        version: 6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))
       acp-mock:
         specifier: 1.1.0
         version: 1.1.0(zod@4.4.3)
       electron:
         specifier: 42.1.0
         version: 42.1.0
+      electron-builder:
+        specifier: 26.8.1
+        version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      electron-vite:
+        specifier: 5.0.0
+        version: 5.0.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))
       jsdom:
         specifier: 29.1.1
         version: 29.1.1
-      typescript:
-        specifier: 6.0.3
-        version: 6.0.3
       vite:
         specifier: 8.0.13
-        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)
+        version: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
       vitest:
         specifier: 4.1.6
-        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))
+        version: 4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))
 
 packages:
+
+  7zip-bin@5.2.0:
+    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
   '@agentclientprotocol/sdk@0.21.1':
     resolution: {integrity: sha512-ZTLH+o9QxcZDLX/9ww+W7C2iExnXFM+vD/uGFVSlR61Kzj9FaxUqBC6Rv/kwgA7qVWYUEI9c5ZNqCuO9PM4rKg==}
@@ -206,9 +212,49 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
+  '@develar/schema-utils@2.6.5':
+    resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
+    engines: {node: '>= 8.9.0'}
+
+  '@electron/asar@3.4.1':
+    resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
+
+  '@electron/fuses@1.8.0':
+    resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
+    hasBin: true
+
+  '@electron/get@3.1.0':
+    resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
+    engines: {node: '>=14'}
+
   '@electron/get@5.0.0':
     resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
     engines: {node: '>=22.12.0'}
+
+  '@electron/notarize@2.5.0':
+    resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
+    engines: {node: '>= 10.0.0'}
+
+  '@electron/osx-sign@1.3.3':
+    resolution: {integrity: sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  '@electron/rebuild@4.0.4':
+    resolution: {integrity: sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  '@electron/universal@2.0.3':
+    resolution: {integrity: sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==}
+    engines: {node: '>=16.4'}
+
+  '@electron/windows-sign@1.2.2':
+    resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
+    engines: {node: '>=14.14'}
+    hasBin: true
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -540,6 +586,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -555,6 +605,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@malept/cross-spawn-promise@2.0.0':
+    resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
+    engines: {node: '>= 12.13.0'}
+
+  '@malept/flatpak-bundler@0.4.0':
+    resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
+    engines: {node: '>= 10.0.0'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -663,8 +721,16 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -691,8 +757,14 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -700,11 +772,26 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/fs-extra@9.0.13':
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@24.12.4':
     resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@types/node@25.8.0':
     resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
+
+  '@types/plist@3.0.5':
+    resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -713,6 +800,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/verror@1.10.11':
+    resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -759,6 +852,18 @@ packages:
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
+
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   acp-mock@1.1.0:
     resolution: {integrity: sha512-2DjTwIQUb3fE6pfCqsoEvAjKALd0uNEFPh4fmqwemCp63OHFr3M8vgC3+hw+zhHrK2rwQmsVo3MqZpEIpRSnxA==}
     engines: {node: '>=20'}
@@ -769,20 +874,71 @@ packages:
     engines: {node: '>=22.12.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-keywords@3.5.2:
+    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+    peerDependencies:
+      ajv: ^6.9.1
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
 
+  app-builder-bin@5.0.0-alpha.12:
+    resolution: {integrity: sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==}
+
+  app-builder-lib@26.8.1:
+    resolution: {integrity: sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      dmg-builder: 26.8.1
+      electron-builder-squirrel-windows: 26.8.1
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
+  async-exit-hook@2.0.1:
+    resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
+    engines: {node: '>=0.12.0'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -791,6 +947,13 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   bare-events@2.8.3:
     resolution: {integrity: sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==}
@@ -833,6 +996,9 @@ packages:
   bare-url@2.4.3:
     resolution: {integrity: sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.29:
     resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
     engines: {node: '>=6.0.0'}
@@ -840,6 +1006,20 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -849,9 +1029,34 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  builder-util-runtime@9.5.1:
+    resolution: {integrity: sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util@26.8.1:
+    resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
@@ -860,12 +1065,81 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  chromium-pickle-js@0.2.0:
+    resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
+
+  ci-info@4.3.1:
+    resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cli-truncate@2.1.0:
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
+  compare-version@0.1.2:
+    resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
+    engines: {node: '>=0.10.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  crc@3.8.0:
+    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
+
+  cross-dirname@0.1.0:
+    resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -890,6 +1164,26 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -898,8 +1192,51 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  dir-compare@4.2.0:
+    resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
+
+  dmg-builder@26.8.1:
+    resolution: {integrity: sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==}
+
+  dmg-license@1.0.11:
+    resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
+    engines: {node: '>=8'}
+    os: [darwin]
+    hasBin: true
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  electron-builder-squirrel-windows@26.8.1:
+    resolution: {integrity: sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==}
+
+  electron-builder@26.8.1:
+    resolution: {integrity: sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  electron-publish@26.8.1:
+    resolution: {integrity: sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==}
 
   electron-to-chromium@1.5.356:
     resolution: {integrity: sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==}
@@ -915,10 +1252,17 @@ packages:
       '@swc/core':
         optional: true
 
+  electron-winstaller@5.4.0:
+    resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
+    engines: {node: '>=8.0.0'}
+
   electron@42.1.0:
     resolution: {integrity: sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -927,12 +1271,38 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -948,6 +1318,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -958,13 +1332,26 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
+  extsprintf@1.4.1:
+    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
+    engines: {'0': node >=0.6.0}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -987,31 +1374,189 @@ packages:
       picomatch:
         optional: true
 
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@5.2.0:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
 
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-corefoundation@1.1.7:
+    resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
+    engines: {node: ^8.11.2 || >=10}
+    os: [darwin]
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  isbinaryfile@4.0.10:
+    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
+    engines: {node: '>= 8.0.0'}
+
+  isbinaryfile@5.0.7:
+    resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
+    engines: {node: '>= 18.0.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -1027,10 +1572,31 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lazy-val@1.0.5:
+    resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1106,12 +1672,23 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -1120,8 +1697,67 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp@0.5.6:
+    resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1131,8 +1767,36 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  node-abi@4.31.0:
+    resolution: {integrity: sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==}
+    engines: {node: '>=22.12.0'}
+
+  node-addon-api@1.7.2:
+    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+
+  node-api-version@0.2.1:
+    resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   node-releases@2.0.44:
     resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1140,11 +1804,31 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pe-library@0.4.1:
+    resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
+    engines: {node: '>=12', npm: '>=6'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -1156,17 +1840,41 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  plist@3.1.0:
+    resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
+    engines: {node: '>=10.4.0'}
+
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
+    engines: {node: '>=10.4.0'}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -1174,6 +1882,10 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -1187,14 +1899,55 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
+  read-binary-file-arch@1.0.6:
+    resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
+    hasBin: true
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resedit@1.7.2:
+    resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  rimraf@2.6.3:
+    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
@@ -1203,8 +1956,20 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   semver@7.8.0:
@@ -1212,8 +1977,27 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -1223,12 +2007,34 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  slice-ansi@3.0.0:
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stat-mode@1.0.0:
+    resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
+    engines: {node: '>= 6'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1236,9 +2042,21 @@ packages:
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1246,11 +2064,25 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
+  temp-file@3.4.0:
+    resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+
+  temp@0.9.4:
+    resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
+    engines: {node: '>=6.0.0'}
+
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  tiny-async-pool@1.3.0:
+    resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1274,6 +2106,13 @@ packages:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
+  tmp-promise@3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -1282,6 +2121,9 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1289,6 +2131,10 @@ packages:
     resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -1301,15 +2147,37 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
+  verror@1.10.1:
+    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
+    engines: {node: '>=0.6.0'}
 
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
@@ -1411,10 +2279,29 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1423,19 +2310,48 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  7zip-bin@5.2.0: {}
 
   '@agentclientprotocol/sdk@0.21.1(zod@4.4.3)':
     dependencies:
@@ -1610,6 +2526,37 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
+  '@develar/schema-utils@2.6.5':
+    dependencies:
+      ajv: 6.15.0
+      ajv-keywords: 3.5.2(ajv@6.15.0)
+
+  '@electron/asar@3.4.1':
+    dependencies:
+      commander: 5.1.0
+      glob: 7.2.3
+      minimatch: 3.1.5
+
+  '@electron/fuses@1.8.0':
+    dependencies:
+      chalk: 4.1.2
+      fs-extra: 9.1.0
+      minimist: 1.2.8
+
+  '@electron/get@3.1.0':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@electron/get@5.0.0':
     dependencies:
       debug: 4.4.3
@@ -1622,6 +2569,59 @@ snapshots:
       undici: 7.25.0
     transitivePeerDependencies:
       - supports-color
+
+  '@electron/notarize@2.5.0':
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      promise-retry: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/osx-sign@1.3.3':
+    dependencies:
+      compare-version: 0.1.2
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      isbinaryfile: 4.0.10
+      minimist: 1.2.8
+      plist: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/rebuild@4.0.4':
+    dependencies:
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      node-abi: 4.31.0
+      node-api-version: 0.2.1
+      node-gyp: 12.3.0
+      read-binary-file-arch: 1.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/universal@2.0.3':
+    dependencies:
+      '@electron/asar': 3.4.1
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      dir-compare: 4.2.0
+      fs-extra: 11.3.5
+      minimatch: 9.0.9
+      plist: 3.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/windows-sign@1.2.2':
+    dependencies:
+      cross-dirname: 0.1.0
+      debug: 4.4.3
+      fs-extra: 11.3.5
+      minimist: 1.2.8
+      postject: 1.0.0-alpha.6
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1797,6 +2797,10 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1815,6 +2819,19 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@malept/cross-spawn-promise@2.0.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@malept/flatpak-bundler@0.4.0':
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      lodash: 4.18.1
+      tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1876,7 +2893,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@standard-schema/spec@1.1.0': {}
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -1906,14 +2929,37 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 25.8.0
+      '@types/responselike': 1.0.3
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/fs-extra@9.0.13':
+    dependencies:
+      '@types/node': 25.8.0
+
+  '@types/http-cache-semantics@4.2.0': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 25.8.0
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.12.4':
     dependencies:
@@ -1923,6 +2969,12 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
+  '@types/plist@3.0.5':
+    dependencies:
+      '@types/node': 25.8.0
+      xmlbuilder: 15.1.1
+    optional: true
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -1931,15 +2983,22 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 25.8.0
+
+  '@types/verror@1.10.11':
+    optional: true
+
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 25.8.0
     optional: true
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -1950,13 +3009,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -1982,6 +3041,13 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@xmldom/xmldom@0.8.13': {}
+
+  '@xmldom/xmldom@0.9.10':
+    optional: true
+
+  abbrev@4.0.0: {}
+
   acp-mock@1.1.0(zod@4.4.3):
     dependencies:
       '@agentclientprotocol/sdk': 0.21.1(zod@4.4.3)
@@ -2001,17 +3067,99 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  agent-base@7.1.4: {}
+
+  ajv-keywords@3.5.2(ajv@6.15.0):
+    dependencies:
+      ajv: 6.15.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  app-builder-bin@5.0.0-alpha.12: {}
+
+  app-builder-lib@26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1):
+    dependencies:
+      '@develar/schema-utils': 2.6.5
+      '@electron/asar': 3.4.1
+      '@electron/fuses': 1.8.0
+      '@electron/get': 3.1.0
+      '@electron/notarize': 2.5.0
+      '@electron/osx-sign': 1.3.3
+      '@electron/rebuild': 4.0.4
+      '@electron/universal': 2.0.3
+      '@malept/flatpak-bundler': 0.4.0
+      '@types/fs-extra': 9.0.13
+      async-exit-hook: 2.0.1
+      builder-util: 26.8.1
+      builder-util-runtime: 9.5.1
+      chromium-pickle-js: 0.2.0
+      ci-info: 4.3.1
+      debug: 4.4.3
+      dmg-builder: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      dotenv: 16.6.1
+      dotenv-expand: 11.0.7
+      ejs: 3.1.10
+      electron-builder-squirrel-windows: 26.8.1(dmg-builder@26.8.1)
+      electron-publish: 26.8.1
+      fs-extra: 10.1.0
+      hosted-git-info: 4.1.0
+      isbinaryfile: 5.0.7
+      jiti: 2.7.0
+      js-yaml: 4.1.1
+      json5: 2.2.3
+      lazy-val: 1.0.5
+      minimatch: 10.2.5
+      plist: 3.1.0
+      proper-lockfile: 4.1.2
+      resedit: 1.7.2
+      semver: 7.7.4
+      tar: 7.5.15
+      temp-file: 3.4.0
+      tiny-async-pool: 1.3.0
+      which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  argparse@2.0.1: {}
 
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
 
+  assert-plus@1.0.0:
+    optional: true
+
   assertion-error@2.0.1: {}
 
+  astral-regex@2.0.0:
+    optional: true
+
+  async-exit-hook@2.0.1: {}
+
+  async@3.2.6: {}
+
+  asynckit@0.4.0: {}
+
+  at-least-node@1.0.0: {}
+
   b4a@1.8.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   bare-events@2.8.3: {}
 
@@ -2045,11 +3193,29 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.29: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  boolean@3.2.0:
+    optional: true
+
+  brace-expansion@1.1.14:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -2061,15 +3227,133 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
+
+  builder-util-runtime@9.5.1:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util@26.8.1:
+    dependencies:
+      7zip-bin: 5.2.0
+      '@types/debug': 4.1.13
+      app-builder-bin: 5.0.0-alpha.12
+      builder-util-runtime: 9.5.1
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      js-yaml: 4.1.1
+      sanitize-filename: 1.6.4
+      source-map-support: 0.5.21
+      stat-mode: 1.0.0
+      temp-file: 3.4.0
+      tiny-async-pool: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   cac@6.7.14: {}
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   caniuse-lite@1.0.30001792: {}
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chownr@3.0.0: {}
+
+  chromium-pickle-js@0.2.0: {}
+
+  ci-info@4.3.1: {}
+
+  ci-info@4.4.0: {}
+
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
+    optional: true
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.3: {}
 
+  commander@5.1.0: {}
+
+  commander@9.5.0:
+    optional: true
+
+  compare-version@0.1.2: {}
+
+  concat-map@0.0.1: {}
+
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.2:
+    optional: true
+
+  crc@3.8.0:
+    dependencies:
+      buffer: 5.7.1
+    optional: true
+
+  cross-dirname@0.1.0:
+    optional: true
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-tree@3.2.1:
     dependencies:
@@ -2091,15 +3375,124 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  defer-to-connect@2.0.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+    optional: true
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+    optional: true
+
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
+  detect-node@2.1.0:
+    optional: true
+
+  dir-compare@4.2.0:
+    dependencies:
+      minimatch: 3.1.5
+      p-limit: 3.1.0
+
+  dmg-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
+    dependencies:
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      builder-util: 26.8.1
+      fs-extra: 10.1.0
+      iconv-lite: 0.6.3
+      js-yaml: 4.1.1
+    optionalDependencies:
+      dmg-license: 1.0.11
+    transitivePeerDependencies:
+      - electron-builder-squirrel-windows
+      - supports-color
+
+  dmg-license@1.0.11:
+    dependencies:
+      '@types/plist': 3.0.5
+      '@types/verror': 1.10.11
+      ajv: 6.15.0
+      crc: 3.8.0
+      iconv-corefoundation: 1.1.7
+      plist: 3.1.1
+      smart-buffer: 4.2.0
+      verror: 1.10.1
+    optional: true
+
   dom-accessibility-api@0.5.16: {}
+
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
+  electron-builder-squirrel-windows@26.8.1(dmg-builder@26.8.1):
+    dependencies:
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      builder-util: 26.8.1
+      electron-winstaller: 5.4.0
+    transitivePeerDependencies:
+      - dmg-builder
+      - supports-color
+
+  electron-builder@26.8.1(electron-builder-squirrel-windows@26.8.1):
+    dependencies:
+      app-builder-lib: 26.8.1(dmg-builder@26.8.1)(electron-builder-squirrel-windows@26.8.1)
+      builder-util: 26.8.1
+      builder-util-runtime: 9.5.1
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      dmg-builder: 26.8.1(electron-builder-squirrel-windows@26.8.1)
+      fs-extra: 10.1.0
+      lazy-val: 1.0.5
+      simple-update-notifier: 2.0.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - electron-builder-squirrel-windows
+      - supports-color
+
+  electron-publish@26.8.1:
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      builder-util: 26.8.1
+      builder-util-runtime: 9.5.1
+      chalk: 4.1.2
+      form-data: 4.0.5
+      fs-extra: 10.1.0
+      lazy-val: 1.0.5
+      mime: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
 
   electron-to-chromium@1.5.356: {}
 
-  electron-vite@5.0.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)):
+  electron-vite@5.0.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
@@ -2107,7 +3500,19 @@ snapshots:
       esbuild: 0.25.12
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  electron-winstaller@5.4.0:
+    dependencies:
+      '@electron/asar': 3.4.1
+      debug: 4.4.3
+      fs-extra: 7.0.1
+      lodash: 4.18.1
+      temp: 0.9.4
+    optionalDependencies:
+      '@electron/windows-sign': 1.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2119,15 +3524,39 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  emoji-regex@8.0.0: {}
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
 
   entities@8.0.0: {}
 
+  env-paths@2.2.1: {}
+
   env-paths@3.0.0: {}
 
+  err-code@2.0.3: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2189,6 +3618,9 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0:
+    optional: true
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -2201,6 +3633,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -2211,7 +3645,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extsprintf@1.4.1:
+    optional: true
+
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -2231,16 +3672,145 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@5.2.0:
     dependencies:
       pump: 3.0.4
 
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.0
+      serialize-error: 7.0.1
+    optional: true
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
+    optional: true
+
+  gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   graceful-fs@4.2.11: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+    optional: true
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -2248,9 +3818,74 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-corefoundation@1.1.7:
+    dependencies:
+      cli-truncate: 2.1.0
+      node-addon-api: 1.7.2
+    optional: true
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ieee754@1.2.1:
+    optional: true
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
+  isbinaryfile@4.0.10: {}
+
+  isbinaryfile@5.0.7: {}
+
+  isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
+
+  isexe@4.0.0: {}
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
+
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsdom@29.1.1:
     dependencies:
@@ -2280,7 +3915,30 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stringify-safe@5.0.1:
+    optional: true
+
   json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  lazy-val@1.0.5: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2331,11 +3989,19 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash@4.18.1: {}
+
+  lowercase-keys@2.0.0: {}
+
   lru-cache@11.3.6: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lz-string@1.5.0: {}
 
@@ -2343,13 +4009,93 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
+
+  math-intrinsics@1.1.0: {}
+
   mdn-data@2.27.1: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@2.6.0: {}
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.14
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mkdirp@0.5.6:
+    dependencies:
+      minimist: 1.2.8
 
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
+  node-abi@4.31.0:
+    dependencies:
+      semver: 7.8.0
+
+  node-addon-api@1.7.2:
+    optional: true
+
+  node-api-version@0.2.1:
+    dependencies:
+      semver: 7.8.0
+
+  node-gyp@12.3.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.8.0
+      tar: 7.5.15
+      tinyglobby: 0.2.16
+      undici: 6.25.0
+      which: 6.0.1
+
   node-releases@2.0.44: {}
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
+
+  normalize-url@6.1.0: {}
+
+  object-keys@1.1.1:
+    optional: true
 
   obug@2.1.1: {}
 
@@ -2357,11 +4103,23 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  p-cancelable@2.1.1: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
 
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
   pathe@2.0.3: {}
+
+  pe-library@0.4.1: {}
 
   pend@1.2.0: {}
 
@@ -2369,11 +4127,29 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  plist@3.1.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+    optional: true
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postject@1.0.0-alpha.6:
+    dependencies:
+      commander: 9.5.0
+    optional: true
 
   pretty-format@27.5.1:
     dependencies:
@@ -2381,7 +4157,20 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  proc-log@6.1.0: {}
+
   progress@2.0.3: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   pump@3.0.4:
     dependencies:
@@ -2389,6 +4178,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  quick-lru@5.1.1: {}
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -2399,7 +4190,41 @@ snapshots:
 
   react@19.2.6: {}
 
+  read-binary-file-arch@1.0.6:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  resedit@1.7.2:
+    dependencies:
+      pe-library: 0.4.1
+
+  resolve-alpn@1.2.1: {}
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
+  retry@0.12.0: {}
+
+  rimraf@2.6.3:
+    dependencies:
+      glob: 7.2.3
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
 
   rolldown@1.0.1:
     dependencies:
@@ -2422,17 +4247,49 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
 
+  safer-buffer@2.1.2: {}
+
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
+
+  sax@1.6.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
+  semver-compare@1.0.0:
+    optional: true
+
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
 
   semver@7.8.0: {}
 
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.8.0
 
   sisteransi@1.0.5: {}
 
@@ -2445,9 +4302,31 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+    optional: true
+
+  smart-buffer@4.2.0:
+    optional: true
+
   source-map-js@1.2.1: {}
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  sprintf-js@1.1.3:
+    optional: true
+
   stackback@0.0.2: {}
+
+  stat-mode@1.0.0: {}
 
   std-env@4.1.0: {}
 
@@ -2460,11 +4339,25 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   sumchecker@3.0.1:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   symbol-tree@3.2.4: {}
 
@@ -2479,6 +4372,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   teex@1.0.1:
     dependencies:
       streamx: 2.25.0
@@ -2486,11 +4387,25 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  temp-file@3.4.0:
+    dependencies:
+      async-exit-hook: 2.0.1
+      fs-extra: 10.1.0
+
+  temp@0.9.4:
+    dependencies:
+      mkdirp: 0.5.6
+      rimraf: 2.6.3
+
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
+
+  tiny-async-pool@1.3.0:
+    dependencies:
+      semver: 5.7.2
 
   tinybench@2.9.0: {}
 
@@ -2509,6 +4424,12 @@ snapshots:
     dependencies:
       tldts-core: 7.0.30
 
+  tmp-promise@3.0.3:
+    dependencies:
+      tmp: 0.2.5
+
+  tmp@0.2.5: {}
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.30
@@ -2516,6 +4437,10 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
 
   tslib@2.8.1:
     optional: true
@@ -2526,13 +4451,22 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-fest@0.13.1:
+    optional: true
+
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
 
   undici-types@7.24.6: {}
 
+  undici@6.25.0: {}
+
   undici@7.25.0: {}
+
+  universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -2540,7 +4474,20 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0):
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  utf8-byte-length@1.0.5: {}
+
+  verror@1.10.1:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
+    optional: true
+
+  vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2551,12 +4498,13 @@ snapshots:
       '@types/node': 25.8.0
       esbuild: 0.28.0
       fsevents: 2.3.3
+      jiti: 2.7.0
       tsx: 4.22.0
 
-  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)):
+  vitest@4.1.6(@types/node@25.8.0)(jsdom@29.1.1)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -2573,7 +4521,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(tsx@4.22.0)
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.8.0
@@ -2597,22 +4545,62 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.5
+
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   xml-name-validator@5.0.0: {}
 
+  xmlbuilder@15.1.1: {}
+
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yauzl@2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yocto-queue@0.1.0: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   electron: true
+  electron-winstaller: false
   esbuild: true

--- a/scripts/adhoc-sign-mac-app.mjs
+++ b/scripts/adhoc-sign-mac-app.mjs
@@ -1,0 +1,21 @@
+import { existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const appPath = process.argv[2];
+if (!appPath) {
+  console.error("Usage: node scripts/adhoc-sign-mac-app.mjs <app-path>");
+  process.exit(1);
+}
+
+if (process.platform !== "darwin") {
+  console.log("Skipping ad-hoc signing because this host is not macOS.");
+  process.exit(0);
+}
+
+if (!existsSync(appPath)) {
+  console.error(`Cannot sign missing app bundle: ${appPath}`);
+  process.exit(1);
+}
+
+const result = spawnSync("codesign", ["--force", "--deep", "--sign", "-", appPath], { stdio: "inherit" });
+process.exit(result.status ?? 1);

--- a/scripts/create-dmg.mjs
+++ b/scripts/create-dmg.mjs
@@ -1,0 +1,28 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+const version = String(packageJson.version);
+const appPath = process.argv[2] ?? "release/mac-universal/Baby Menu.app";
+const outputDir = process.argv[3] ?? "release";
+const dmgPath = join(outputDir, `Baby-Menu-${version}-universal.dmg`);
+
+if (process.platform !== "darwin") {
+  console.error("DMG creation requires macOS.");
+  process.exit(1);
+}
+
+if (!existsSync(appPath)) {
+  console.error(`Cannot create DMG from missing app bundle: ${appPath}`);
+  process.exit(1);
+}
+
+mkdirSync(outputDir, { recursive: true });
+const result = spawnSync(
+  "hdiutil",
+  ["create", "-volname", "Baby Menu", "-srcfolder", appPath, "-ov", "-format", "UDZO", dmgPath],
+  { stdio: "inherit" },
+);
+process.exit(result.status ?? 1);

--- a/src/main/agent-runtime.ts
+++ b/src/main/agent-runtime.ts
@@ -22,6 +22,14 @@ export type BabyMenuAgentRuntimeOptions = {
   agentName?: string;
   registryOverrides?: Record<string, string>;
   requestTimeoutMs?: number;
+  paths?: BabyMenuAgentRuntimePaths;
+};
+
+export type BabyMenuAgentRuntimePaths = {
+  extensionsDir: string;
+  agentStateDir: string;
+  snapshotDir: string;
+  isPackaged?: boolean;
 };
 
 export type BabyMenuAgentRuntimeSendOptions = {
@@ -31,6 +39,7 @@ export type BabyMenuAgentRuntimeSendOptions = {
 type ResolveDefaultAgentNameOptions = {
   env?: Partial<Pick<NodeJS.ProcessEnv, "BABY_MENU_AGENT" | "PATH">>;
   commandExists?: (command: string) => boolean;
+  allowFallbackWhenMissing?: boolean;
 };
 
 const PREFERRED_AGENTS = [
@@ -65,12 +74,14 @@ function commandExists(command: string): boolean {
   return spawnSync(lookupCommand, lookupArgs, { stdio: "ignore" }).status === 0;
 }
 
-export function resolveDefaultAgentName(options: ResolveDefaultAgentNameOptions = {}): string {
+export function resolveDefaultAgentName(options: ResolveDefaultAgentNameOptions = {}): string | null {
   const configuredAgent = options.env?.BABY_MENU_AGENT ?? process.env.BABY_MENU_AGENT;
   if (configuredAgent?.trim()) return configuredAgent.trim();
 
   const hasCommand = options.commandExists ?? commandExists;
-  return PREFERRED_AGENTS.find((agent) => hasCommand(agent.command))?.name ?? PREFERRED_AGENTS[0].name;
+  const detected = PREFERRED_AGENTS.find((agent) => hasCommand(agent.command))?.name;
+  if (detected) return detected;
+  return options.allowFallbackWhenMissing === false ? null : PREFERRED_AGENTS[0].name;
 }
 
 export function resolveAgentTimeoutMs(env: Partial<Pick<NodeJS.ProcessEnv, "BABY_MENU_AGENT_TIMEOUT_MS">> = process.env) {
@@ -81,8 +92,23 @@ export function resolveAgentTimeoutMs(env: Partial<Pick<NodeJS.ProcessEnv, "BABY
 export function getAgentRuntimeCwd(
   rootDir: string,
   env: Partial<Pick<NodeJS.ProcessEnv, "BABY_MENU_EXTENSIONS_DIR">> = process.env,
+  paths?: Pick<BabyMenuAgentRuntimePaths, "extensionsDir">,
 ): string {
+  if (paths) return paths.extensionsDir;
   return getExtensionsDir(rootDir, env);
+}
+
+export function selectAgentChangeSessionKind({
+  isPackaged,
+  rootDir,
+  extensionsDir,
+}: {
+  isPackaged?: boolean;
+  rootDir: string;
+  extensionsDir: string;
+}): "git" | "snapshot" {
+  if (isPackaged) return "snapshot";
+  return resolve(extensionsDir) === resolve(join(rootDir, "extensions")) ? "git" : "snapshot";
 }
 
 export function withAgentTimeout<T>(
@@ -233,6 +259,7 @@ export class BabyMenuAgentRuntime {
   private readonly agentName: string;
   private readonly registryOverrides: Record<string, string> | undefined;
   private readonly requestTimeoutMs: number;
+  private readonly paths: BabyMenuAgentRuntimePaths | undefined;
 
   constructor(
     private readonly rootDir: string,
@@ -241,9 +268,10 @@ export class BabyMenuAgentRuntime {
     this.agentName =
       typeof options === "string"
         ? options
-        : options.agentName ?? resolveDefaultAgentName();
+        : options.agentName ?? resolveDefaultAgentName() ?? PREFERRED_AGENTS[0].name;
     this.registryOverrides = typeof options === "string" ? undefined : options.registryOverrides;
     this.requestTimeoutMs = typeof options === "string" ? resolveAgentTimeoutMs() : options.requestTimeoutMs ?? resolveAgentTimeoutMs();
+    this.paths = typeof options === "string" ? undefined : options.paths;
   }
 
   get session(): AgentChangeSession | null {
@@ -348,14 +376,14 @@ export class BabyMenuAgentRuntime {
   }
 
   private async ensureAgentRuntimeCwd(): Promise<string> {
-    const agentCwd = getAgentRuntimeCwd(this.rootDir);
+    const agentCwd = getAgentRuntimeCwd(this.rootDir, process.env, this.paths);
     await mkdir(agentCwd, { recursive: true });
     return agentCwd;
   }
 
   private async beginChangeSession(agentCwd: string): Promise<AgentChangeSession> {
-    if (isDevExtensionWorkspace(this.rootDir, agentCwd)) {
-      return DevExtensionChangeSession.begin(agentCwd, getDevExtensionSnapshotDir(this.rootDir));
+    if (selectAgentChangeSessionKind({ isPackaged: this.paths?.isPackaged, rootDir: this.rootDir, extensionsDir: agentCwd }) === "snapshot") {
+      return DevExtensionChangeSession.begin(agentCwd, this.paths?.snapshotDir ?? getDevExtensionSnapshotDir(this.rootDir));
     }
 
     return GitChangeSession.begin(this.rootDir);
@@ -364,7 +392,7 @@ export class BabyMenuAgentRuntime {
   private async ensureRuntime(agentCwd: string): Promise<AcpxRuntime> {
     if (this.runtime) return this.runtime;
 
-    const stateDir = getAgentStateDir(this.rootDir);
+    const stateDir = this.paths?.agentStateDir ?? getAgentStateDir(this.rootDir);
     await mkdir(stateDir, { recursive: true });
     this.runtime = createAcpRuntime({
       cwd: agentCwd,

--- a/src/main/app-paths.ts
+++ b/src/main/app-paths.ts
@@ -1,0 +1,84 @@
+import { app } from "electron";
+import { isAbsolute, join } from "node:path";
+import { EXTENSIONS_DIR_ENV } from "../shared/paths";
+
+export type BabyMenuRuntimePaths = {
+  appDataRoot: string;
+  sourceRoot: string;
+  extensionsDir: string;
+  recipesDir: string;
+  cacheDir: string;
+  widgetCacheDir: string;
+  serverActionCacheDir: string;
+  agentStateDir: string;
+  devExtensionSnapshotDir: string;
+  bundledExtensionTemplateDir: string | null;
+  isPackaged: boolean;
+};
+
+type CreateBabyMenuRuntimePathsOptions = {
+  isPackaged: boolean;
+  sourceRoot: string;
+  env?: Partial<Pick<NodeJS.ProcessEnv, typeof EXTENSIONS_DIR_ENV>>;
+  homeDir?: string;
+  resourcesPath?: string;
+};
+
+export function createBabyMenuRuntimePaths(options: CreateBabyMenuRuntimePathsOptions): BabyMenuRuntimePaths {
+  if (!options.isPackaged) {
+    const cacheDir = join(options.sourceRoot, ".cache", "baby-menu");
+    const extensionsDir = resolveSourceExtensionsDir(options.sourceRoot, options.env);
+    return {
+      appDataRoot: options.sourceRoot,
+      sourceRoot: options.sourceRoot,
+      extensionsDir,
+      recipesDir: join(extensionsDir, "recipes"),
+      cacheDir,
+      widgetCacheDir: join(cacheDir, "widgets"),
+      serverActionCacheDir: join(cacheDir, "server-actions"),
+      agentStateDir: join(cacheDir, "acp-sessions"),
+      devExtensionSnapshotDir: join(cacheDir, "dev-extension-snapshots"),
+      bundledExtensionTemplateDir: null,
+      isPackaged: false,
+    };
+  }
+
+  if (!options.homeDir) throw new Error("homeDir is required for packaged Baby Menu paths");
+  if (!options.resourcesPath) throw new Error("resourcesPath is required for packaged Baby Menu paths");
+
+  const appDataRoot = join(options.homeDir, ".baby-menu");
+  const cacheDir = join(appDataRoot, "cache");
+  const extensionsDir = join(appDataRoot, "extensions");
+  return {
+    appDataRoot,
+    sourceRoot: options.sourceRoot,
+    extensionsDir,
+    recipesDir: join(extensionsDir, "recipes"),
+    cacheDir,
+    widgetCacheDir: join(cacheDir, "widgets"),
+    serverActionCacheDir: join(cacheDir, "server-actions"),
+    agentStateDir: join(cacheDir, "acp-sessions"),
+    devExtensionSnapshotDir: join(cacheDir, "snapshots"),
+    bundledExtensionTemplateDir: join(options.resourcesPath, "extensions-template"),
+    isPackaged: true,
+  };
+}
+
+export function resolveBabyMenuRuntimePaths(sourceRoot: string): BabyMenuRuntimePaths {
+  return createBabyMenuRuntimePaths({
+    isPackaged: app.isPackaged,
+    sourceRoot,
+    env: process.env,
+    homeDir: app.isPackaged ? app.getPath("home") : undefined,
+    resourcesPath: app.isPackaged ? process.resourcesPath : undefined,
+  });
+}
+
+function resolveSourceExtensionsDir(
+  sourceRoot: string,
+  env: Partial<Pick<NodeJS.ProcessEnv, typeof EXTENSIONS_DIR_ENV>> = process.env,
+): string {
+  const configured = env[EXTENSIONS_DIR_ENV];
+  if (!configured) return join(sourceRoot, "extensions");
+  return isAbsolute(configured) ? configured : join(sourceRoot, configured);
+}

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -2,6 +2,9 @@ import { app, BrowserWindow, screen, type Rectangle } from "electron";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getRepoRoot } from "../shared/paths";
+import { BabyMenuAgentRuntime } from "./agent-runtime";
+import { resolveBabyMenuRuntimePaths } from "./app-paths";
+import { seedExtensionWorkspace } from "./extension-seeder";
 import { registerIpcHandlers } from "./ipc";
 import {
   DEFAULT_POPOVER_SIZE,
@@ -11,7 +14,14 @@ import {
   responsivePopoverSize,
   type Size,
 } from "./popover";
+import { createPreferencesService } from "./preferences";
+import { createServerActionRegistry } from "./server-action-registry";
+import { expandProcessPathForGuiLaunch } from "./shell-path";
 import { createBabyMenuTray, type BabyMenuTray } from "./tray";
+import { createWidgetModuleRegistry } from "./widget-module-registry";
+import { registerBabyMenuProtocolHandlers, registerBabyMenuProtocolSchemes } from "./widget-protocol";
+
+registerBabyMenuProtocolSchemes();
 
 let popoverWindow: BrowserWindow | null = null;
 let activeTray: BabyMenuTray | null = null;
@@ -69,13 +79,49 @@ function setPopoverContentHeight(height: number) {
 }
 
 export async function startBabyMenuApp(): Promise<void> {
+  expandProcessPathForGuiLaunch();
   await app.whenReady();
+  const sourceRoot = getRepoRoot();
+  const paths = resolveBabyMenuRuntimePaths(sourceRoot);
+  await seedExtensionWorkspace({ extensionsDir: paths.extensionsDir, templateDir: paths.bundledExtensionTemplateDir });
+  registerBabyMenuProtocolHandlers({ widgetCacheDir: paths.widgetCacheDir });
 
   if (process.platform === "darwin") {
     app.dock?.hide();
   }
 
-  registerIpcHandlers(getRepoRoot(), undefined, undefined, undefined, { setContentHeight: setPopoverContentHeight });
+  const preferences = createPreferencesService({ userDataDir: paths.appDataRoot, app });
+  await preferences.apply();
+
+  const agentRuntime = new BabyMenuAgentRuntime(paths.appDataRoot, {
+    paths: {
+      extensionsDir: paths.extensionsDir,
+      agentStateDir: paths.agentStateDir,
+      snapshotDir: paths.devExtensionSnapshotDir,
+      isPackaged: paths.isPackaged,
+    },
+  });
+  const serverActions = createServerActionRegistry({
+    rootDir: paths.appDataRoot,
+    actionRoots: [paths.extensionsDir],
+    cacheDir: paths.serverActionCacheDir,
+  });
+  const widgetModules = createWidgetModuleRegistry({
+    rootDir: paths.appDataRoot,
+    extensionsDir: paths.extensionsDir,
+    mode: paths.isPackaged ? "compiled" : "vite",
+    widgetCacheDir: paths.widgetCacheDir,
+  });
+
+  registerIpcHandlers(
+    paths.appDataRoot,
+    agentRuntime,
+    serverActions,
+    widgetModules,
+    { setContentHeight: setPopoverContentHeight },
+    preferences,
+    { recipesDir: paths.recipesDir },
+  );
   activeTray = createBabyMenuTray((bounds) => {
     void togglePopover(bounds);
   });

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -119,7 +119,7 @@ async function collectModuleGraph(options: {
     modules.set(normalizedPath, { filePath: normalizedPath, source });
 
     const dependencies = await Promise.all(
-      importSpecifierMatches(source).map(async (match) => {
+      importSpecifierMatches(source, { includeTypeOnly: false }).map(async (match) => {
         if (!isLocalSpecifier(match.specifier)) {
           assertSupportedExternalImport(options.kind, match.specifier, options.extensionId, options.extensionDir, normalizedPath);
           return null;
@@ -264,20 +264,29 @@ function contentHash(modules: SourceModule[], extensionDir: string, kind: Extens
   return hash.digest("hex").slice(0, HASH_LENGTH);
 }
 
-function importSpecifierMatches(source: string): Array<{ specifier: string; start: number; end: number }> {
+function importSpecifierMatches(source: string, options: { includeTypeOnly?: boolean } = {}): Array<{ specifier: string; start: number; end: number }> {
   const matches = [
-    ...matchesForPattern(source, STATIC_IMPORT_PATTERN),
+    ...matchesForPattern(source, STATIC_IMPORT_PATTERN, options),
     ...matchesForPattern(source, SIDE_EFFECT_IMPORT_PATTERN),
   ];
   return matches.sort((left, right) => left.start - right.start);
 }
 
-function matchesForPattern(source: string, pattern: RegExp): Array<{ specifier: string; start: number; end: number }> {
-  return [...source.matchAll(pattern)].map((match) => {
+function matchesForPattern(
+  source: string,
+  pattern: RegExp,
+  options: { includeTypeOnly?: boolean } = {},
+): Array<{ specifier: string; start: number; end: number }> {
+  return [...source.matchAll(pattern)].flatMap((match) => {
+    if (!options.includeTypeOnly && isTypeOnlyImport(match[0])) return [];
     const specifier = match[2];
     const start = (match.index ?? 0) + match[1].length;
-    return { specifier, start, end: start + specifier.length };
+    return [{ specifier, start, end: start + specifier.length }];
   });
+}
+
+function isTypeOnlyImport(statement: string): boolean {
+  return /^\s*(?:import|export)\s+type\b/.test(statement);
 }
 
 function applyReplacements(source: string, replacements: Array<{ start: number; end: number; value: string }>): string {

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -1,0 +1,305 @@
+import { builtinModules } from "node:module";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+export type ExtensionModuleKind = "widget" | "server";
+
+export type CompileExtensionModuleOptions = {
+  kind: ExtensionModuleKind;
+  extensionId: string;
+  extensionDir: string;
+  entryFile: string;
+  cacheRoot: string;
+};
+
+export type CompiledExtensionModule = {
+  hash: string;
+  outputDir: string;
+  outputPath: string;
+  moduleUrl: string;
+};
+
+type SourceModule = {
+  filePath: string;
+  source: string;
+};
+
+type ResolvedLocalImport = {
+  path: string;
+};
+
+const LOCAL_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs"];
+const STATIC_IMPORT_PATTERN = /(\b(?:import|export)\b[\s\S]*?\bfrom\s*["'])([^"']+)(["'])/g;
+const SIDE_EFFECT_IMPORT_PATTERN = /(\bimport\s*["'])([^"']+)(["'])/g;
+const HASH_LENGTH = 16;
+
+export async function compileExtensionModule(options: CompileExtensionModuleOptions): Promise<CompiledExtensionModule> {
+  const extensionDir = resolve(options.extensionDir);
+  const entryFile = resolve(options.entryFile);
+  assertInsideExtension(extensionDir, entryFile, options.extensionId);
+
+  const graph = await collectModuleGraph({
+    kind: options.kind,
+    extensionId: options.extensionId,
+    extensionDir,
+    entryFile,
+  });
+  const hash = contentHash(graph, extensionDir, options.kind);
+  const outputDir = join(options.cacheRoot, options.extensionId, hash);
+
+  await Promise.all(
+    graph.map(async (module) => {
+      const outputPath = compiledOutputPath(outputDir, extensionDir, module.filePath);
+      const output = await transpileAndRewriteModule({
+        kind: options.kind,
+        extensionId: options.extensionId,
+        extensionDir,
+        filePath: module.filePath,
+        source: module.source,
+      });
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, output);
+    }),
+  );
+
+  const outputPath = compiledOutputPath(outputDir, extensionDir, entryFile);
+  return {
+    hash,
+    outputDir,
+    outputPath,
+    moduleUrl: pathToFileURL(outputPath).href,
+  };
+}
+
+export async function rewriteExtensionModuleImports(options: {
+  kind: ExtensionModuleKind;
+  extensionId: string;
+  extensionDir: string;
+  filePath: string;
+  source: string;
+  validateExternalImports?: boolean;
+}): Promise<string> {
+  const extensionDir = resolve(options.extensionDir);
+  const filePath = resolve(options.filePath);
+  const replacements = await Promise.all(
+    importSpecifierMatches(options.source).map(async (match) => {
+      const rewritten = await rewriteImportSpecifier({
+        kind: options.kind,
+        extensionId: options.extensionId,
+        extensionDir,
+        filePath,
+        specifier: match.specifier,
+        validateExternalImports: options.validateExternalImports ?? true,
+      });
+      if (rewritten === match.specifier) return null;
+      return { start: match.start, end: match.end, value: rewritten };
+    }),
+  );
+
+  return applyReplacements(options.source, replacements.filter((replacement) => replacement !== null));
+}
+
+async function collectModuleGraph(options: {
+  kind: ExtensionModuleKind;
+  extensionId: string;
+  extensionDir: string;
+  entryFile: string;
+}): Promise<SourceModule[]> {
+  const modules = new Map<string, SourceModule>();
+
+  async function visit(filePath: string) {
+    const normalizedPath = resolve(filePath);
+    if (modules.has(normalizedPath)) return;
+    assertInsideExtension(options.extensionDir, normalizedPath, options.extensionId);
+
+    const source = await readFile(normalizedPath, "utf8");
+    modules.set(normalizedPath, { filePath: normalizedPath, source });
+
+    const dependencies = await Promise.all(
+      importSpecifierMatches(source).map(async (match) => {
+        if (!isLocalSpecifier(match.specifier)) {
+          assertSupportedExternalImport(options.kind, match.specifier, options.extensionId, options.extensionDir, normalizedPath);
+          return null;
+        }
+        return resolveLocalImport(normalizedPath, match.specifier, options.extensionDir, options.extensionId);
+      }),
+    );
+    await Promise.all(dependencies.filter((dependency): dependency is ResolvedLocalImport => Boolean(dependency)).map((dependency) => visit(dependency.path)));
+  }
+
+  await visit(options.entryFile);
+  return [...modules.values()].sort((left, right) => left.filePath.localeCompare(right.filePath));
+}
+
+async function transpileAndRewriteModule(options: {
+  kind: ExtensionModuleKind;
+  extensionId: string;
+  extensionDir: string;
+  filePath: string;
+  source: string;
+}) {
+  const transpiled = ts.transpileModule(options.source, {
+    fileName: options.filePath,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      jsx: ts.JsxEmit.ReactJSX,
+      esModuleInterop: true,
+      importsNotUsedAsValues: ts.ImportsNotUsedAsValues.Remove,
+      sourceMap: false,
+    },
+  }).outputText;
+
+  return rewriteExtensionModuleImports({ ...options, source: transpiled, validateExternalImports: true });
+}
+
+async function rewriteImportSpecifier(options: {
+  kind: ExtensionModuleKind;
+  extensionId: string;
+  extensionDir: string;
+  filePath: string;
+  specifier: string;
+  validateExternalImports: boolean;
+}): Promise<string> {
+  if (!isLocalSpecifier(options.specifier)) {
+    if (options.kind === "widget") return rewriteWidgetExternalImport(options);
+    if (options.validateExternalImports) {
+      assertSupportedExternalImport(options.kind, options.specifier, options.extensionId, options.extensionDir, options.filePath);
+    }
+    return options.specifier;
+  }
+
+  const resolved = await resolveLocalImport(options.filePath, options.specifier, options.extensionDir, options.extensionId);
+  return relativeModuleSpecifier(options.filePath, resolved.path, options.extensionDir);
+}
+
+function rewriteWidgetExternalImport(options: {
+  extensionId: string;
+  extensionDir: string;
+  filePath: string;
+  specifier: string;
+  validateExternalImports: boolean;
+}): string {
+  if (options.specifier === "react") return "baby-menu-host://react/index.mjs";
+  if (options.specifier === "react/jsx-runtime" || options.specifier === "react/jsx-dev-runtime") {
+    return "baby-menu-host://react-jsx-runtime/index.mjs";
+  }
+  if (options.validateExternalImports) {
+    assertSupportedExternalImport("widget", options.specifier, options.extensionId, options.extensionDir, options.filePath);
+  }
+  return options.specifier;
+}
+
+function assertSupportedExternalImport(
+  kind: ExtensionModuleKind,
+  specifier: string,
+  extensionId: string,
+  extensionDir: string,
+  filePath: string,
+) {
+  if (kind === "widget" && (specifier === "react" || specifier === "react/jsx-runtime" || specifier === "react/jsx-dev-runtime")) {
+    return;
+  }
+  if (kind === "server" && (specifier.startsWith("node:") || builtinModules.includes(specifier))) return;
+
+  throw new Error(
+    `Unsupported ${kind} import "${specifier}" in ${formatExtensionPath(extensionId, extensionDir, filePath)}`,
+  );
+}
+
+async function resolveLocalImport(
+  filePath: string,
+  specifier: string,
+  extensionDir: string,
+  extensionId: string,
+): Promise<ResolvedLocalImport> {
+  const basePath = resolve(dirname(filePath), specifier);
+  assertInsideExtension(extensionDir, basePath, extensionId, "Local import escapes extension workspace");
+
+  const candidates = extname(specifier)
+    ? [basePath]
+    : [...LOCAL_EXTENSIONS.map((extension) => `${basePath}${extension}`), ...LOCAL_EXTENSIONS.map((extension) => join(basePath, `index${extension}`))];
+
+  for (const candidate of candidates) {
+    try {
+      const source = await readFile(candidate, "utf8");
+      void source;
+      return { path: resolve(candidate) };
+    } catch {
+      // Try the next import candidate.
+    }
+  }
+
+  throw new Error(`Cannot resolve local import "${specifier}" in ${formatExtensionPath(extensionId, extensionDir, filePath)}`);
+}
+
+function compiledOutputPath(outputDir: string, extensionDir: string, filePath: string): string {
+  return join(outputDir, replaceExtension(relative(extensionDir, filePath), ".mjs"));
+}
+
+function relativeModuleSpecifier(fromFile: string, toFile: string, extensionDir: string): string {
+  const fromOutput = replaceExtension(relative(extensionDir, fromFile), ".mjs");
+  const toOutput = replaceExtension(relative(extensionDir, toFile), ".mjs");
+  let specifier = relative(dirname(fromOutput), toOutput).split("\\").join("/");
+  if (!specifier.startsWith(".")) specifier = `./${specifier}`;
+  return specifier;
+}
+
+function replaceExtension(filePath: string, extension: string): string {
+  return filePath.slice(0, filePath.length - extname(filePath).length) + extension;
+}
+
+function contentHash(modules: SourceModule[], extensionDir: string, kind: ExtensionModuleKind): string {
+  const hash = createHash("sha256");
+  hash.update(`${kind}\0`);
+  for (const module of modules) {
+    hash.update(relative(extensionDir, module.filePath));
+    hash.update("\0");
+    hash.update(module.source);
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, HASH_LENGTH);
+}
+
+function importSpecifierMatches(source: string): Array<{ specifier: string; start: number; end: number }> {
+  const matches = [
+    ...matchesForPattern(source, STATIC_IMPORT_PATTERN),
+    ...matchesForPattern(source, SIDE_EFFECT_IMPORT_PATTERN),
+  ];
+  return matches.sort((left, right) => left.start - right.start);
+}
+
+function matchesForPattern(source: string, pattern: RegExp): Array<{ specifier: string; start: number; end: number }> {
+  return [...source.matchAll(pattern)].map((match) => {
+    const specifier = match[2];
+    const start = (match.index ?? 0) + match[1].length;
+    return { specifier, start, end: start + specifier.length };
+  });
+}
+
+function applyReplacements(source: string, replacements: Array<{ start: number; end: number; value: string }>): string {
+  return replacements
+    .sort((left, right) => right.start - left.start)
+    .reduce((current, replacement) => {
+      return `${current.slice(0, replacement.start)}${replacement.value}${current.slice(replacement.end)}`;
+    }, source);
+}
+
+function assertInsideExtension(extensionDir: string, filePath: string, extensionId: string, message = "Extension path escapes workspace") {
+  const relativePath = relative(extensionDir, filePath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    throw new Error(`${message}: ${formatExtensionPath(extensionId, extensionDir, filePath)}`);
+  }
+}
+
+function isLocalSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./") || specifier.startsWith("../");
+}
+
+function formatExtensionPath(extensionId: string, extensionDir: string, filePath: string): string {
+  const relativePath = relative(extensionDir, filePath).split("\\").join("/");
+  return `${extensionId}/${relativePath}`;
+}

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from "node:module";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
@@ -49,6 +49,16 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
   });
   const hash = contentHash(graph, extensionDir, options.kind);
   const outputDir = join(options.cacheRoot, options.extensionId, hash);
+  const outputPath = compiledOutputPath(outputDir, extensionDir, entryFile);
+
+  if (await pathExists(outputPath)) {
+    return {
+      hash,
+      outputDir,
+      outputPath,
+      moduleUrl: pathToFileURL(outputPath).href,
+    };
+  }
 
   await Promise.all(
     graph.map(async (module) => {
@@ -65,13 +75,21 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
     }),
   );
 
-  const outputPath = compiledOutputPath(outputDir, extensionDir, entryFile);
   return {
     hash,
     outputDir,
     outputPath,
     moduleUrl: pathToFileURL(outputPath).href,
   };
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function rewriteExtensionModuleImports(options: {

--- a/src/main/extension-seeder.ts
+++ b/src/main/extension-seeder.ts
@@ -1,0 +1,25 @@
+import { cp, mkdir, stat } from "node:fs/promises";
+
+export type SeedExtensionWorkspaceOptions = {
+  extensionsDir: string;
+  templateDir: string | null;
+};
+
+export async function seedExtensionWorkspace(options: SeedExtensionWorkspaceOptions): Promise<boolean> {
+  if (!options.templateDir) return false;
+  if (await pathExists(options.extensionsDir)) return false;
+  if (!(await pathExists(options.templateDir))) return false;
+
+  await mkdir(options.extensionsDir, { recursive: true });
+  await cp(options.templateDir, options.extensionsDir, { recursive: true, force: false, errorOnExist: false });
+  return true;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/main/extension-seeder.ts
+++ b/src/main/extension-seeder.ts
@@ -7,7 +7,6 @@ export type SeedExtensionWorkspaceOptions = {
 
 export async function seedExtensionWorkspace(options: SeedExtensionWorkspaceOptions): Promise<boolean> {
   if (!options.templateDir) return false;
-  if (await pathExists(options.extensionsDir)) return false;
   if (!(await pathExists(options.templateDir))) return false;
 
   await mkdir(options.extensionsDir, { recursive: true });

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from "electron";
 import { pathToFileURL } from "node:url";
-import type { AgentChatResult, GitActionResult, RecipeMetadata } from "../shared/contracts";
+import type { AgentChatResult, BabyMenuSettings, GitActionResult, RecipeMetadata } from "../shared/contracts";
 import { getExtensionsDir, getRecipesDir } from "../shared/paths";
 import { BabyMenuAgentRuntime, type BabyMenuAgentRuntimeSendOptions } from "./agent-runtime";
 import { loadRecipes } from "./recipe-loader";
@@ -15,15 +15,29 @@ type PopoverController = {
   setContentHeight: (height: number) => void | Promise<void>;
 };
 
+type SettingsController = {
+  get: () => Promise<BabyMenuSettings> | BabyMenuSettings;
+  setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuSettings> | BabyMenuSettings;
+};
+
+type IpcRuntimeOptions = {
+  recipesDir?: string;
+};
+
 export function registerIpcHandlers(
   rootDir: string,
   agentRuntime: AgentRuntimeFacade = new BabyMenuAgentRuntime(rootDir),
   serverActions: ServerActionRegistry = createServerActionRegistry({ rootDir, actionRoots: [getExtensionsDir(rootDir)] }),
   widgetModules: WidgetModuleRegistry = createWidgetModuleRegistry(rootDir),
   popover: PopoverController = { setContentHeight: () => undefined },
+  settings: SettingsController = {
+    get: () => ({ openAtLogin: false }),
+    setOpenAtLogin: (openAtLogin) => ({ openAtLogin }),
+  },
+  runtimeOptions: IpcRuntimeOptions = {},
 ) {
   ipcMain.handle("baby-menu:recipes:list", async (): Promise<RecipeMetadata[]> => {
-    return loadRecipes(pathToFileURL(`${getRecipesDir(rootDir)}/`));
+    return loadRecipes(pathToFileURL(`${runtimeOptions.recipesDir ?? getRecipesDir(rootDir)}/`));
   });
 
   ipcMain.handle("baby-menu:agent:send", async (event, prompt: string): Promise<AgentChatResult> => {
@@ -55,5 +69,13 @@ export function registerIpcHandlers(
   ipcMain.handle("baby-menu:popover:set-content-height", async (_event, height: number) => {
     await popover.setContentHeight(height);
     return { ok: true };
+  });
+
+  ipcMain.handle("baby-menu:settings:get", async () => {
+    return settings.get();
+  });
+
+  ipcMain.handle("baby-menu:settings:set-open-at-login", async (_event, openAtLogin: boolean) => {
+    return settings.setOpenAtLogin(openAtLogin);
   });
 }

--- a/src/main/preferences.ts
+++ b/src/main/preferences.ts
@@ -1,0 +1,50 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export type BabyMenuPreferences = {
+  openAtLogin: boolean;
+};
+
+type LoginItemApp = {
+  setLoginItemSettings: (settings: { openAtLogin: boolean }) => void;
+  getLoginItemSettings: () => { openAtLogin?: boolean };
+};
+
+export type PreferencesService = {
+  get: () => Promise<BabyMenuPreferences>;
+  setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuPreferences>;
+  apply: () => Promise<BabyMenuPreferences>;
+};
+
+export function createPreferencesService({ userDataDir, app }: { userDataDir: string; app: LoginItemApp }): PreferencesService {
+  const filePath = join(userDataDir, "preferences.json");
+
+  async function readPreferences(): Promise<BabyMenuPreferences> {
+    try {
+      const parsed = JSON.parse(await readFile(filePath, "utf8")) as Partial<BabyMenuPreferences>;
+      return { openAtLogin: parsed.openAtLogin ?? app.getLoginItemSettings().openAtLogin ?? false };
+    } catch {
+      return { openAtLogin: app.getLoginItemSettings().openAtLogin ?? false };
+    }
+  }
+
+  async function writePreferences(preferences: BabyMenuPreferences): Promise<BabyMenuPreferences> {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, `${JSON.stringify(preferences, null, 2)}\n`);
+    return preferences;
+  }
+
+  return {
+    get: readPreferences,
+    async setOpenAtLogin(openAtLogin) {
+      const preferences = await writePreferences({ openAtLogin });
+      app.setLoginItemSettings({ openAtLogin });
+      return preferences;
+    },
+    async apply() {
+      const preferences = await readPreferences();
+      app.setLoginItemSettings({ openAtLogin: preferences.openAtLogin });
+      return preferences;
+    },
+  };
+}

--- a/src/main/server-action-registry.ts
+++ b/src/main/server-action-registry.ts
@@ -1,8 +1,9 @@
 import type { Dirent } from "node:fs";
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { readdir } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { BabyMenuCapabilityDescriptor } from "../shared/contracts";
+import { compileExtensionModule, rewriteExtensionModuleImports } from "./extension-module-compiler";
 
 export type ServerActionContext = {
   rootDir: string;
@@ -28,6 +29,7 @@ type ServerActionModule = {
 type CreateServerActionRegistryOptions = {
   rootDir: string;
   actionRoots?: string[];
+  cacheDir?: string;
 };
 
 const DEFAULT_ACTION_ROOTS = ["extensions"];
@@ -42,7 +44,7 @@ export function createServerActionRegistry(options: CreateServerActionRegistryOp
       await Promise.all(actionRoots.map((root) => discoverServerActionFiles(resolveActionRoot(options.rootDir, root))))
     ).flat();
 
-    const loaded = await Promise.all(files.map(async (filePath) => loadServerActionFile(filePath, options.rootDir, ++importVersion)));
+    const loaded = await Promise.all(files.map(async (filePath) => loadServerActionFile(filePath, options.rootDir, ++importVersion, options.cacheDir)));
     return loaded.flat();
   };
 
@@ -84,8 +86,8 @@ async function discoverServerActionFiles(rootDir: string): Promise<string[]> {
   return files.flat().sort();
 }
 
-async function loadServerActionFile(filePath: string, rootDir: string, importVersion: number): Promise<LoadedServerAction[]> {
-  const importPath = await prepareServerActionModule(filePath, rootDir, importVersion);
+async function loadServerActionFile(filePath: string, rootDir: string, importVersion: number, cacheDir?: string): Promise<LoadedServerAction[]> {
+  const importPath = await prepareServerActionModule(filePath, rootDir, cacheDir);
   const moduleUrl = pathToFileURL(importPath);
   moduleUrl.searchParams.set("babyMenuServerActionVersion", String(importVersion));
   const module = (await import(moduleUrl.href)) as ServerActionModule;
@@ -100,114 +102,28 @@ async function loadServerActionFile(filePath: string, rootDir: string, importVer
   }));
 }
 
-async function prepareServerActionModule(filePath: string, rootDir: string, importVersion: number): Promise<string> {
-  const cacheRoot = join(rootDir, ".cache", "baby-menu", "server-actions", String(importVersion));
-  await copyServerActionModule(filePath, rootDir, cacheRoot, new Set());
-  return cachedModulePath(filePath, rootDir, cacheRoot);
-}
-
-async function copyServerActionModule(
-  filePath: string,
-  rootDir: string,
-  cacheRoot: string,
-  seen: Set<string>,
-): Promise<void> {
+async function prepareServerActionModule(filePath: string, rootDir: string, cacheDir?: string): Promise<string> {
   const normalizedPath = resolve(filePath);
-  if (seen.has(normalizedPath)) return;
-  seen.add(normalizedPath);
-
-  const source = await readFile(normalizedPath, "utf8");
-  const dependencies = await findLocalServerActionDependencies(source, normalizedPath);
-  const rewritten = await rewriteLocalServerActionImports(source, normalizedPath);
-  const outputPath = cachedModulePath(normalizedPath, rootDir, cacheRoot);
-  await mkdir(dirname(outputPath), { recursive: true });
-  await writeFile(outputPath, rewritten);
-
-  await Promise.all(dependencies.map((dependency) => copyServerActionModule(dependency, rootDir, cacheRoot, seen)));
-}
-
-function cachedModulePath(filePath: string, rootDir: string, cacheRoot: string): string {
-  const relativePath = relative(rootDir, filePath);
-  return join(cacheRoot, relativePath);
+  const extensionId = inferExtensionId(normalizedPath);
+  const compiled = await compileExtensionModule({
+    kind: "server",
+    extensionId,
+    extensionDir: dirname(normalizedPath),
+    entryFile: normalizedPath,
+    cacheRoot: cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
+  });
+  return compiled.outputPath;
 }
 
 export async function rewriteLocalServerActionImports(source: string, filePath: string): Promise<string> {
-  const importPattern = /(\b(?:import|export)\b[\s\S]*?\bfrom\s*["'])(\.{1,2}\/[^"']+)(["'])/g;
-  const replacements = await Promise.all(
-    [...source.matchAll(importPattern)].map(async (match) => {
-      const resolved = await resolveLocalImport(filePath, match[2]);
-      if (!resolved) return null;
-      return {
-        start: match.index + match[1].length,
-        end: match.index + match[1].length + match[2].length,
-        value: toExtensionSpecifier(match[2], resolved.kind),
-      };
-    }),
-  );
-
-  return applyReplacements(source, replacements.filter((replacement) => replacement !== null));
-}
-
-async function findLocalServerActionDependencies(source: string, filePath: string): Promise<string[]> {
-  const importPattern = /\b(?:import|export)\b[\s\S]*?\bfrom\s*["'](\.{1,2}\/[^"']+)["']/g;
-  const dependencies = await Promise.all(
-    [...source.matchAll(importPattern)].map(async (match) => (await resolveLocalImport(filePath, match[1]))?.path),
-  );
-  return dependencies.filter((dependency): dependency is string => Boolean(dependency));
-}
-
-type ResolvedLocalImport = {
-  path: string;
-  kind: { type: "file"; extension: string } | { type: "index"; extension: string };
-};
-
-async function resolveLocalImport(filePath: string, specifier: string): Promise<ResolvedLocalImport | null> {
-  if (!specifier.startsWith(".")) return null;
-  if (extname(specifier)) return resolveExistingImport(filePath, specifier);
-
-  const basePath = resolve(dirname(filePath), specifier);
-  for (const extension of [".ts", ".mjs", ".js"]) {
-    if (await fileExists(`${basePath}${extension}`)) {
-      return { path: `${basePath}${extension}`, kind: { type: "file", extension } };
-    }
-  }
-
-  for (const extension of [".ts", ".mjs", ".js"]) {
-    const indexPath = join(basePath, `index${extension}`);
-    if (await fileExists(indexPath)) return { path: indexPath, kind: { type: "index", extension } };
-  }
-
-  return null;
-}
-
-async function resolveExistingImport(filePath: string, specifier: string): Promise<ResolvedLocalImport | null> {
-  const resolved = resolve(dirname(filePath), specifier);
-  if (await fileExists(resolved)) {
-    return { path: resolved, kind: { type: "file", extension: extname(resolved) } };
-  }
-  return null;
-}
-
-async function fileExists(filePath: string): Promise<boolean> {
-  try {
-    const entries = await readdir(dirname(filePath), { withFileTypes: true });
-    return entries.some((entry) => entry.isFile() && entry.name === basename(filePath));
-  } catch {
-    return false;
-  }
-}
-
-function toExtensionSpecifier(specifier: string, kind: ResolvedLocalImport["kind"]): string {
-  if (kind.type === "index") return `${specifier}/index${kind.extension}`;
-  return `${specifier}${kind.extension}`;
-}
-
-function applyReplacements(source: string, replacements: Array<{ start: number; end: number; value: string }>): string {
-  return replacements
-    .sort((left, right) => right.start - left.start)
-    .reduce((current, replacement) => {
-      return `${current.slice(0, replacement.start)}${replacement.value}${current.slice(replacement.end)}`;
-    }, source);
+  return rewriteExtensionModuleImports({
+    kind: "server",
+    extensionId: inferExtensionId(filePath),
+    extensionDir: dirname(filePath),
+    filePath,
+    source,
+    validateExternalImports: false,
+  });
 }
 
 function normalizeExtensionId(value: unknown): string | null {

--- a/src/main/shell-path.ts
+++ b/src/main/shell-path.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+
+type MergeShellPathOptions = {
+  currentPath?: string;
+  homeDir?: string;
+  shellPath?: string;
+};
+
+const COMMON_GUI_PATHS = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+export function mergeShellPath(options: MergeShellPathOptions = {}): string {
+  const homeDir = options.homeDir ?? homedir();
+  const segments = [
+    ...(options.currentPath ?? "").split(":"),
+    ...COMMON_GUI_PATHS,
+    `${homeDir}/.local/bin`,
+    ...(options.shellPath ?? "").split(":"),
+  ];
+
+  return [...new Set(segments.map((segment) => segment.trim()).filter(Boolean))].join(":");
+}
+
+export function readLoginShellPath(): string | undefined {
+  if (process.platform === "win32") return undefined;
+  const result = spawnSync("/bin/zsh", ["-lc", "print -r -- $PATH"], {
+    encoding: "utf8",
+    timeout: 2000,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) return undefined;
+  return result.stdout.trim() || undefined;
+}
+
+export function expandProcessPathForGuiLaunch(): string {
+  process.env.PATH = mergeShellPath({ currentPath: process.env.PATH, shellPath: readLoginShellPath() });
+  return process.env.PATH;
+}

--- a/src/main/widget-module-registry.ts
+++ b/src/main/widget-module-registry.ts
@@ -3,6 +3,7 @@ import { readdir, stat } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { BabyMenuWidgetModuleDescriptor } from "../shared/contracts";
 import { getExtensionsDir } from "../shared/paths";
+import { compileExtensionModule } from "./extension-module-compiler";
 
 export type WidgetModuleRegistry = {
   list: () => Promise<BabyMenuWidgetModuleDescriptor[]>;
@@ -11,23 +12,30 @@ export type WidgetModuleRegistry = {
 export type DiscoverWidgetModulesOptions = {
   rootDir: string;
   extensionsDir?: string;
+  mode?: "vite" | "compiled";
+  widgetCacheDir?: string;
 };
 
 const STARTER_EXTENSION_ID = "hello-world";
 const WIDGET_FILE_PATTERN = /^widget\.(tsx|jsx|ts|js|mjs)$/;
 
-export function createWidgetModuleRegistry(rootDir: string): WidgetModuleRegistry {
+type CreateWidgetModuleRegistryOptions = DiscoverWidgetModulesOptions;
+
+export function createWidgetModuleRegistry(rootDir: string | CreateWidgetModuleRegistryOptions): WidgetModuleRegistry {
+  const options = typeof rootDir === "string" ? { rootDir } : rootDir;
   return {
-    list: () => discoverWidgetModules({ rootDir }),
+    list: () => discoverWidgetModules(options),
   };
 }
 
 export async function discoverWidgetModules({
   rootDir,
   extensionsDir = getExtensionsDir(rootDir),
+  mode = "vite",
+  widgetCacheDir,
 }: DiscoverWidgetModulesOptions): Promise<BabyMenuWidgetModuleDescriptor[]> {
   const files = await discoverWidgetFiles(resolve(extensionsDir));
-  const modules = await Promise.all(files.map((filePath) => widgetModuleDescriptor(rootDir, filePath)));
+  const modules = await Promise.all(files.map((filePath) => widgetModuleDescriptor({ rootDir, extensionsDir, mode, widgetCacheDir }, filePath)));
   return modules
     .filter((module): module is BabyMenuWidgetModuleDescriptor => Boolean(module))
     .sort((left, right) => left.id.localeCompare(right.id));
@@ -52,26 +60,55 @@ async function discoverWidgetFiles(rootDir: string): Promise<string[]> {
   return files.flat();
 }
 
-async function widgetModuleDescriptor(rootDir: string, filePath: string): Promise<BabyMenuWidgetModuleDescriptor | null> {
-  const extensionId = inferExtensionId(rootDir, filePath);
+async function widgetModuleDescriptor(options: Required<Pick<DiscoverWidgetModulesOptions, "rootDir" | "extensionsDir" | "mode">> & Pick<DiscoverWidgetModulesOptions, "widgetCacheDir">, filePath: string): Promise<BabyMenuWidgetModuleDescriptor | null> {
+  const extensionId = inferExtensionId(options.extensionsDir, filePath);
   if (!extensionId || extensionId === STARTER_EXTENSION_ID) return null;
 
   const fileStat = await stat(filePath);
+  const moduleUrl =
+    options.mode === "compiled"
+      ? await compiledWidgetModuleUrl({ extensionsDir: options.extensionsDir, extensionId, filePath, widgetCacheDir: options.widgetCacheDir })
+      : rendererModuleUrl(filePath, fileStat.mtimeMs);
   return {
     id: `${extensionId}.widget`,
     extensionId,
-    moduleUrl: rendererModuleUrl(filePath, fileStat.mtimeMs),
+    moduleUrl,
   };
 }
 
-function inferExtensionId(rootDir: string, filePath: string): string | null {
-  const extensionRoot = getExtensionsDir(rootDir);
-  const relativePath = relative(extensionRoot, filePath);
+function inferExtensionId(extensionsDir: string, filePath: string): string | null {
+  const relativePath = relative(extensionsDir, filePath);
   const firstSegment = relativePath.split(/[\\/]/)[0];
   if (firstSegment && firstSegment !== ".." && firstSegment !== ".") return firstSegment;
 
   const parent = basename(dirname(filePath));
   return parent && parent !== "." ? parent : basename(filePath, extname(filePath));
+}
+
+async function compiledWidgetModuleUrl({
+  extensionsDir,
+  extensionId,
+  filePath,
+  widgetCacheDir,
+}: {
+  extensionsDir: string;
+  extensionId: string;
+  filePath: string;
+  widgetCacheDir?: string;
+}): Promise<string> {
+  if (!widgetCacheDir) throw new Error("widgetCacheDir is required for compiled widget modules");
+  const extensionDir = join(resolve(extensionsDir), extensionId);
+  const compiled = await compileExtensionModule({
+    kind: "widget",
+    extensionId,
+    extensionDir,
+    entryFile: filePath,
+    cacheRoot: widgetCacheDir,
+  });
+  const outputRelativePath = relative(compiled.outputDir, compiled.outputPath).split("\\").join("/");
+  const encodedExtensionId = encodeURIComponent(extensionId);
+  const encodedPath = outputRelativePath.split("/").map(encodeURIComponent).join("/");
+  return `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodedPath}`;
 }
 
 function rendererModuleUrl(filePath: string, mtimeMs: number): string {

--- a/src/main/widget-module-registry.ts
+++ b/src/main/widget-module-registry.ts
@@ -35,7 +35,16 @@ export async function discoverWidgetModules({
   widgetCacheDir,
 }: DiscoverWidgetModulesOptions): Promise<BabyMenuWidgetModuleDescriptor[]> {
   const files = await discoverWidgetFiles(resolve(extensionsDir));
-  const modules = await Promise.all(files.map((filePath) => widgetModuleDescriptor({ rootDir, extensionsDir, mode, widgetCacheDir }, filePath)));
+  const modules = await Promise.all(
+    files.map(async (filePath) => {
+      try {
+        return await widgetModuleDescriptor({ rootDir, extensionsDir, mode, widgetCacheDir }, filePath);
+      } catch (error) {
+        if (mode !== "compiled") throw error;
+        return null;
+      }
+    }),
+  );
   return modules
     .filter((module): module is BabyMenuWidgetModuleDescriptor => Boolean(module))
     .sort((left, right) => left.id.localeCompare(right.id));

--- a/src/main/widget-protocol.ts
+++ b/src/main/widget-protocol.ts
@@ -1,0 +1,118 @@
+import { protocol } from "electron";
+import { readFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+const WIDGET_SCHEME = "baby-menu-widget";
+const HOST_SCHEME = "baby-menu-host";
+
+export function registerBabyMenuProtocolSchemes() {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: WIDGET_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+    {
+      scheme: HOST_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ]);
+}
+
+export function registerBabyMenuProtocolHandlers(options: { widgetCacheDir: string }) {
+  protocol.handle(WIDGET_SCHEME, async (request) => {
+    const filePath = resolveWidgetProtocolFilePath(options.widgetCacheDir, request.url);
+    const source = await readFile(filePath, "utf8");
+    return new Response(source, { headers: { "content-type": "text/javascript; charset=utf-8" } });
+  });
+
+  protocol.handle(HOST_SCHEME, async (request) => {
+    return new Response(hostProtocolModuleSource(request.url), {
+      headers: { "content-type": "text/javascript; charset=utf-8" },
+    });
+  });
+}
+
+export function resolveWidgetProtocolFilePath(widgetCacheDir: string, rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== `${WIDGET_SCHEME}:`) throw new Error("Invalid widget module URL");
+  const extensionId = decodeURIComponent(url.hostname);
+  const pathSegments = url.pathname.split("/").filter(Boolean).map(decodeURIComponent);
+  if (!extensionId || pathSegments.length < 2 || pathSegments.some((segment) => segment === "." || segment === "..")) {
+    throw new Error("Invalid widget module URL");
+  }
+  if (!pathSegments.at(-1)?.endsWith(".mjs")) throw new Error("Invalid widget module URL");
+
+  const filePath = resolve(join(widgetCacheDir, extensionId, ...pathSegments));
+  const relativePath = relative(resolve(widgetCacheDir), filePath);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) throw new Error("Invalid widget module URL");
+  return filePath;
+}
+
+export function hostProtocolModuleSource(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  if (url.protocol !== `${HOST_SCHEME}:`) throw new Error("Unknown host module URL");
+  const moduleId = `${url.hostname}${url.pathname}`;
+
+  if (moduleId === "react/index.mjs") {
+    return `const React = window.__BABY_MENU_WIDGET_HOST__.React;
+export const Children = React.Children;
+export const Component = React.Component;
+export const Fragment = React.Fragment;
+export const Profiler = React.Profiler;
+export const PureComponent = React.PureComponent;
+export const StrictMode = React.StrictMode;
+export const Suspense = React.Suspense;
+export const cache = React.cache;
+export const cloneElement = React.cloneElement;
+export const createContext = React.createContext;
+export const createElement = React.createElement;
+export const createRef = React.createRef;
+export const forwardRef = React.forwardRef;
+export const isValidElement = React.isValidElement;
+export const lazy = React.lazy;
+export const memo = React.memo;
+export const startTransition = React.startTransition;
+export const use = React.use;
+export const useActionState = React.useActionState;
+export const useCallback = React.useCallback;
+export const useContext = React.useContext;
+export const useDebugValue = React.useDebugValue;
+export const useDeferredValue = React.useDeferredValue;
+export const useState = React.useState;
+export const useEffect = React.useEffect;
+export const useEffectEvent = React.useEffectEvent;
+export const useId = React.useId;
+export const useImperativeHandle = React.useImperativeHandle;
+export const useInsertionEffect = React.useInsertionEffect;
+export const useRef = React.useRef;
+export const useMemo = React.useMemo;
+export const useReducer = React.useReducer;
+export const useLayoutEffect = React.useLayoutEffect;
+export const useOptimistic = React.useOptimistic;
+export const useSyncExternalStore = React.useSyncExternalStore;
+export const useTransition = React.useTransition;
+export const version = React.version;
+export default React;
+`;
+  }
+
+  if (moduleId === "react-jsx-runtime/index.mjs") {
+    return `const runtime = window.__BABY_MENU_WIDGET_HOST__.jsxRuntime;
+export const jsx = runtime.jsx;
+export const jsxs = runtime.jsxs;
+export const Fragment = runtime.Fragment;
+`;
+  }
+
+  throw new Error("Unknown host module URL");
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,10 @@ const api: BabyMenuApi = {
   popover: {
     setContentHeight: (height: number) => ipcRenderer.invoke("baby-menu:popover:set-content-height", height),
   },
+  settings: {
+    get: () => ipcRenderer.invoke("baby-menu:settings:get"),
+    setOpenAtLogin: (openAtLogin: boolean) => ipcRenderer.invoke("baby-menu:settings:set-open-at-login", openAtLogin),
+  },
 };
 
 contextBridge.exposeInMainWorld("babyMenu", api);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { AgentChat } from "./agent/AgentChat";
 import { MenuSurface } from "./menu/MenuSurface";
 
@@ -11,12 +11,44 @@ export function App() {
         <span className="mark">
           baby<span className="sep">_</span>menu
         </span>
+        <OpenAtLoginToggle />
       </header>
       <div className="pop-body">
         <MenuSurface />
       </div>
       <AgentChat />
     </main>
+  );
+}
+
+function OpenAtLoginToggle() {
+  const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.babyMenu?.settings?.get().then((settings) => {
+      if (!cancelled) setOpenAtLogin(settings.openAtLogin);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle() {
+    if (openAtLogin === null || !window.babyMenu?.settings) return;
+    const next = await window.babyMenu.settings.setOpenAtLogin(!openAtLogin);
+    setOpenAtLogin(next.openAtLogin);
+  }
+
+  return (
+    <button
+      type="button"
+      className={`settings-toggle${openAtLogin ? " enabled" : ""}`}
+      aria-pressed={openAtLogin ? "true" : "false"}
+      onClick={() => void toggle()}
+    >
+      login {openAtLogin ? "on" : "off"}
+    </button>
   );
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,13 +1,17 @@
-import { StrictMode } from "react";
+import * as React from "react";
+import * as jsxRuntime from "react/jsx-runtime";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { installWidgetHostShims } from "./widget-host-shim";
 import "./styles.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing root element");
 
+installWidgetHostShims(window, React, jsxRuntime);
+
 createRoot(root).render(
-  <StrictMode>
+  <React.StrictMode>
     <App />
-  </StrictMode>,
+  </React.StrictMode>,
 );

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -62,6 +62,24 @@ button {
   color: var(--signal-live);
 }
 
+.settings-toggle {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--ink-faint);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  padding: 3px 8px;
+  text-transform: uppercase;
+}
+
+.settings-toggle.enabled {
+  border-color: rgba(106, 227, 182, 0.35);
+  color: var(--signal-live);
+}
+
 .pop-body {
   flex: 1;
   min-height: 0;

--- a/src/renderer/widget-host-shim.ts
+++ b/src/renderer/widget-host-shim.ts
@@ -1,0 +1,3 @@
+export function installWidgetHostShims(target: Window, React: unknown, jsxRuntime: unknown) {
+  target.__BABY_MENU_WIDGET_HOST__ = { React, jsxRuntime };
+}

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -37,6 +37,10 @@ export type AgentRuntimeStatus = {
   eventType: "text_delta";
 };
 
+export type BabyMenuSettings = {
+  openAtLogin: boolean;
+};
+
 export type BabyMenuCapabilityDescriptor = {
   id: string;
   extensionId: string;
@@ -82,10 +86,18 @@ export type BabyMenuApi = {
   popover: {
     setContentHeight: (height: number) => Promise<{ ok: boolean }>;
   };
+  settings: {
+    get: () => Promise<BabyMenuSettings>;
+    setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuSettings>;
+  };
 };
 
 declare global {
   interface Window {
     babyMenu?: BabyMenuApi;
+    __BABY_MENU_WIDGET_HOST__?: {
+      React: unknown;
+      jsxRuntime: unknown;
+    };
   }
 }

--- a/tests/agent-chat.test.tsx
+++ b/tests/agent-chat.test.tsx
@@ -34,6 +34,10 @@ function installBabyMenuAgentMock() {
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
     },
+    settings: {
+      get: vi.fn(async () => ({ openAtLogin: false })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+    },
   };
 
   return {

--- a/tests/agent-runtime-distribution.test.ts
+++ b/tests/agent-runtime-distribution.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { getAgentRuntimeCwd, resolveDefaultAgentName, selectAgentChangeSessionKind } from "../src/main/agent-runtime";
+import { mergeShellPath } from "../src/main/shell-path";
+
+describe("agent runtime distribution behavior", () => {
+  it("uses git sessions only for source-mode tracked extensions", () => {
+    expect(
+      selectAgentChangeSessionKind({ isPackaged: false, rootDir: "/repo", extensionsDir: "/repo/extensions" }),
+    ).toBe("git");
+    expect(
+      selectAgentChangeSessionKind({ isPackaged: false, rootDir: "/repo", extensionsDir: "/repo/extensions-dev" }),
+    ).toBe("snapshot");
+    expect(
+      selectAgentChangeSessionKind({
+        isPackaged: true,
+        rootDir: "/repo",
+        extensionsDir: "/Users/me/Library/Application Support/baby-menu/extensions",
+      }),
+    ).toBe("snapshot");
+  });
+
+  it("launches packaged agents from the user-data extension workspace", () => {
+    expect(
+      getAgentRuntimeCwd("/repo", {}, { extensionsDir: "/Users/me/.baby-menu/extensions" }),
+    ).toBe("/Users/me/.baby-menu/extensions");
+  });
+
+  it("merges Homebrew, local-bin, and login-shell PATH entries for GUI launches", () => {
+    const merged = mergeShellPath({
+      currentPath: "/usr/bin:/bin",
+      homeDir: "/Users/me",
+      shellPath: "/opt/custom/bin:/usr/bin",
+    }).split(":");
+
+    expect(merged).toContain("/opt/homebrew/bin");
+    expect(merged).toContain("/usr/local/bin");
+    expect(merged).toContain("/Users/me/.local/bin");
+    expect(merged).toContain("/opt/custom/bin");
+    expect(merged.filter((entry) => entry === "/usr/bin")).toHaveLength(1);
+  });
+
+  it("can report that no supported agent CLI is available", () => {
+    expect(
+      resolveDefaultAgentName({ env: {}, commandExists: () => false, allowFallbackWhenMissing: false }),
+    ).toBeNull();
+  });
+});

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -8,6 +8,8 @@ const trayInstance = {
 
 const electronApp = {
   dock: { hide: vi.fn() },
+  getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
+  setLoginItemSettings: vi.fn(),
   isPackaged: false,
   on: vi.fn(),
   whenReady: vi.fn(async () => undefined),
@@ -31,11 +33,16 @@ const BrowserWindow = vi.fn(function BrowserWindowMock() {
 const getDisplayNearestPoint = vi.fn(() => ({
   workArea: { x: 0, y: 0, width: 1440, height: 900 },
 }));
+const protocol = {
+  registerSchemesAsPrivileged: vi.fn(),
+  handle: vi.fn(),
+};
 const registerIpcHandlers = vi.fn();
 
 vi.mock("electron", () => ({
   app: electronApp,
   BrowserWindow,
+  protocol,
   screen: { getDisplayNearestPoint },
 }));
 
@@ -47,7 +54,12 @@ vi.mock("../src/main/tray", () => ({
   createBabyMenuTray,
 }));
 
+vi.mock("../src/main/shell-path", () => ({
+  expandProcessPathForGuiLaunch: vi.fn(() => "/usr/bin:/bin"),
+}));
+
 vi.mock("../src/shared/paths", () => ({
+  EXTENSIONS_DIR_ENV: "BABY_MENU_EXTENSIONS_DIR",
   getRepoRoot: vi.fn(() => "/repo"),
 }));
 

--- a/tests/app-paths.test.ts
+++ b/tests/app-paths.test.ts
@@ -52,7 +52,7 @@ describe("Baby Menu runtime paths", () => {
     });
   });
 
-  it("seeds packaged extension templates only when the user workspace is missing", async () => {
+  it("seeds missing packaged extension templates without overwriting user files", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-seed-"));
     tempDirs.push(rootDir);
     const templateDir = join(rootDir, "Resources", "extensions-template");
@@ -69,9 +69,16 @@ describe("Baby Menu runtime paths", () => {
     await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("template rules\n");
 
     await writeFile(join(extensionsDir, "AGENTS.md"), "user rules\n");
-    const skipped = await seedExtensionWorkspace({ extensionsDir, templateDir });
+    await mkdir(join(templateDir, "goodbye-world"), { recursive: true });
+    await writeFile(join(templateDir, "recipes", "new.html"), "<title>New</title>\n");
+    await writeFile(join(templateDir, "goodbye-world", "widget.tsx"), "export const goodbyeWorldWidget = {};\n");
+    const reseeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
 
-    expect(skipped).toBe(false);
+    expect(reseeded).toBe(true);
     await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("user rules\n");
+    await expect(readFile(join(extensionsDir, "recipes", "new.html"), "utf8")).resolves.toBe("<title>New</title>\n");
+    await expect(readFile(join(extensionsDir, "goodbye-world", "widget.tsx"), "utf8")).resolves.toBe(
+      "export const goodbyeWorldWidget = {};\n",
+    );
   });
 });

--- a/tests/app-paths.test.ts
+++ b/tests/app-paths.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createBabyMenuRuntimePaths } from "../src/main/app-paths";
+import { seedExtensionWorkspace } from "../src/main/extension-seeder";
+
+describe("Baby Menu runtime paths", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    const { rm } = await import("node:fs/promises");
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("keeps source-mode mutable state in the checkout and honors extension workspace overrides", () => {
+    const paths = createBabyMenuRuntimePaths({
+      isPackaged: false,
+      sourceRoot: "/repo",
+      env: { BABY_MENU_EXTENSIONS_DIR: "extensions-dev" },
+    });
+
+    expect(paths).toMatchObject({
+      appDataRoot: "/repo",
+      sourceRoot: "/repo",
+      extensionsDir: "/repo/extensions-dev",
+      cacheDir: "/repo/.cache/baby-menu",
+      agentStateDir: "/repo/.cache/baby-menu/acp-sessions",
+      devExtensionSnapshotDir: "/repo/.cache/baby-menu/dev-extension-snapshots",
+      bundledExtensionTemplateDir: null,
+      isPackaged: false,
+    });
+  });
+
+  it("keeps packaged mutable state under a home dot directory and templates under Resources", () => {
+    const paths = createBabyMenuRuntimePaths({
+      isPackaged: true,
+      sourceRoot: "/ignored/source",
+      homeDir: "/Users/me",
+      resourcesPath: "/Applications/Baby Menu.app/Contents/Resources",
+    });
+
+    expect(paths).toMatchObject({
+      appDataRoot: "/Users/me/.baby-menu",
+      sourceRoot: "/ignored/source",
+      extensionsDir: "/Users/me/.baby-menu/extensions",
+      cacheDir: "/Users/me/.baby-menu/cache",
+      agentStateDir: "/Users/me/.baby-menu/cache/acp-sessions",
+      devExtensionSnapshotDir: "/Users/me/.baby-menu/cache/snapshots",
+      bundledExtensionTemplateDir: "/Applications/Baby Menu.app/Contents/Resources/extensions-template",
+      isPackaged: true,
+    });
+  });
+
+  it("seeds packaged extension templates only when the user workspace is missing", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-seed-"));
+    tempDirs.push(rootDir);
+    const templateDir = join(rootDir, "Resources", "extensions-template");
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    await mkdir(join(templateDir, "recipes"), { recursive: true });
+    await mkdir(join(templateDir, "hello-world"), { recursive: true });
+    await writeFile(join(templateDir, "AGENTS.md"), "template rules\n");
+    await writeFile(join(templateDir, "recipes", "starter.html"), "<title>Starter</title>\n");
+    await writeFile(join(templateDir, "hello-world", "widget.tsx"), "export const helloWorldWidget = {};\n");
+
+    const seeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(seeded).toBe(true);
+    await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("template rules\n");
+
+    await writeFile(join(extensionsDir, "AGENTS.md"), "user rules\n");
+    const skipped = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(skipped).toBe(false);
+    await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("user rules\n");
+  });
+});

--- a/tests/electron-vite-config.test.ts
+++ b/tests/electron-vite-config.test.ts
@@ -1,4 +1,4 @@
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
@@ -36,5 +36,15 @@ describe("electron-vite config", () => {
     const { default: config } = await import("../electron.vite.config");
 
     expect(config.renderer?.server?.fs?.allow).toContain(rootDir);
+  });
+
+  it("writes the production renderer bundle inside the repo-level out directory", async () => {
+    vi.stubGlobal("__dirname", rootDir);
+
+    const { default: config } = await import("../electron.vite.config");
+
+    expect(resolve(rootDir, "src/renderer", config.renderer?.build?.outDir ?? "")).toBe(
+      resolve(rootDir, "out/renderer"),
+    );
   });
 });

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { compileExtensionModule } from "../src/main/extension-module-compiler";
+
+describe("extension module compiler", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("compiles TSX widgets with local helpers and host React shims", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "meter");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(join(extensionDir, "helper.ts"), `export const label: string = "CPU";\n`);
+    await writeFile(
+      join(extensionDir, "widget.tsx"),
+      `import { useState } from "react";
+      import { label } from "./helper";
+      export const widget = { id: "meter", title: label, render: () => <span>{useState(1)[0]}</span> };`,
+    );
+
+    const compiled = await compileExtensionModule({
+      kind: "widget",
+      extensionId: "meter",
+      extensionDir,
+      entryFile: join(extensionDir, "widget.tsx"),
+      cacheRoot: join(rootDir, "cache", "widgets"),
+    });
+
+    expect(compiled.hash).toMatch(/^[a-f0-9]{16}$/);
+    expect(compiled.outputPath).toBe(join(rootDir, "cache", "widgets", "meter", compiled.hash, "widget.mjs"));
+    const output = await readFile(compiled.outputPath, "utf8");
+    expect(output).toContain(`from "baby-menu-host://react/index.mjs"`);
+    expect(output).toContain(`from "baby-menu-host://react-jsx-runtime/index.mjs"`);
+    expect(output).toContain(`from "./helper.mjs"`);
+    await expect(readFile(join(rootDir, "cache", "widgets", "meter", compiled.hash, "helper.mjs"), "utf8")).resolves.toContain(
+      "CPU",
+    );
+  });
+
+  it("compiles TypeScript server actions with local imports into importable ESM", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "quota");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(join(extensionDir, "quota.ts"), `export function readQuota(): number { return 72; }\n`);
+    await writeFile(
+      join(extensionDir, "server.ts"),
+      `import { readQuota } from "./quota";
+      export const actions = { getQuota: () => ({ remaining: readQuota() }) };`,
+    );
+
+    const compiled = await compileExtensionModule({
+      kind: "server",
+      extensionId: "quota",
+      extensionDir,
+      entryFile: join(extensionDir, "server.ts"),
+      cacheRoot: join(rootDir, "cache", "server-actions"),
+    });
+    const module = (await import(`${compiled.moduleUrl}?test=${Date.now()}`)) as { actions: { getQuota: () => unknown } };
+
+    expect(module.actions.getQuota()).toEqual({ remaining: 72 });
+    await expect(readFile(compiled.outputPath, "utf8")).resolves.toContain(`from "./quota.mjs"`);
+  });
+
+  it("rejects unsupported external imports with a clear error", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "bad-widget");
+    const entryFile = join(extensionDir, "widget.tsx");
+    await mkdir(dirname(entryFile), { recursive: true });
+    await writeFile(entryFile, `import thing from "lodash"; export const widget = thing;\n`);
+
+    await expect(
+      compileExtensionModule({
+        kind: "widget",
+        extensionId: "bad-widget",
+        extensionDir,
+        entryFile,
+        cacheRoot: join(rootDir, "cache", "widgets"),
+      }),
+    ).rejects.toThrow("Unsupported widget import \"lodash\" in bad-widget/widget.tsx");
+  });
+
+  it("rejects local imports that escape the extension workspace", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "unsafe");
+    const entryFile = join(extensionDir, "server.ts");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(join(rootDir, "extensions", "shared.ts"), `export const secret = true;\n`);
+    await writeFile(entryFile, `import { secret } from "../shared"; export const actions = { secret: () => secret };\n`);
+
+    await expect(
+      compileExtensionModule({
+        kind: "server",
+        extensionId: "unsafe",
+        extensionDir,
+        entryFile,
+        cacheRoot: join(rootDir, "cache", "server-actions"),
+      }),
+    ).rejects.toThrow("Local import escapes extension workspace");
+  });
+});

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -43,6 +43,29 @@ describe("extension module compiler", () => {
     );
   });
 
+  it("ignores type-only imports when collecting widget dependencies", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "starter");
+    const entryFile = join(extensionDir, "widget.tsx");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `import type { RefreshableBabyMenuWidget } from "../../src/shared/contracts";
+      export const widget: RefreshableBabyMenuWidget = { id: "starter", title: "Starter", render: () => "ok", refresh: async () => undefined };`,
+    );
+
+    const compiled = await compileExtensionModule({
+      kind: "widget",
+      extensionId: "starter",
+      extensionDir,
+      entryFile,
+      cacheRoot: join(rootDir, "cache", "widgets"),
+    });
+
+    await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("../../src/shared/contracts");
+  });
+
   it("compiles TypeScript server actions with local imports into importable ESM", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
     tempDirs.push(rootDir);

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -64,6 +64,30 @@ describe("extension module compiler", () => {
     });
 
     await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("../../src/shared/contracts");
+  });
+
+  it("reuses cached output for unchanged extension modules", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "cached");
+    const entryFile = join(extensionDir, "widget.tsx");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(entryFile, `export const widget = { id: "cached", title: "Cached", render: () => null };\n`);
+
+    const options = {
+      kind: "widget" as const,
+      extensionId: "cached",
+      extensionDir,
+      entryFile,
+      cacheRoot: join(rootDir, "cache", "widgets"),
+    };
+    const first = await compileExtensionModule(options);
+    const firstStat = await stat(first.outputPath);
+    const second = await compileExtensionModule(options);
+    const secondStat = await stat(second.outputPath);
+
+    expect(second).toEqual(first);
+    expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs);
   });
 
   it("compiles TypeScript server actions with local imports into importable ESM", async () => {

--- a/tests/ipc-capabilities.test.ts
+++ b/tests/ipc-capabilities.test.ts
@@ -152,4 +152,23 @@ describe("capabilities IPC", () => {
 
     await expect(handlers.get("baby-menu:popover:set-content-height")?.({}, 333)).resolves.toEqual({ ok: true });
   });
+
+  it("registers settings channels for open-at-login", async () => {
+    const { registerIpcHandlers } = await import("../src/main/ipc");
+    const agentRuntime = {
+      send: vi.fn(),
+      save: vi.fn(),
+      rollback: vi.fn(),
+    };
+    const settings = {
+      get: vi.fn(async () => ({ openAtLogin: false })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+    };
+
+    registerIpcHandlers("/repo", agentRuntime, undefined, undefined, undefined, settings);
+
+    await expect(handlers.get("baby-menu:settings:get")?.({})).resolves.toEqual({ openAtLogin: false });
+    await expect(handlers.get("baby-menu:settings:set-open-at-login")?.({}, true)).resolves.toEqual({ openAtLogin: true });
+    expect(settings.setOpenAtLogin).toHaveBeenCalledWith(true);
+  });
 });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -1,0 +1,29 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPreferencesService } from "../src/main/preferences";
+
+describe("preferences service", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("persists and applies the open-at-login preference", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const appFacade = {
+      setLoginItemSettings: vi.fn(),
+      getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
+    };
+    const service = createPreferencesService({ userDataDir, app: appFacade });
+
+    await expect(service.get()).resolves.toEqual({ openAtLogin: false });
+    await expect(service.setOpenAtLogin(true)).resolves.toEqual({ openAtLogin: true });
+
+    expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+    await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": true');
+  });
+});

--- a/tests/preload-capabilities.test.ts
+++ b/tests/preload-capabilities.test.ts
@@ -32,6 +32,12 @@ describe("preload capabilities bridge", () => {
 
     await api.popover.setContentHeight(333);
     expect(invoke).toHaveBeenCalledWith("baby-menu:popover:set-content-height", 333);
+
+    await api.settings.get();
+    expect(invoke).toHaveBeenCalledWith("baby-menu:settings:get");
+
+    await api.settings.setOpenAtLogin(true);
+    expect(invoke).toHaveBeenCalledWith("baby-menu:settings:set-open-at-login", true);
   });
 
   it("exposes agent status events from the main process", async () => {

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import packageJson from "../package.json";
+import { describe, expect, it } from "vitest";
+
+describe("distribution config", () => {
+  it("adds mac packaging scripts and keeps TypeScript available at runtime for extension compilation", () => {
+    expect(packageJson.scripts?.["package:mac"]).toContain("electron-builder --mac dir --universal");
+    expect(packageJson.scripts?.["dist:mac"]).toContain("scripts/create-dmg.mjs");
+    expect(packageJson.dependencies?.typescript).toBe("6.0.3");
+    expect(packageJson.devDependencies?.["electron-builder"]).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("declares an unsigned electron-builder mac bundle with extension templates", async () => {
+    const config = await readFile(resolve(import.meta.dirname, "../electron-builder.yml"), "utf8");
+
+    expect(config).toContain("appId: com.kunchenguid.baby-menu");
+    expect(config).toContain("to: extensions-template");
+    expect(config).toContain("identity: null");
+    expect(config).toContain("hardenedRuntime: false");
+  });
+
+  it("adds a tag-triggered release workflow that uploads the DMG and updates the Homebrew tap", async () => {
+    const workflow = await readFile(resolve(import.meta.dirname, "../.github/workflows/release.yml"), "utf8");
+
+    expect(workflow).toContain('tags:');
+    expect(workflow).toContain('"v*"');
+    expect(workflow).toContain("CSC_IDENTITY_AUTO_DISCOVERY");
+    expect(workflow).toContain("codesign --force --deep --sign -");
+    expect(workflow).toContain("gh release");
+    expect(workflow).toContain("HOMEBREW_TAP_TOKEN");
+    expect(workflow).toContain("Casks/baby-menu.rb");
+    expect(workflow).toContain("xattr");
+    expect(workflow).toContain('"~/.baby-menu"');
+  });
+});

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -30,6 +30,7 @@ describe("distribution config", () => {
     expect(workflow).toContain("gh release");
     expect(workflow).toContain("HOMEBREW_TAP_TOKEN");
     expect(workflow).toContain("Casks/baby-menu.rb");
+    expect(workflow).toContain("git diff --cached --quiet");
     expect(workflow).toContain("xattr");
     expect(workflow).toContain('"~/.baby-menu"');
   });

--- a/tests/renderer-layout.test.ts
+++ b/tests/renderer-layout.test.ts
@@ -31,4 +31,11 @@ describe("renderer layout styles", () => {
     expect(css).toMatch(/\.app-shell\s*\{[^}]*max-height:\s*min\(720px,\s*100vh\)/s);
     expect(css).not.toMatch(/\.app-shell\s*\{[^}]*height:\s*100vh/s);
   });
+
+  it("includes compact settings styles for the open-at-login toggle", async () => {
+    const css = await readFile(stylesPath, "utf8");
+
+    expect(css).toMatch(/\.settings-toggle\s*\{/);
+    expect(css).toMatch(/\.settings-toggle\.enabled\s*\{/);
+  });
 });

--- a/tests/renderer-monochrome-lab.test.tsx
+++ b/tests/renderer-monochrome-lab.test.tsx
@@ -36,6 +36,10 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
     },
+    settings: {
+      get: vi.fn(async () => ({ openAtLogin: false })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+    },
   };
 
   const api: BabyMenuApi = {
@@ -43,6 +47,7 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
     ...overrides,
     widgets: overrides.widgets ?? baseApi.widgets,
     popover: overrides.popover ?? baseApi.popover,
+    settings: overrides.settings ?? baseApi.settings,
   };
 
   window.babyMenu = api;

--- a/tests/renderer-widget-host.test.tsx
+++ b/tests/renderer-widget-host.test.tsx
@@ -24,6 +24,10 @@ function installBabyMenuApi(widgets: BabyMenuApi["widgets"]) {
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
     },
+    settings: {
+      get: vi.fn(async () => ({ openAtLogin: false })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+    },
   };
 }
 

--- a/tests/server-action-registry.test.ts
+++ b/tests/server-action-registry.test.ts
@@ -85,6 +85,17 @@ describe("server action registry", () => {
     await expect(registry.invoke("codex-quota", "getQuota")).resolves.toEqual({ remaining: 72 });
   });
 
+  it("rejects unsupported external imports from generated server actions", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "external", "server.ts");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `import slugify from "slugify"; export const actions = { slugify };`);
+    const registry = createServerActionRegistry({ rootDir });
+
+    await expect(registry.list()).rejects.toThrow('Unsupported server import "slugify" in external/server.ts');
+  });
+
   it("rewrites extensionless local imports so Node ESM can load server actions", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
     tempDirs.push(rootDir);
@@ -100,7 +111,7 @@ describe("server action registry", () => {
       sourcePath,
     );
 
-    expect(rewritten).toContain(`from "./codex-quota.ts"`);
+    expect(rewritten).toContain(`from "./codex-quota.mjs"`);
     expect(rewritten).toContain(`from "react"`);
   });
 

--- a/tests/widget-host-shim.test.ts
+++ b/tests/widget-host-shim.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { installWidgetHostShims } from "../src/renderer/widget-host-shim";
+
+describe("renderer widget host shims", () => {
+  it("exposes the host React and JSX runtime objects for compiled widgets", () => {
+    const target = {} as Window;
+    const React = { useState: () => undefined };
+    const jsxRuntime = { jsx: () => undefined, Fragment: Symbol.for("fragment") };
+
+    installWidgetHostShims(target, React, jsxRuntime);
+
+    expect(target.__BABY_MENU_WIDGET_HOST__).toEqual({ React, jsxRuntime });
+  });
+});

--- a/tests/widget-module-registry.test.ts
+++ b/tests/widget-module-registry.test.ts
@@ -56,4 +56,30 @@ describe("widget module registry", () => {
     });
     expect(modules[0]?.moduleUrl).toMatch(/^baby-menu-widget:\/\/cpu-temp\/[a-f0-9]{16}\/widget\.mjs$/);
   });
+
+  it("skips invalid compiled widgets while returning valid widgets", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-widget-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    await mkdir(join(extensionsDir, "good-widget"), { recursive: true });
+    await mkdir(join(extensionsDir, "bad-widget"), { recursive: true });
+    await writeFile(
+      join(extensionsDir, "good-widget", "widget.tsx"),
+      `export const goodWidget = { id: "good-widget", title: "Good", render: () => null };\n`,
+    );
+    await writeFile(join(extensionsDir, "bad-widget", "widget.tsx"), `import thing from "lodash"; export const badWidget = thing;\n`);
+
+    const modules = await discoverWidgetModules({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir: join(rootDir, "cache", "widgets"),
+    });
+
+    expect(modules).toHaveLength(1);
+    expect(modules[0]).toMatchObject({
+      id: "good-widget.widget",
+      extensionId: "good-widget",
+    });
+  });
 });

--- a/tests/widget-module-registry.test.ts
+++ b/tests/widget-module-registry.test.ts
@@ -31,4 +31,29 @@ describe("widget module registry", () => {
     expect(modules[0]?.moduleUrl).toContain("cpu-temp/widget.tsx");
     expect(modules[0]?.moduleUrl).toContain("babyMenuWidgetVersion=");
   });
+
+  it("returns custom protocol module URLs for compiled production widgets", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-widget-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    await mkdir(join(extensionsDir, "cpu-temp"), { recursive: true });
+    await writeFile(
+      join(extensionsDir, "cpu-temp", "widget.tsx"),
+      `export const cpuTempWidget = { id: "cpu-temp", title: "CPU", render: () => null };\n`,
+    );
+
+    const modules = await discoverWidgetModules({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir: join(rootDir, "cache", "widgets"),
+    });
+
+    expect(modules).toHaveLength(1);
+    expect(modules[0]).toMatchObject({
+      id: "cpu-temp.widget",
+      extensionId: "cpu-temp",
+    });
+    expect(modules[0]?.moduleUrl).toMatch(/^baby-menu-widget:\/\/cpu-temp\/[a-f0-9]{16}\/widget\.mjs$/);
+  });
 });

--- a/tests/widget-protocol.test.ts
+++ b/tests/widget-protocol.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { hostProtocolModuleSource, resolveWidgetProtocolFilePath } from "../src/main/widget-protocol";
+
+describe("widget protocol", () => {
+  it("resolves widget URLs only inside the compiler cache", () => {
+    expect(resolveWidgetProtocolFilePath("/cache/widgets", "baby-menu-widget://cpu-temp/abc123/widget.mjs")).toBe(
+      "/cache/widgets/cpu-temp/abc123/widget.mjs",
+    );
+  });
+
+  it("rejects path traversal and non-module widget protocol URLs", () => {
+    expect(() => resolveWidgetProtocolFilePath("/cache/widgets", "baby-menu-widget://cpu-temp/../secret.mjs")).toThrow(
+      "Invalid widget module URL",
+    );
+    expect(() => resolveWidgetProtocolFilePath("/cache/widgets", "baby-menu-widget://cpu-temp/abc123/widget.txt")).toThrow(
+      "Invalid widget module URL",
+    );
+  });
+
+  it("serves host React shim modules from the renderer host object", () => {
+    expect(hostProtocolModuleSource("baby-menu-host://react/index.mjs")).toContain(
+      "window.__BABY_MENU_WIDGET_HOST__.React",
+    );
+    expect(hostProtocolModuleSource("baby-menu-host://react-jsx-runtime/index.mjs")).toContain(
+      "window.__BABY_MENU_WIDGET_HOST__.jsxRuntime",
+    );
+    expect(() => hostProtocolModuleSource("baby-menu-host://unknown/index.mjs")).toThrow("Unknown host module URL");
+  });
+});


### PR DESCRIPTION
## Intent

The developer wanted to fully implement the Baby Menu macOS distribution strategy, including packaging as a real Electron menu-bar app without Developer ID signing or notarization, production extension loading, safe packaged Save/Rollback behavior, autostart, release automation, and Homebrew Cask distribution through a general Kun-owned tap. They then requested changing packaged mutable state from Electron userData/Application Support to a dot directory at ~/.baby-menu, with extensions under ~/.baby-menu/extensions and cask zap behavior updated accordingly. Finally, they wanted a local general Homebrew tap repository created under ~/github/kunchenguid/ with a ready baby-menu cask using the current packaged DMG/version information.

## What Changed
- Adds macOS packaging and distribution support with Electron Builder, ad-hoc signing, DMG creation, tag-based release automation, and Homebrew Cask publishing.
- Introduces packaged runtime paths under `~/.baby-menu`, including extension seeding/reseeding, snapshot-based Save/Rollback, compiled widget/server-action loading, custom widget protocols, and GUI `PATH` expansion for agent CLIs.
- Adds user-facing packaged app behavior and documentation, including an open-at-login setting, install/update guidance, packaged runtime constraints, and distribution strategy updates.

## Risk Assessment

⚠️ Medium: The current review found no remaining substantiated merge-blocking issues, but the change is a broad packaged-runtime and release-automation update with behavior that still depends on macOS packaging/install validation outside this review.

## Testing

- Summary: Scoped the change, ran focused distribution/runtime tests and the full Vitest suite, built the universal macOS app and DMG, inspected the generated package contents/metadata, and verified the ad-hoc-signed bundle; all in-repository checks passed, with only the out-of-worktree local Homebrew tap left unverified.
<details>
<summary>Evidence: Packaged app resources</summary>

```text
{
"appBundle": true,
"dmg": true,
"dmgBytes": 256833761,
"resources": true,
"extensionTemplate": true,
"extensionTemplateItems": ["AGENTS.md", "recipes", "hello-world"],
"recipeFiles": ["claude-code-quota.html", "codex-quota.html"]
}
```
</details>
<details>
<summary>Evidence: Bundle metadata</summary>

```text
Baby Menu
com.kunchenguid.baby-menu
0.1.0
Note: LSUIElement was not present in Info.plist; the app hides the dock at runtime via app.dock.hide(), which is covered by the app lifecycle tests.
```
</details>
<details>
<summary>Evidence: DMG metadata</summary>

```text
hdiutil imageinfo release/Baby-Menu-0.1.0-universal.dmg reported Format: UDZO, Compressed: true, Checksummed: true, Encrypted: false, and Backing Store Name: Baby-Menu-0.1.0-universal.dmg.
```
</details>
<details>
<summary>Evidence: Code signature verification</summary>

```text
release/mac-universal/Baby Menu.app: valid on disk
release/mac-universal/Baby Menu.app: satisfies its Designated Requirement
```
</details>
<details>
<summary>Evidence: Automated tests</summary>

```text
Focused distribution/runtime tests: 8 files passed, 30 tests passed.
Full test suite: 30 files passed, 115 tests passed.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5)</summary>

**Round 1** - found 2 warnings
- ⚠️ `src/main/extension-seeder.ts:10` - Packaged installs never receive new or restored bundled extension templates once ~/.baby-menu/extensions exists, so future releases that add recipes, AGENTS.md guidance, or starter extension updates will silently keep serving the old workspace forever. Consider seeding missing template files or versioning the bundled baseline separately from user-created extension content.
- ⚠️ `.github/workflows/release.yml:105` - The Homebrew tap update step fails when the generated cask is unchanged, which makes release workflow reruns or re-publishes of an already-updated version fail at git commit. Guard the commit/push with a diff check so the automation is idempotent.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `src/main/extension-seeder.ts:10` - Packaged installs never receive new or restored bundled extension templates once ~/.baby-menu/extensions exists, so future releases that add recipes, AGENTS.md guidance, or starter extension updates will silently keep serving the old workspace forever. Consider seeding missing template files or versioning the bundled baseline separately from user-created extension content.
- ⚠️ `.github/workflows/release.yml:61` - Release workflow reruns fail after a GitHub Release has already been created, which blocks recovery from later failures such as the Homebrew tap update. Make the release step idempotent, for example by uploading with --clobber when the release exists or checking for the release before create.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `src/main/extension-seeder.ts:10` - Packaged installs never receive new or restored bundled extension templates once ~/.baby-menu/extensions exists, so future releases that add recipes, AGENTS.md guidance, or starter extension updates will silently keep serving the old workspace forever. Consider seeding missing template files or versioning the bundled baseline separately from user-created extension content.

**Round 4** (auto-fix) - found 1 error
- 🚨 `src/main/extension-module-compiler.ts:121` - The packaged module compiler walks imports in the original TypeScript source before transpilation, so erased type-only imports such as `import type { RefreshableBabyMenuWidget } from &#34;../../src/shared/contracts&#34;` are resolved and rejected as workspace escapes. This makes packaged widgets fail to load when they follow the starter widget&#39;s type-import pattern; skip type-only imports when collecting/revising the runtime graph, or collect dependencies from emitted JavaScript instead.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `src/main/widget-module-registry.ts:38` - In compiled mode, one invalid widget makes the entire `widgets.list()` IPC call reject because descriptors are built with a single `Promise.all`. The renderer only catches failures after descriptors are returned, so a single packaged widget with a compile/import validation error prevents every other widget from loading. Catch per-file compilation failures here and skip or surface only the broken widget instead of failing the whole list.
- ⚠️ `src/main/widget-module-registry.ts:68` - Packaged widget discovery recompiles and rewrites each widget module every time `widgets.list()` runs; `WidgetHost` polls that API every second, so an idle packaged app will repeatedly transpile TypeScript and write cache files. Reuse the existing content hash/cache output when it already exists, or avoid the one-second hot-reload polling path in packaged mode.

**Round 6** (auto-fix) - passed ✅

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ The in-repository distribution/runtime behavior was validated, but the user intent also mentions a local Homebrew tap repository under ~/github/kunchenguid. This run was explicitly limited to the isolated worktree, so I could not inspect or validate that out-of-repository tap state.
- <code>`git diff --stat 5b27cb31575d9e86724c3b5806c4e8faa5f05fb2..e4bef5a42ca25641c9376f0bafc91633b4502b13` and `git diff --name-only 5b27cb31575d9e86724c3b5806c4e8faa5f05fb2..e4bef5a42ca25641c9376f0bafc91633b4502b13` to scope the changed distribution/runtime surface</code>
- `pnpm vitest run tests/app-paths.test.ts tests/agent-runtime-distribution.test.ts tests/release-config.test.ts tests/extension-module-compiler.test.ts tests/widget-module-registry.test.ts tests/server-action-registry.test.ts tests/widget-protocol.test.ts tests/preferences.test.ts`
- `pnpm dist:mac`
- <code>`node --input-type=module -e &#39;...&#39;` to inspect the generated app bundle, DMG, and packaged extension-template contents</code>
- `/usr/libexec/PlistBuddy -c 'Print :CFBundleName' -c 'Print :CFBundleIdentifier' -c 'Print :CFBundleVersion' -c 'Print :LSUIElement' 'release/mac-universal/Baby Menu.app/Contents/Info.plist'`
- `hdiutil imageinfo 'release/Baby-Menu-0.1.0-universal.dmg'`
- `codesign --verify --deep --strict --verbose=2 'release/mac-universal/Baby Menu.app'`
- `pnpm vitest run tests`

</details>

<details>
<summary>🔧 **Document** - 7 issues found → auto-fixed (8)</summary>

**Round 1** - found 7 issues (4 warnings, 3 infos)
- ⚠️ `README.md:36` - The README still says baby-menu is only a source-run project and documents only source installation, but this change adds `electron-builder`, `package:mac`/`dist:mac`, a tag-triggered release workflow, and Homebrew Cask distribution. Update the Install section with the Homebrew cask command, update command, and packaged-app expectations.
- ⚠️ `README.md:14` - The README describes runtime editing as modifying &#34;this same repo&#34; with Git as the undo button, and the How It Works diagram only shows `extensions/&lt;id&gt;` plus `GitChangeSession`. Packaged mode now seeds and edits `~/.baby-menu/extensions` and uses snapshot Save/Rollback without git commits, so the README should distinguish source mode from packaged mode.
- ℹ️ `README.md:106` - The Development command list omits the new `package:mac` and `dist:mac` scripts added in `package.json`. Add them so developers know how to build the local packaged app and DMG.
- ⚠️ `AGENTS.md:27` - AGENTS.md still frames the app as an agent editing this repo with git as the accept/rollback mechanism, and its runtime section only documents `GitChangeSession`/dev snapshot behavior. The packaged runtime now uses `app-paths`, `~/.baby-menu`, extension seeding, snapshot sessions, compiled widget/server modules, custom protocols, PATH expansion, and preferences, so the developer architecture docs need to be updated.
- ℹ️ `AGENTS.md:6` - AGENTS.md command documentation does not include the new `package:mac` and `dist:mac` scripts. Add these packaging commands and their outputs so future agents use the intended local distribution workflow.
- ⚠️ `docs/distribution-strategy.md:47` - The distribution strategy doc&#39;s &#34;Current Repo Constraints&#34; section says the repo has no app packager, release workflow, signing, cask, or login-item support, but the target commit adds those pieces. Update this section from pre-implementation constraints to the current implemented state, or clearly split historical context from remaining gaps.
- ℹ️ `docs/distribution-strategy.md:758` - The Implementation Phases section still presents packaging, `~/.baby-menu` packaged state, production extension compilation, and release automation as future deliverables even though this change implements them. Mark completed phases as implemented and call out any remaining manual steps, such as creating/configuring the external tap and release secret.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `extensions/AGENTS.md:12` - The extension authoring guide lists the extension file shape but does not document the new packaged compiler constraints introduced by this change. `extension-module-compiler.ts` only permits widget imports from React/JSX runtime plus local helpers, and server-action imports from Node built-ins plus local helpers; arbitrary npm imports will fail in packaged mode. Update `extensions/AGENTS.md` so embedded agents generate extensions that work in both source and packaged runtimes.

**Round 3** (auto-fix) - found 1 info
- ℹ️ `README.md:34` - The branch adds a user-facing open-at-login setting: `App.tsx` renders a `login on/off` toggle, the preload bridge exposes `window.babyMenu.settings`, and `preferences.ts` persists `openAtLogin` under the app data root while applying Electron login-item settings. The README&#39;s install/runtime sections describe packaged state and update flow but do not document that users can enable or disable launch-at-login from the popover, so the new behavior is missing from user-facing docs.

**Round 4** (auto-fix) - found 5 issues (1 warning, 4 infos)
- ℹ️ `README.md:34` - The new Homebrew Cask release path declares `depends_on macos: &#34;&gt;= :ventura&#34;` in the generated cask, but the user-facing Install section only says macOS generically. Update the README install requirements to state the supported macOS version so users on older macOS versions know the cask will not install.
- ⚠️ `README.md:34` - The packaged app now targets users who install without a source checkout, and the code expands GUI `PATH` to find external agent CLIs, but the README Install section does not document that Baby Menu still requires a supported, already-authenticated agent CLI such as `claude`, `codex`, or `npx`/Pi on PATH, or that `BABY_MENU_AGENT` can select one. Add this prerequisite so packaged users understand why agent turns may fail after installation.
- ℹ️ `docs/distribution-strategy.md:618` - The example release workflow skeleton still uses `gh release upload &#34;$GITHUB_REF_NAME&#34; &#34;$DMG_PATH&#34; --clobber`, while the implemented `.github/workflows/release.yml` creates the GitHub Release when it does not exist and edits/uploads when it does. Update the skeleton to match the implemented create-or-update behavior so maintainers do not copy a workflow that fails on the first tagged release.
- ℹ️ `docs/distribution-strategy.md:665` - The example release workflow skeleton always runs `git commit` after rewriting `Casks/baby-menu.rb`, but the implemented workflow guards with `git diff --cached --quiet` before committing. Update the skeleton to include the no-op guard so reruns or unchanged cask content do not fail with an empty commit.
- ℹ️ `docs/distribution-strategy.md:92` - The packaged runtime layout documents `~/.baby-menu/cache` and a generic `logs/` directory, but `AgentTurnLogRecorder` writes turn transcripts under `rootDir/.cache/baby-menu/agent-turns`, which becomes `~/.baby-menu/.cache/baby-menu/agent-turns` in packaged mode. Update the runtime layout/current-state docs to include the actual agent-turn log path or clarify it is a remaining cleanup item.

**Round 5** (auto-fix) - found 2 infos
- ℹ️ `docs/distribution-strategy.md:86` - The packaged runtime layout enumerates `~/.baby-menu/extensions`, `~/.baby-menu/cache`, and agent-turn logs, but this change also persists the new open-at-login preference to `~/.baby-menu/preferences.json` via `createPreferencesService({ userDataDir: paths.appDataRoot })`. Add `preferences.json` to the runtime layout/current-state docs so packaged mutable state and zap expectations are complete.
- ℹ️ `docs/distribution-strategy.md:450` - The Electron Builder config example omits the implemented `mac.x64ArchFiles: Contents/Resources/app.asar.unpacked/node_modules/{@esbuild/**,esbuild/**}` setting from `electron-builder.yml`. Update the packaging config docs to match the actual universal macOS build configuration so maintainers do not copy a stale config.

**Round 6** (auto-fix) - found 1 info
- ℹ️ `docs/distribution-strategy.md:168` - The First Launch Seeding section still says packaged templates are copied only if the extension workspace does not exist, but `seedExtensionWorkspace()` runs on every startup and copies missing template files without overwriting user files; `tests/app-paths.test.ts` explicitly covers reseeding new recipes/extensions into an existing workspace. Update this section to describe the implemented missing-file reseed behavior on launch and upgrade.

**Round 7** (auto-fix) - found 2 infos
- ℹ️ `README.md:121` - The README says `BABY_MENU_EXTENSIONS_DIR` overrides the active extension workspace, but the packaged runtime path resolver ignores that environment variable and always uses `~/.baby-menu/extensions`; only source mode honors the override. Update the environment flag description to scope the override to source/dev runs so packaged users and developers do not expect it to affect installed apps.
- ℹ️ `AGENTS.md:53` - The module index still calls `git-change-session.ts` the production Save/Rollback safety boundary, but this branch makes packaged production use `DevExtensionChangeSession` snapshots and reserves `GitChangeSession` for the tracked source `extensions/` workspace. Update the description to say it is the tracked-source Save/Rollback boundary.

**Round 8** (auto-fix) - found 2 infos
- ℹ️ `.agents/skills/baby-menu-design/README.md:3` - The design-system README still describes Baby Menu as an agent that edits the app&#39;s own source code at runtime and lists `GitChangeSession` invariants as the architecture context. This branch adds packaged runtime behavior where the agent edits the active extension workspace under `~/.baby-menu/extensions` and Save/Rollback use filesystem snapshots instead of git. Update this design documentation so future UI/design work is grounded in the active-extension-workspace model and source-vs-packaged change-session split.
- ℹ️ `.agents/skills/baby-menu-design/SKILL.md:38` - The design skill manifest tells agents to treat `GitChangeSession` invariants as the architectural ground truth, but the target change makes git only one source-mode change-session implementation while packaged mode uses snapshot sessions in `~/.baby-menu`. Update the reference note to mention runtime change-session invariants rather than git-only invariants.

**Round 9** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
