### PR TITLE
feat(main): enable packaged app login launch by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,6 @@ body:
       label: Launch mode
       options:
         - Packaged app
-        - pnpm start
         - pnpm dev
         - tests
         - other / not sure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@ Embedded agents launched from baby-menu should work from the active extension wo
 
 ## Commands
 
-- `pnpm start` - runs `electron-vite dev` directly with no extension workspace override. `BabyMenuAgentRuntime` falls back to the tracked `extensions/` directory, so the embedded agent edits real git-tracked files gated by `GitChangeSession`. Use this when iterating on or shipping changes to tracked extensions.
 - `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md` and `extensions/recipes/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
 - `pnpm dev:reset` - removes `extensions-dev/`, recreates it with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
 - `pnpm build` - build main, preload, and renderer bundles into `out/`.
@@ -27,7 +26,7 @@ Use `pnpm` (declared `packageManager: pnpm@11.1.1`). Renderer dev server is pinn
 ## Architecture
 
 This is a macOS tray-bar Electron app whose distinguishing idea is that an embedded agent (running via `acpx/runtime`) edits the active extension workspace at runtime.
-Source mode uses git as the accept/rollback mechanism for tracked extensions; packaged mode edits `~/.baby-menu/extensions` and uses filesystem snapshots.
+Tracked source extensions use git as the accept/rollback mechanism when selected explicitly; packaged mode edits `~/.baby-menu/extensions` and uses filesystem snapshots.
 
 Three processes, kept deliberately separate:
 
@@ -76,7 +75,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 
 1. Resolves the active extension workspace from runtime paths. Source mode honors `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`; packaged mode uses `~/.baby-menu/extensions` after seeding bundled templates.
 2. Uses `DevExtensionChangeSession` for snapshot workspaces such as `extensions-dev/` and packaged `~/.baby-menu/extensions`, so Save keeps generated files and Rollback restores the pre-turn contents.
-3. Uses `GitChangeSession.begin(rootDir)` only for the tracked source `extensions/` workspace. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
+3. Uses `GitChangeSession.begin(rootDir)` only for the tracked source `extensions/` workspace when that workspace is selected explicitly. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
 4. Lazily constructs the ACP runtime with `createFileSessionStore({ stateDir })` under `.cache/baby-menu/acp-sessions` in source mode or `~/.baby-menu/cache/acp-sessions` in packaged mode, with `permissionMode: "approve-all"`.
 5. Uses a fixed `sessionKey: "baby-menu-agent-chat"` so the agent has a single persistent conversation.
 

--- a/README.md
+++ b/README.md
@@ -7,52 +7,56 @@
   <a href="https://discord.gg/Wsy2NpnZDu"><img alt="Discord" src="https://img.shields.io/discord/1439901831038763092?style=flat-square&label=discord" /></a>
 </p>
 
-<h3 align="center">A menu-bar app that writes its own widgets while you watch.</h3>
+<h3 align="center">Adopt a baby menu and help it grow.</h3>
 
-Every menu-bar app ships a fixed set of widgets. Want your CPU temp next to your Claude usage next to your next calendar event? You either wait for someone to build it, glue together three different apps, or learn Electron.
+Every menu-bar app ships a fixed set of widgets.
+Want your CPU temp next to your Claude usage next to your next calendar event?
+Good luck waiting for someone to build exactly that.
 
-baby-menu flips that. The tray popover hosts a coding agent that edits the active extension workspace at runtime. You ask for a widget in plain English, the agent writes the extension, and you click Save to keep it or Rollback to wipe it.
+baby-menu flips it.
+The popover menu can run your coding agent to edit the menu on the fly.
+You ask for a feature in plain English, the agent writes an extension and it hot reloads into the menu in real time.
 
-- **Ask, don't configure** - "add a battery widget that shows charge and power source" - the agent ships the widget.
-- **Safe change sessions** - every turn runs inside a change session; source mode uses git, while packaged mode snapshots `~/.baby-menu/extensions`.
-- **Recipes over prompts** - non-trivial widgets live as self-contained HTML specs in `extensions/recipes/` so the agent implements them the same way every time.
+- **Personal self-evolving software** - this is a glimpse into a future where every piece of software is personal and self-evolving towards your exact needs.
+- **Ask, don't configure** - tweak the menu using natural language, not configuration.
+- **Worry-free** - every agent turn can be kept or rolled back.
 
 ## Quick Start
 
-```sh
-$ pnpm install              # installs deps and the pinned Electron binary
-$ pnpm dev                  # tray icon appears in your menu bar
-
-# click the tray icon, in the popover chat:
-> add a cpu temp widget that shows current temperature and fan status
-
-# agent writes extensions-dev/cpu-temp/widget.tsx and server.ts
-# the widget mounts live in the popover
-# click Save to keep it, or Rollback to throw the turn away
-```
-
-## Install
-
-**Homebrew Cask**
-
-Requires macOS 13 Ventura or newer.
-Baby Menu also needs a supported, already-authenticated agent CLI such as `claude`, `codex`, or `npx` on `PATH`; set `BABY_MENU_AGENT=<name>` before launch to choose one explicitly.
+Requires macOS 13 Ventura or newer, Homebrew, and a supported, already-authenticated agent CLI such as `claude`, `codex`, or `npx` on `PATH`.
 
 ```sh
 brew install --cask kunchenguid/tap/baby-menu
