### PR TITLE
fix(main): restore tray popover cursor tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.2",
     "acp-mock": "1.1.0",
-    "electron": "42.1.0",
+    "electron": "42.2.0",
     "electron-builder": "26.8.1",
     "electron-vite": "5.0.0",
     "jsdom": "29.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(zod@4.4.3)
       electron:
-        specifier: 42.1.0
-        version: 42.1.0
+        specifier: 42.2.0
+        version: 42.2.0
       electron-builder:
         specifier: 26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -1256,8 +1256,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.1.0:
-    resolution: {integrity: sha512-0szNwC/0dWtkvNce5j3ThiuL0TxBNrZN/BZhdOiGwbLreiD/+u3MGpkct4hA5Ycagb8MXjpEr5/oosi+FwuKRQ==}
+  electron@42.2.0:
+    resolution: {integrity: sha512-b2Tc7sIKiZEl0tBVwFM5GJ+FT5KYhmy9QJHjx8BGVZPVW2SctXWEvrE959ElB56qw7H05dBkhlikDA1DmpaAMw==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -3516,7 +3516,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.1.0:
+  electron@42.2.0:
     dependencies:
       '@electron/get': 5.0.0
       '@types/node': 24.12.4

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -49,6 +49,9 @@ async function createPopoverWindow(): Promise<BrowserWindow> {
     if (process.env.BABY_MENU_KEEP_POPOVER_OPEN === "1") return;
     popoverWindow?.hide();
   });
