### PR TITLE
fix(main): suppress macOS keychain prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,12 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `preload` entry: `src/preload/index.ts` -> `out/preload/index.js`.
 - `renderer` root: `src/renderer/` -> `out/renderer/`. In dev, main loads `process.env.ELECTRON_RENDERER_URL`; in production it loads `out/renderer/index.html` via `loadFile`.
 
+`typescript` is intentionally externalized from the production main bundle because `extension-module-compiler.ts` imports it at runtime to compile packaged extensions.
+Keep `typescript` in runtime dependencies unless that compiler path changes.
+
 `createPopoverOptions` enforces `frame:false`, `contextIsolation:true`, `nodeIntegration:false`, `skipTaskbar:true`, `alwaysOnTop:true`. Do not relax these without a reason.
+On macOS, `app.ts` appends Chromium's `use-mock-keychain` switch before app readiness, so do not rely on Chromium or renderer storage for keychain-backed secrets.
+Keep credential and token work in extension server actions.
 
 ### Agent runtime + change sessions
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
     build: {
       rollupOptions: {
-        external: ["electron"],
+        external: ["electron", "typescript"],
         input: {
           index: resolve(__dirname, "src/main/app.ts"),
         },

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -36,6 +36,7 @@ Do not leave placeholder, demo, or mock widgets alongside the user's requested w
 Export a `RefreshableBabyMenuWidget` or `BabyMenuWidget` from `widget.tsx`.
 Keep the widget renderer-only.
 Do not read files, spawn commands, use credentials, or perform privileged network work from the renderer.
+Do not store tokens or secrets in renderer or browser storage; Baby Menu disables Chromium keychain-backed storage on macOS.
 
 ## Widget Design System
 

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -21,6 +21,10 @@ import { createBabyMenuTray, type BabyMenuTray } from "./tray";
 import { createWidgetModuleRegistry } from "./widget-module-registry";
 import { registerBabyMenuProtocolHandlers, registerBabyMenuProtocolSchemes } from "./widget-protocol";
 
+if (process.platform === "darwin") {
+  app.commandLine.appendSwitch("use-mock-keychain");
+}
+
 registerBabyMenuProtocolSchemes();
 
 let popoverWindow: BrowserWindow | null = null;

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -87,14 +87,25 @@ vi.mock("../src/shared/paths", () => ({
 }));
 
 describe("startBabyMenuApp", () => {
+  const originalPlatform = process.platform;
+
   beforeEach(() => {
     vi.clearAllMocks();
     electronApp.isPackaged = false;
     browserWindowInstance.isDestroyed.mockReturnValue(false);
     browserWindowInstance.isVisible.mockReturnValue(false);
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
   });
 
   it("disables Chromium keychain prompts before app startup on macOS", async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+
     await import("../src/main/app");
 
     expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledWith("use-mock-keychain");

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -7,6 +7,7 @@ const trayInstance = {
 };
 
 const electronApp = {
+  commandLine: { appendSwitch: vi.fn() },
   dock: { hide: vi.fn() },
   getPath: vi.fn((name: string) => (name === "home" ? "/home/test-user" : "/tmp")),
   getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
@@ -91,6 +92,12 @@ describe("startBabyMenuApp", () => {
     electronApp.isPackaged = false;
     browserWindowInstance.isDestroyed.mockReturnValue(false);
     browserWindowInstance.isVisible.mockReturnValue(false);
+  });
+
+  it("disables Chromium keychain prompts before app startup on macOS", async () => {
+    await import("../src/main/app");
+
+    expect(electronApp.commandLine.appendSwitch).toHaveBeenCalledWith("use-mock-keychain");
   });
 
   it("retains the tray object for the app lifetime", async () => {

--- a/tests/electron-vite-config.test.ts
+++ b/tests/electron-vite-config.test.ts
@@ -18,6 +18,14 @@ describe("electron-vite config", () => {
     expect(asExternalList(config.preload?.build?.rollupOptions?.external)).toContain("electron");
   });
 
+  it("keeps TypeScript external in the production main bundle", async () => {
+    vi.stubGlobal("__dirname", rootDir);
+
+    const { default: config } = await import("../electron.vite.config");
+
+    expect(asExternalList(config.main?.build?.rollupOptions?.external)).toContain("typescript");
+  });
+
   it("builds the preload bridge as a CommonJS file for Electron", async () => {
     vi.stubGlobal("__dirname", rootDir);
 


### PR DESCRIPTION
## Intent

The developer wanted to diagnose and fix production-only launch issues in a newly released and installed macOS Baby Menu package. They needed to understand why TypeScript was ending up in the packaged main bundle, whether that dependency was intentional, and why it caused an ESM/CommonJS startup crash. They also wanted to eliminate a scary recurring macOS Keychain security dialog for end users, especially in packaged or ad-hoc signed builds. Their constraints were to keep the explanation focused on intentional versus accidental references, avoid unnecessary credential access, and preserve an appropriate security model where secrets belong in extension server actions rather than Chromium storage.

## What Changed

- App startup now appends Chromium's `use-mock-keychain` switch on macOS before readiness to avoid recurring Keychain prompts from packaged or ad-hoc signed builds.
- The Electron production config keeps `typescript` externalized from the main bundle so the runtime compiler path remains intentional instead of being bundled into the app entry.
- Added regression coverage for the macOS keychain switch and TypeScript externalization, plus maintainer and extension-author docs for the related security/runtime invariants.

## Risk Assessment

✅ Low: The change is narrowly scoped to an early Electron command-line switch, production bundling of an existing runtime dependency, and targeted regression tests, with no material issues found.

## Testing

<code>Ran the focused lifecycle/config tests, built and packaged the macOS app, inspected the production bundle for the keychain switch and CJS preload path, and opened the packaged `.app` long enough to confirm the main and helper processes started instead of crashing.</code>

<details>
<summary>Evidence: Packaged app launch evidence</summary>

```text
42929 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KS68R9DMAPZZ4TDR97FXRVSC/release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu
42942 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KS68R9DMAPZZ4TDR97FXRVSC/release/mac-universal/Baby Menu.app/Contents/Frameworks/Baby Menu Helper.app/Contents/MacOS/Baby Menu Helper --type=gpu-process ...
42943 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KS68R9DMAPZZ4TDR97FXRVSC/release/mac-universal/Baby Menu.app/Contents/Frameworks/Baby Menu Helper.app/Contents/MacOS/Baby Menu Helper --type=utility --utility-sub-type=network.mojom.NetworkService ...
```
</details>
<details>
<summary>Evidence: Production bundle startup markers</summary>

```text
out/main/index.js: import ts from "typescript";
out/main/index.js: if (process.platform === "darwin") app.commandLine.appendSwitch("use-mock-keychain");
out/main/index.js: popoverWindow = new BrowserWindow(createPopoverOptions(join(dirname, "../preload/index.cjs")));
out/preload/index.cjs: electron.contextBridge.exposeInMainWorld("babyMenu", {
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `tests/app-lifecycle.test.ts:100` - This assertion is unconditional, but the production code only appends `use-mock-keychain` when `process.platform === &#34;darwin&#34;`; CI runs `pnpm test` on `ubuntu-latest`, so this test will fail there unless it stubs `process.platform` to `darwin` or expects no call on non-macOS.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm vitest run tests/app-lifecycle.test.ts tests/electron-vite-config.test.ts`
- `pnpm build`
- `pnpm package:mac`
- `open -n "release/mac-universal/Baby Menu.app"; sleep 5; pgrep -fl "Baby Menu"; osascript -e 'tell application "Baby Menu" to quit' >/dev/null 2>&1 || true; sleep 1; pgrep -fl "Baby Menu" || true`
- <code>`grep` checks over `out/main/index.js` and `out/preload/index.cjs` for `use-mock-keychain`, `../preload/index.cjs`, `from &#34;typescript&#34;`, and `contextBridge.exposeInMainWorld`</code>

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 warnings
- ⚠️ `AGENTS.md:62` - The Electron build wiring docs describe the main/preload/renderer outputs but do not document the new production-build invariant that `typescript` is intentionally externalized in the main bundle. Since `src/main/extension-module-compiler.ts` imports TypeScript at runtime and `package.json` keeps it in dependencies, this config change should be documented so maintainers do not treat the external as accidental or move TypeScript back to dev-only dependencies.
- ⚠️ `AGENTS.md:72` - The app lifecycle/security architecture docs do not mention that macOS startup now appends Chromium&#39;s `use-mock-keychain` switch before app readiness. This changes credential-storage assumptions for the Electron shell and should be documented with the security model: avoid Chromium/renderer keychain-backed secret storage and keep secrets in extension server actions.
- ⚠️ `extensions/AGENTS.md:34` - The extension authoring contract says widgets must not use credentials from the renderer, but it does not state the new practical constraint that Chromium keychain-backed storage is intentionally disabled on macOS. Extension docs should explicitly tell widget authors not to store tokens or secrets in renderer/browser storage and to route credential work through `server.ts` actions.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
