### PR TITLE
fix(main): skip login item updates in source dev mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `extension-seeder.ts` - seeds bundled extension templates into the packaged extension workspace.
 - `extension-module-compiler.ts` - compiles extension widget and server modules for production loading.
 - `widget-protocol.ts` - registers custom protocols for compiled widget modules and the renderer host shim.
-- `preferences.ts` - stores app preferences under the active app data root and applies login-item settings.
+- `preferences.ts` - stores app preferences under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
 - `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `recipe-loader.ts` - discovers and parses `recipes/*.html` from the active extension workspace.
 - `server-action-registry.ts` - dynamically loads extension server actions from the active extension workspace and exposes them through the generic capability bridge.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ pnpm lint         # tsc --noEmit (same as typecheck)
 ```
 
 Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
-Source/dev mode never opts Baby Menu into opening at login.
+Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
 Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu.app`.
 
 Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.

--- a/src/main/preferences.ts
+++ b/src/main/preferences.ts
@@ -34,6 +34,11 @@ export function createPreferencesService({
     return { openAtLogin: allowOpenAtLogin && preferences.openAtLogin };
   }
 
+  function applyLoginItemSettings(preferences: BabyMenuPreferences): void {
+    if (!allowOpenAtLogin) return;
+    app.setLoginItemSettings({ openAtLogin: preferences.openAtLogin });
+  }
+
   async function readPreferences(): Promise<BabyMenuPreferences> {
     try {
       const parsed = JSON.parse(await readFile(filePath, "utf8")) as Partial<BabyMenuPreferences>;
@@ -53,12 +58,12 @@ export function createPreferencesService({
     get: readPreferences,
     async setOpenAtLogin(openAtLogin) {
       const preferences = await writePreferences(normalizePreferences({ openAtLogin }));
-      app.setLoginItemSettings({ openAtLogin: preferences.openAtLogin });
+      applyLoginItemSettings(preferences);
       return preferences;
     },
     async apply() {
       const preferences = await readPreferences();
-      app.setLoginItemSettings({ openAtLogin: preferences.openAtLogin });
+      applyLoginItemSettings(preferences);
       return preferences;
     },
   };

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -157,12 +157,12 @@ describe("startBabyMenuApp", () => {
     expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 360, height: 333 });
   });
 
-  it("does not opt source dev mode into opening at login", async () => {
+  it("does not touch login items in source dev mode", async () => {
     const appModule = await import("../src/main/app");
 
     await appModule.startBabyMenuApp();
 
-    expect(electronApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    expect(electronApp.setLoginItemSettings).not.toHaveBeenCalled();
   });
 
   it("opts packaged app launches into opening at login by default", async () => {

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -55,7 +55,7 @@ describe("preferences service", () => {
     await expect(service.setOpenAtLogin(true)).resolves.toEqual({ openAtLogin: false });
     await expect(service.get()).resolves.toEqual({ openAtLogin: false });
 
-    expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
+    expect(appFacade.setLoginItemSettings).not.toHaveBeenCalled();
     await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": false');
   });
 


### PR DESCRIPTION
## Intent

The developer wanted to understand and fix a macOS “Unable to set login item: Operation not permitted” error that appeared when running pnpm dev. They determined the dev app should not call Electron’s login-item API at all when login items are disallowed in source/dev mode, rather than calling it with openAtLogin set to false. They explicitly wanted a real code fix, with tests updated to cover the expected dev-mode behavior and verification via targeted Vitest tests and typecheck.

## What Changed

- Updated preferences handling so source/dev mode does not call Electron's `setLoginItemSettings` API when login items are disallowed.
- Adjusted lifecycle and preferences tests to expect no login-item API calls in source/dev mode while preserving packaged-app login behavior.
- Clarified README and architecture docs that development mode leaves macOS login items untouched.

## Risk Assessment

✅ Low: The change is narrowly scoped to skipping Electron login-item API calls when login items are disallowed in source/dev mode, with aligned coverage and no material regressions found.

## Testing

I exercised the changed login-item path by inspecting the source/dev and packaged startup logic and the targeted Vitest assertions, attempted the smallest relevant Vitest command, and captured an evidence transcript; actual automated execution could not proceed because this environment has no Node or pnpm tooling installed.

<details>
<summary>Evidence: Login-item validation transcript</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KS9Q3FKV2WZQCRW5VT881A91/login-item-validation.md</code>

```text
Evidence transcript documenting the intended behavior, inspected assertions, attempted Vitest command, and missing Node/pnpm setup checks.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ Automated validation could not run in this environment because `pnpm`, `node`, and `corepack` are unavailable on PATH and common macOS install paths, and `node_modules/.bin/vitest` is absent. This prevents end-to-end execution of the targeted login-item Vitest cases here.
- <code>Inspected `git diff 8f1f22619737a05b29c26ddcb8d0d3260a6777d4..f03cf8c9d23cd8cd0eda1c851eda7a12e87148e7 -- src/main/preferences.ts tests/preferences.test.ts tests/app-lifecycle.test.ts`.</code>
- <code>Attempted `pnpm vitest run tests/preferences.test.ts tests/app-lifecycle.test.ts -t &#34;login|open at login|source dev mode|packaged app&#34;`, which failed before tests ran because `pnpm` was not found.</code>
- <code>Checked setup with `node --version`, `corepack --version`, `/opt/homebrew/bin/node`, `/usr/local/bin/node`, `/opt/homebrew/bin/pnpm`, `/usr/local/bin/pnpm`, and `node_modules/.bin/vitest`; none were available.</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `README.md:146` - The source/development behavior is now stricter than documented: `pnpm dev` does not call Electron&#39;s login-item API at all when login items are disallowed, rather than merely not opting the app into opening at login. Update the source/development note to say dev mode never touches macOS login items or `setLoginItemSettings`, so the documented behavior matches the permission-error fix.
- ⚠️ `AGENTS.md:57` - The `preferences.ts` module description says it applies login-item settings, but the implementation now applies them only when `allowOpenAtLogin` is true and intentionally skips the API in source/dev mode. Update this architecture note to document the packaged-only login-item side effect and the dev-mode no-op invariant.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