+open -a "Baby Menu"
 ```
 
-Update with:
+Click the tray icon, then ask for a widget in the popover chat such as:
+
+```text
+add a CPU temp widget that shows current temperature and fan status
+```
+
+Baby Menu writes the extension under `~/.baby-menu/extensions`, mounts the widget live, and shows Save / Rollback controls for the turn.
+Use Save to keep it, or Rollback to throw it away.
+The packaged app opens at login by default.
+Use the `login on/off` toggle in the popover header to turn that off or back on.
+
+## Install Details
+
+The packaged app stores mutable extensions, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets.
+Set `BABY_MENU_AGENT=<name>` in the launch environment to choose an agent explicitly.
+
+Update with Homebrew:
 
 ```sh
 brew update
 brew upgrade --cask baby-menu
 ```
 
-The packaged app stores mutable extensions, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets.
-Use the `login on/off` toggle in the popover header to control whether baby-menu opens at login.
+## From Source
 
-**From source**
+Use source mode when developing Baby Menu itself.
+End users should install the Homebrew Cask above.
 
 ```sh
 git clone https://github.com/kunchenguid/baby-menu.git
@@ -92,39 +96,42 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
    └─────────────────────┘
 ```
 
-- **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem. Everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
-- **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria. The agent reads the matching recipe before implementing.
-- **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets via `window.babyMenu.capabilities.invoke(extensionId, action, input)`. No per-widget IPC channels.
-- **Runtime-specific extension roots** - `pnpm start` edits tracked `extensions/` with `GitChangeSession`; `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with snapshot Save/Rollback.
+- **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem.
+  Everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
+- **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria.
+  The agent reads the matching recipe before implementing.
+- **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets via `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
+  No per-widget IPC channels.
+- **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with snapshot Save/Rollback.
+  Tracked `extensions/` remain the source templates for dev and packaged extension workspaces.
 
 ## Layout
 
-| Path                              | What lives here                                              |
-| --------------------------------- | ------------------------------------------------------------ |
-| `src/main/`                       | Electron lifecycle, tray, popover, IPC, git, agent runtime   |
-| `src/preload/index.ts`            | The stable `window.babyMenu` bridge                          |
-| `src/renderer/`                   | React UI: `AgentChat` + `WidgetHost`                         |
-| `src/shared/contracts.ts`         | `BabyMenuApi`, `BabyMenuWidget`, `GitSessionSnapshot`, etc.  |
-| `extensions/<id>/`                | Tracked extensions (`widget.tsx`, `server.ts`)               |
-| `extensions/recipes/*.html`       | Self-contained widget specs the agent reads                  |
-| `extensions-dev/`                 | Gitignored dev workspace prepared by `scripts/dev.mjs`       |
-| `~/.baby-menu/extensions/`        | Packaged app extension workspace                             |
-| `~/.baby-menu/cache/`             | Packaged widget, server-action, snapshot, and agent caches    |
-| `tests/`                          | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)           |
+| Path                        | What lives here                                             |
+| --------------------------- | ----------------------------------------------------------- |
+| `src/main/`                 | Electron lifecycle, tray, popover, IPC, git, agent runtime  |
+| `src/preload/index.ts`      | The stable `window.babyMenu` bridge                         |
+| `src/renderer/`             | React UI: `AgentChat` + `WidgetHost`                        |
+| `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `GitSessionSnapshot`, etc. |
+| `extensions/<id>/`          | Tracked extensions (`widget.tsx`, `server.ts`)              |
+| `extensions/recipes/*.html` | Self-contained widget specs the agent reads                 |
+| `extensions-dev/`           | Gitignored dev workspace prepared by `scripts/dev.mjs`      |
+| `~/.baby-menu/extensions/`  | Packaged app extension workspace                            |
+| `~/.baby-menu/cache/`       | Packaged widget, server-action, snapshot, and agent caches  |
+| `tests/`                    | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)          |
 
 ## Environment Flags
 
-| Var                              | Effect                                                        |
-| -------------------------------- | ------------------------------------------------------------- |
-| `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up  |
-| `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)             |
-| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs    |
+| Var                              | Effect                                                       |
+| -------------------------------- | ------------------------------------------------------------ |
+| `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up |
+| `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)            |
+| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs  |
 
 ## Development
 
 ```sh
-pnpm start        # run Electron + renderer dev server against the real extensions/ dir
-pnpm dev          # same, but agent edits the gitignored extensions-dev/ sandbox
+pnpm dev          # run Electron + renderer dev server with a gitignored extensions-dev/ sandbox
 pnpm dev:reset    # wipe extensions-dev/ and start fresh
 pnpm build        # build main + preload + renderer into out/
 pnpm package:mac  # build and create an ad-hoc-signed .app in release/mac-universal/
@@ -135,8 +142,11 @@ pnpm typecheck    # tsc --noEmit
 pnpm lint         # tsc --noEmit (same as typecheck)
 ```
 
-Use `pnpm start` when you want the embedded agent to edit tracked `extensions/` files (the `GitChangeSession` Save/Rollback boundary kicks in). Use `pnpm dev` when you want a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
+Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
+Source/dev mode never opts Baby Menu into opening at login.
+Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu.app`.
 
 Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.
 
-TDD is required for bug fixes and new features. Tests live in `tests/` at the repo root, not co-located.
+TDD is required for bug fixes and new features.
+Tests live in `tests/` at the repo root, not co-located.

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -5,7 +5,7 @@ The implemented app now includes packaging, runtime path changes, production ext
 
 ## Goals
 
-- Ship Baby Menu as a macOS menu-bar app, not as a source checkout that users run with `pnpm start`.
+- Ship Baby Menu as a macOS menu-bar app, not as a source checkout that users run with a direct `electron-vite dev` script.
 - Preserve the core product behavior where an embedded agent can create or edit widgets while the app is running.
 - Avoid a production Vite dev server.
 - Avoid Developer ID signing and notarization for now.
@@ -111,7 +111,6 @@ repo/
 
 | Mode | Renderer | Extension Workspace | Change Session | Widget Loader |
 | --- | --- | --- | --- | --- |
-| `pnpm start` | Vite dev server | `repo/extensions` | `GitChangeSession` | Vite `/@fs` |
 | `pnpm dev` | Vite dev server | `repo/extensions-dev` | snapshot session | Vite `/@fs` |
 | Packaged app | `out/renderer/index.html` | `app.getPath("home")/.baby-menu/extensions` | snapshot session | compiled module protocol |
 
@@ -381,12 +380,14 @@ Use Electron's login-item API from the app, not the Homebrew cask.
 
 Recommended default:
 
-- Add a setting in the app UI for “Open Baby Menu at login”.
+- Open the packaged app at login by default.
+- Add a setting in the app UI so users can opt out.
+- Never enable login-item startup from source/dev mode.
 - Persist the preference in user data.
 - Call `app.setLoginItemSettings({ openAtLogin: true })` when enabled.
 - Call `app.setLoginItemSettings({ openAtLogin: false })` when disabled.
 
-For a menu-bar utility, enabling autostart by default may be acceptable, but the least surprising implementation is to show a first-run prompt or settings toggle.
+For a packaged menu-bar utility, enabling autostart by default is acceptable when the opt-out setting is visible.
 Do not rely on a LaunchAgent from the cask unless a future background daemon is introduced.
 
 ## Packaging Tool
@@ -797,7 +798,7 @@ Acceptance criteria:
 
 - Packaged mode never writes generated extension files into the `.app` bundle.
 - Save and Rollback work without a git repo.
-- Source `pnpm start` still uses `GitChangeSession` for tracked `extensions`.
+- Source tracked `extensions` still use `GitChangeSession` when selected explicitly.
 - Source `pnpm dev` still uses snapshot sessions for `extensions-dev`.
 
 ### Phase 3: Add Production Extension Compilation - implemented

--- a/docs/distribution-strategy.md
+++ b/docs/distribution-strategy.md
@@ -736,7 +736,9 @@ Required install tests:
 - `/Applications/Baby Menu.app` exists.
 - The app launches from Finder.
 - The app launches from Spotlight.
-- The app launches after login when autostart is enabled.
+- The packaged app launches after login by default.
+- The popover exposes a visible opt-out toggle for opening at login.
+- Source/dev mode does not enable a login item.
 - The app does not require a source checkout, Node, or pnpm.
 - Quarantine does not block launch after Homebrew installation.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "postinstall": "install-electron",
-    "start": "electron-vite dev",
     "dev": "node scripts/dev.mjs",
     "dev:reset": "node scripts/dev.mjs --reset",
     "build": "electron-vite build",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -90,7 +90,12 @@ export async function startBabyMenuApp(): Promise<void> {
     app.dock?.hide();
   }
 
-  const preferences = createPreferencesService({ userDataDir: paths.appDataRoot, app });
+  const preferences = createPreferencesService({
+    userDataDir: paths.appDataRoot,
+    app,
+    defaultOpenAtLogin: paths.isPackaged,
+    allowOpenAtLogin: paths.isPackaged,
+  });
   await preferences.apply();
 
   const agentRuntime = new BabyMenuAgentRuntime(paths.appDataRoot, {

--- a/src/main/preferences.ts
+++ b/src/main/preferences.ts
@@ -7,7 +7,6 @@ export type BabyMenuPreferences = {
 
 type LoginItemApp = {
   setLoginItemSettings: (settings: { openAtLogin: boolean }) => void;
-  getLoginItemSettings: () => { openAtLogin?: boolean };
 };
 
 export type PreferencesService = {
@@ -16,15 +15,31 @@ export type PreferencesService = {
   apply: () => Promise<BabyMenuPreferences>;
 };
 
-export function createPreferencesService({ userDataDir, app }: { userDataDir: string; app: LoginItemApp }): PreferencesService {
+type CreatePreferencesServiceOptions = {
+  userDataDir: string;
+  app: LoginItemApp;
+  defaultOpenAtLogin?: boolean;
+  allowOpenAtLogin?: boolean;
+};
+
+export function createPreferencesService({
+  userDataDir,
+  app,
+  defaultOpenAtLogin = true,
+  allowOpenAtLogin = true,
+}: CreatePreferencesServiceOptions): PreferencesService {
   const filePath = join(userDataDir, "preferences.json");
+
+  function normalizePreferences(preferences: BabyMenuPreferences): BabyMenuPreferences {
+    return { openAtLogin: allowOpenAtLogin && preferences.openAtLogin };
+  }
 
   async function readPreferences(): Promise<BabyMenuPreferences> {
     try {
       const parsed = JSON.parse(await readFile(filePath, "utf8")) as Partial<BabyMenuPreferences>;
-      return { openAtLogin: parsed.openAtLogin ?? app.getLoginItemSettings().openAtLogin ?? false };
+      return normalizePreferences({ openAtLogin: parsed.openAtLogin ?? defaultOpenAtLogin });
     } catch {
-      return { openAtLogin: app.getLoginItemSettings().openAtLogin ?? false };
+      return normalizePreferences({ openAtLogin: defaultOpenAtLogin });
     }
   }
 
@@ -37,8 +52,8 @@ export function createPreferencesService({ userDataDir, app }: { userDataDir: st
   return {
     get: readPreferences,
     async setOpenAtLogin(openAtLogin) {
-      const preferences = await writePreferences({ openAtLogin });
-      app.setLoginItemSettings({ openAtLogin });
+      const preferences = await writePreferences(normalizePreferences({ openAtLogin }));
+      app.setLoginItemSettings({ openAtLogin: preferences.openAtLogin });
       return preferences;
     },
     async apply() {

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -113,4 +113,12 @@ describe("startBabyMenuApp", () => {
 
     expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 360, height: 333 });
   });
+
+  it("does not opt source dev mode into opening at login", async () => {
+    const appModule = await import("../src/main/app");
+
+    await appModule.startBabyMenuApp();
+
+    expect(electronApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+  });
 });

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -8,6 +8,7 @@ const trayInstance = {
 
 const electronApp = {
   dock: { hide: vi.fn() },
+  getPath: vi.fn((name: string) => (name === "home" ? "/home/test-user" : "/tmp")),
   getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
   setLoginItemSettings: vi.fn(),
   isPackaged: false,
@@ -50,6 +51,27 @@ vi.mock("../src/main/ipc", () => ({
   registerIpcHandlers,
 }));
 
+vi.mock("../src/main/agent-runtime", () => ({
+  BabyMenuAgentRuntime: vi.fn(),
+}));
+
+vi.mock("../src/main/extension-seeder", () => ({
+  seedExtensionWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("../src/main/server-action-registry", () => ({
+  createServerActionRegistry: vi.fn(() => ({})),
+}));
+
+vi.mock("../src/main/widget-module-registry", () => ({
+  createWidgetModuleRegistry: vi.fn(() => ({})),
+}));
+
+vi.mock("../src/main/widget-protocol", () => ({
+  registerBabyMenuProtocolHandlers: vi.fn(),
+  registerBabyMenuProtocolSchemes: vi.fn(),
+}));
+
 vi.mock("../src/main/tray", () => ({
   createBabyMenuTray,
 }));
@@ -66,6 +88,7 @@ vi.mock("../src/shared/paths", () => ({
 describe("startBabyMenuApp", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    electronApp.isPackaged = false;
     browserWindowInstance.isDestroyed.mockReturnValue(false);
     browserWindowInstance.isVisible.mockReturnValue(false);
   });
@@ -120,5 +143,15 @@ describe("startBabyMenuApp", () => {
     await appModule.startBabyMenuApp();
 
     expect(electronApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+  });
+
+  it("opts packaged app launches into opening at login by default", async () => {
+    electronApp.isPackaged = true;
+    process.resourcesPath = "/Applications/Baby Menu.app/Contents/Resources";
+    const appModule = await import("../src/main/app");
+
+    await appModule.startBabyMenuApp();
+
+    expect(electronApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
   });
 });

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -147,7 +147,10 @@ describe("startBabyMenuApp", () => {
 
   it("opts packaged app launches into opening at login by default", async () => {
     electronApp.isPackaged = true;
-    process.resourcesPath = "/Applications/Baby Menu.app/Contents/Resources";
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: "/Applications/Baby Menu.app/Contents/Resources",
+    });
     const appModule = await import("../src/main/app");
 
     await appModule.startBabyMenuApp();

--- a/tests/package-config.test.ts
+++ b/tests/package-config.test.ts
@@ -25,4 +25,8 @@ describe("package configuration", () => {
   it("provides an explicit command to destroy the generated dev extension workspace", () => {
     expect(packageJson.scripts?.["dev:reset"]).toBe("node scripts/dev.mjs --reset");
   });
+
+  it("does not expose a direct start script that bypasses the packaged app path", () => {
+    expect(packageJson.scripts).not.toHaveProperty("start");
+  });
 });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -11,19 +11,66 @@ describe("preferences service", () => {
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
   });
 
-  it("persists and applies the open-at-login preference", async () => {
+  it("defaults to opening at login until the user opts out", async () => {
     const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
     tempDirs.push(userDataDir);
     const appFacade = {
       setLoginItemSettings: vi.fn(),
-      getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
     };
     const service = createPreferencesService({ userDataDir, app: appFacade });
 
-    await expect(service.get()).resolves.toEqual({ openAtLogin: false });
-    await expect(service.setOpenAtLogin(true)).resolves.toEqual({ openAtLogin: true });
+    await expect(service.get()).resolves.toEqual({ openAtLogin: true });
+    await expect(service.apply()).resolves.toEqual({ openAtLogin: true });
 
     expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
-    await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": true');
+  });
+
+  it("can default to not opening at login for source dev mode", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const appFacade = {
+      setLoginItemSettings: vi.fn(),
+    };
+    const service = createPreferencesService({ userDataDir, app: appFacade, defaultOpenAtLogin: false });
+
+    await expect(service.get()).resolves.toEqual({ openAtLogin: false });
+    await expect(service.apply()).resolves.toEqual({ openAtLogin: false });
+
+    expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+  });
+
+  it("prevents source dev mode from enabling open at login", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const appFacade = {
+      setLoginItemSettings: vi.fn(),
+    };
+    const service = createPreferencesService({
+      userDataDir,
+      app: appFacade,
+      defaultOpenAtLogin: false,
+      allowOpenAtLogin: false,
+    });
+
+    await expect(service.setOpenAtLogin(true)).resolves.toEqual({ openAtLogin: false });
+    await expect(service.get()).resolves.toEqual({ openAtLogin: false });
+
+    expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": false');
+  });
+
+  it("persists and applies an explicit open-at-login opt-out", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const appFacade = {
+      setLoginItemSettings: vi.fn(),
+    };
+    const service = createPreferencesService({ userDataDir, app: appFacade });
+
+    await expect(service.setOpenAtLogin(false)).resolves.toEqual({ openAtLogin: false });
+    await expect(service.get()).resolves.toEqual({ openAtLogin: false });
+
+    expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": false');
   });
 });


### PR DESCRIPTION
## What Changed

- Defaults packaged builds to open at login on first run while keeping source/dev mode from enabling a login item automatically.
- Persists user preference changes so opting out of open-at-login remains respected across launches.
- Updates docs and tests to cover the packaged default, source/dev behavior, persisted opt-out, and package config expectations.

## Risk Assessment

✅ Low: The change is narrowly scoped to login-item defaults and source-mode guarding, with tests documenting the intended behavior and no material correctness risks found.

## Testing

After the initial dependency setup timeout and lifecycle harness timeout were resolved with a test-only mock cleanup, focused tests passed and the verbose evidence run exercised packaged startup opting into login launch, source/dev startup opting out, and user opt-out persistence.

<details>
<summary>Evidence: Open-at-login behavior evidence</summary>

```text
✓ tests/preferences.test.ts > preferences service > defaults to opening at login until the user opts out
✓ tests/preferences.test.ts > preferences service > can default to not opening at login for source dev mode
✓ tests/preferences.test.ts > preferences service > prevents source dev mode from enabling open at login
✓ tests/preferences.test.ts > preferences service > persists and applies an explicit open-at-login opt-out
✓ tests/app-lifecycle.test.ts > startBabyMenuApp > does not opt source dev mode into opening at login
✓ tests/app-lifecycle.test.ts > startBabyMenuApp > opts packaged app launches into opening at login by default
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- <code>`pnpm vitest run tests/preferences.test.ts tests/app-lifecycle.test.ts tests/package-config.test.ts` - initial attempt was interrupted during dependency setup, retry exposed lifecycle harness timeouts, and the final run passed after the test harness fix.</code>
- <code>`pnpm vitest run tests/app-lifecycle.test.ts` - reproduced lifecycle harness timeouts before the test-only fix.</code>
- <code>`pnpm vitest run tests/app-lifecycle.test.ts tests/preferences.test.ts --reporter=verbose` - captured behavior-named evidence for packaged default, source/dev default, and persisted opt-out.</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/distribution-strategy.md:739` - The testing checklist still frames login launch as something to verify only &#34;when autostart is enabled&#34;, but the change makes packaged builds opt into open-at-login by default and disables that behavior in source/dev mode. Update the checklist to explicitly verify the packaged first-run default, the visible opt-out toggle, and that source/dev mode does not enable a login item.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