+  // Once the popover is hidden, drop back to accessory mode so the dock icon disappears again.
+  // See setPopoverKeyWindowActive for why the popover becomes a regular-policy app while visible.
+  popoverWindow.on("hide", () => setPopoverKeyWindowActive(false));
 
   await loadPopoverRenderer(
     popoverWindow,
@@ -70,8 +73,22 @@ async function togglePopover(trayBounds: Rectangle): Promise<void> {
 
   const display = screen.getDisplayNearestPoint({ x: trayBounds.x, y: trayBounds.y });
   window.setBounds(calculatePopoverBounds(trayBounds, display.workArea, latestPopoverSize));
+  setPopoverKeyWindowActive(true);
   window.show();
   window.focus();
+}
+
+// baby-menu runs as a macOS accessory app (dock hidden) so it has no permanent dock icon. But an
+// accessory app's windows never become the macOS "key window", and macOS only does CSS cursor-rect
+// tracking for the key window - so as an accessory app the popover's cursor never updates correctly
+// (it stays the default arrow, or updates unstably and flickers). Switching to the "regular"
+// activation policy while the popover is visible lets it become the key window so the cursor tracks
+// correctly; switching back to "accessory" on hide keeps the dock icon from lingering. Net effect:
+// the dock icon is only present for the brief moment the popover is open.
+function setPopoverKeyWindowActive(active: boolean): void {
+  if (process.platform !== "darwin") return;
+  app.setActivationPolicy(active ? "regular" : "accessory");
+  if (active) app.focus({ steal: true });
 }
 
 function setPopoverContentHeight(height: number) {

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Rectangle } from "electron";
 
 const trayInstance = {
@@ -97,6 +97,13 @@ describe("startBabyMenuApp", () => {
     electronApp.isPackaged = false;
     browserWindowInstance.isDestroyed.mockReturnValue(false);
     browserWindowInstance.isVisible.mockReturnValue(false);
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  });
+
+  afterEach(() => {
     Object.defineProperty(process, "platform", {
       configurable: true,
       value: originalPlatform,

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -12,6 +12,8 @@ const electronApp = {
   getPath: vi.fn((name: string) => (name === "home" ? "/home/test-user" : "/tmp")),
   getLoginItemSettings: vi.fn(() => ({ openAtLogin: false })),
   setLoginItemSettings: vi.fn(),
+  setActivationPolicy: vi.fn(),
+  focus: vi.fn(),
   isPackaged: false,
   on: vi.fn(),
   whenReady: vi.fn(async () => undefined),
@@ -91,6 +93,7 @@ describe("startBabyMenuApp", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.resetModules();
     electronApp.isPackaged = false;
     browserWindowInstance.isDestroyed.mockReturnValue(false);
     browserWindowInstance.isVisible.mockReturnValue(false);
@@ -151,6 +154,7 @@ describe("startBabyMenuApp", () => {
     const popoverController = registerIpcHandlers.mock.calls.at(-1)?.[4];
     const onTrayClick = createBabyMenuTray.mock.calls.at(-1)?.[0];
     await onTrayClick?.({ x: 100, y: 10, width: 24, height: 24 });
+    await vi.waitFor(() => expect(browserWindowInstance.setBounds).toHaveBeenCalled());
 
     popoverController.setContentHeight(333);
 
@@ -176,5 +180,31 @@ describe("startBabyMenuApp", () => {
     await appModule.startBabyMenuApp();
 
     expect(electronApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: true });
+  });
+
+  it("temporarily uses regular activation policy while the macOS popover is visible", async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+    const appModule = await import("../src/main/app");
+
+    await appModule.startBabyMenuApp();
+    const onTrayClick = createBabyMenuTray.mock.calls.at(-1)?.[0];
+    await onTrayClick?.({ x: 100, y: 10, width: 24, height: 24 });
+
+    await vi.waitFor(() =>
+      expect((electronApp as { setActivationPolicy: ReturnType<typeof vi.fn> }).setActivationPolicy).toHaveBeenCalledWith(
+        "regular",
+      ),
+    );
+    expect((electronApp as { focus: ReturnType<typeof vi.fn> }).focus).toHaveBeenCalledWith({ steal: true });
+
+    const onHide = browserWindowInstance.on.mock.calls.find(([event]) => event === "hide")?.[1];
+    onHide?.();
+
+    expect((electronApp as { setActivationPolicy: ReturnType<typeof vi.fn> }).setActivationPolicy).toHaveBeenLastCalledWith(
+      "accessory",
+    );
   });
 });


### PR DESCRIPTION
## Intent

The developer wanted to fix a Baby Menu cursor flicker bug where hovering over text inputs and buttons caused rapid cursor instability. They asked to reproduce and diagnose it autonomously, validate theories with instrumentation and logs, compare against a stable Electron app, and avoid relying on system-level explanations once hi-bit proved Electron could behave correctly. They explicitly wanted temporary debug patches reverted, clean logging that reset on app start, and a final shippable fix rather than just root-cause analysis. They also requested restoring Electron to the latest version allowed by the repo's pnpm minimum-release-age policy, and the investigation converged on toggling macOS activation policy so the tray popover becomes a key window while open without showing the Dock icon permanently.

## What Changed

- Temporarily switches the macOS app activation policy to `regular` while the tray popover is visible, then back to `accessory` when hidden so the popover can become the key window and track cursors correctly.
- Keeps the popover focused after opening and preserves the hidden Dock icon behavior outside the visible popover lifecycle.
- Updates Electron from `42.1.0` to `42.2.0` and adds lifecycle coverage for the macOS activation policy transitions.

## Risk Assessment

✅ Low: The change is narrowly scoped to macOS popover activation policy handling with focused lifecycle test coverage and no material issues found.

## Testing

Focused lifecycle, popover geometry, and package-config tests passed; the app built successfully; direct macOS tray automation was blocked by assistive-access permissions, so an Electron runtime harness invoked the real tray-click path, captured the rendered popover, and recorded that the app switched to regular activation while visible/focused and back to accessory after hide.

<details>
<summary>Evidence: Rendered popover window after real tray-click path</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSN8RSC6WXN5Z2TYNV4E8M4K/popover-window.png</code>

```text
PNG image data, 360 x 478.
```
</details>
<details>
<summary>Evidence: Runtime activation and cursor trace</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSN8RSC6WXN5Z2TYNV4E8M4K/popover-runtime-trace.json</code>

```text
beforeHide: visible=true, focused=true, appActive=true; afterHide: visible=false, focused=false, appActive=false; trace includes setActivationPolicy('regular'), app.focus({ steal: true }), window.show(), window.focus(), then setActivationPolicy('accessory'); textarea computed cursor is 'text'.
```
</details>
<details>
<summary>Evidence: Electron harness transcript</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSN8RSC6WXN5Z2TYNV4E8M4K/popover-runtime-evidence.log</code>

```text
evidence harness starting; imported app module; started app function; window count 1; evidence harness complete.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/main/app.ts:90` - The new macOS-only activation path calls `app.setActivationPolicy()` and then `app.focus()`, but the existing Electron app test double in `tests/app-lifecycle.test.ts` defines neither method; on macOS, tray-click lifecycle tests that exercise this changed path will throw before reaching their assertions. Add these methods to the mock and assert the regular/accessory transitions so the popover lifecycle remains covered.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `tests/app-lifecycle.test.ts:186` - This test mutates `process.platform` to `darwin` but relies on `beforeEach` for restoration, and because it is now the last test in the file it leaves the global platform overridden for any later tests scheduled in the same worker. Restore `process.platform` in `afterEach` or a `finally` block so this macOS-specific coverage cannot leak into unrelated tests.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm vitest run tests/app-lifecycle.test.ts tests/popover-position.test.ts`
- `pnpm vitest run tests/package-config.test.ts`
- `pnpm build`
- <code>Manual macOS tray automation attempt with `osascript`; blocked by missing assistive-access permission, so I used the runtime harness instead.</code>
- `ELECTRON_ENABLE_LOGGING=1 ./node_modules/.bin/electron /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSN8RSC6WXN5Z2TYNV4E8M4K/popover-runtime-evidence.mjs`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
