### PR TITLE
fix(renderer): use native cursors and enforce refreshable intervals

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -190,6 +190,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 - **Focus** (keyboard): `--focus-ring` 1px solid mint + 4px mint glow. Same rule for everything.
 - **Disabled**: `opacity: 0.32`. No filter, no grayscale.
 - **Composer focus**: input border shifts to `rgba(106,227,182,0.45)`. The caret stays.
+- **Cursors**: use the default arrow across the popover, text cursor only in editable fields, pointer on buttons and links, and `not-allowed` on disabled controls.
 
 ### Layout rules
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -34,6 +34,8 @@ Do not leave placeholder, demo, or mock widgets alongside the user's requested w
 ## Widget Contract
 
 Export a `RefreshableBabyMenuWidget` or `BabyMenuWidget` from `widget.tsx`.
+Only `RefreshableBabyMenuWidget` may declare `refreshIntervalMs`, and it must also declare `refresh`.
+Plain `BabyMenuWidget` exports must not declare a refresh interval.
 Keep the widget renderer-only.
 Do not read files, spawn commands, use credentials, or perform privileged network work from the renderer.
 Do not store tokens or secrets in renderer or browser storage; Baby Menu disables Chromium keychain-backed storage on macOS.

--- a/src/renderer/menu/WidgetHost.tsx
+++ b/src/renderer/menu/WidgetHost.tsx
@@ -122,7 +122,16 @@ export function widgetsFromModule(module: unknown): RefreshableBabyMenuWidget[] 
 function isRefreshableBabyMenuWidget(value: unknown): value is RefreshableBabyMenuWidget {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Partial<RefreshableBabyMenuWidget>;
-  return typeof candidate.id === "string" && typeof candidate.title === "string" && typeof candidate.render === "function";
+  const hasRefresh = typeof candidate.refresh === "function";
+  const hasInvalidRefresh = candidate.refresh !== undefined && !hasRefresh;
+  const hasInvalidInterval = candidate.refreshIntervalMs !== undefined && !hasRefresh;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.render === "function" &&
+    !hasInvalidRefresh &&
+    !hasInvalidInterval
+  );
 }
 
 function importRuntimeWidgetModule(moduleUrl: string): Promise<unknown> {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -26,6 +26,30 @@ button {
   -webkit-appearance: none;
 }
 
+/* Native-feel cursors: arrow everywhere, I-beam only in editable fields,
+   pointer on controls. cursor inherits, so the root rule sets the default
+   and interactive elements override it. */
+html {
+  cursor: default;
+}
+
+input,
+textarea,
+[contenteditable="true"] {
+  cursor: text;
+}
+
+button,
+[role="button"],
+a[href] {
+  cursor: pointer;
+}
+
+button:disabled,
+[aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
 .app-shell {
   width: 360px;
   height: auto;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -59,10 +59,17 @@ export type BabyMenuWidget = {
   render: () => ReactNode;
 };
 
-export type RefreshableBabyMenuWidget = BabyMenuWidget & {
-  refreshIntervalMs?: number;
-  refresh?: () => void | Promise<void>;
-};
+export type RefreshableBabyMenuWidget = BabyMenuWidget &
+  (
+    | {
+        refreshIntervalMs?: number;
+        refresh: () => void | Promise<void>;
+      }
+    | {
+        refreshIntervalMs?: never;
+        refresh?: never;
+      }
+  );
 
 export type BabyMenuApi = {
   recipes: {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -56,11 +56,11 @@ export type BabyMenuWidgetModuleDescriptor = {
 export type BabyMenuWidget = {
   id: string;
   title: string;
-  refreshIntervalMs?: number;
   render: () => ReactNode;
 };
 
 export type RefreshableBabyMenuWidget = BabyMenuWidget & {
+  refreshIntervalMs?: number;
   refresh?: () => void | Promise<void>;
 };
 

--- a/tests/contracts-types.test.ts
+++ b/tests/contracts-types.test.ts
@@ -1,4 +1,5 @@
 import type { RefreshableBabyMenuWidget } from "../src/shared/contracts";
+import { describe, expect, it } from "vitest";
 
 const refreshableWidget: RefreshableBabyMenuWidget = {
   id: "quota",
@@ -19,3 +20,9 @@ const intervalWithoutRefresh: RefreshableBabyMenuWidget = {
 };
 
 void intervalWithoutRefresh;
+
+describe("RefreshableBabyMenuWidget contract", () => {
+  it("accepts widgets that pair refresh intervals with refresh callbacks", () => {
+    expect(refreshableWidget.refreshIntervalMs).toBe(1000);
+  });
+});

--- a/tests/contracts-types.test.ts
+++ b/tests/contracts-types.test.ts
@@ -1,0 +1,21 @@
+import type { RefreshableBabyMenuWidget } from "../src/shared/contracts";
+
+const refreshableWidget: RefreshableBabyMenuWidget = {
+  id: "quota",
+  title: "Quota",
+  refreshIntervalMs: 1000,
+  refresh: async () => undefined,
+  render: () => null,
+};
+
+void refreshableWidget;
+
+// @ts-expect-error refresh intervals require a refresh callback.
+const intervalWithoutRefresh: RefreshableBabyMenuWidget = {
+  id: "quota",
+  title: "Quota",
+  refreshIntervalMs: 1000,
+  render: () => null,
+};
+
+void intervalWithoutRefresh;

--- a/tests/widget-host.test.tsx
+++ b/tests/widget-host.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
-import { act, renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { RefreshableBabyMenuWidget } from "../src/shared/contracts";
+import { WidgetHost } from "../src/renderer/menu/WidgetHost";
 import { useWidgetRefresh } from "../src/renderer/menu/useWidgetRefresh";
 
 describe("useWidgetRefresh", () => {
@@ -28,5 +30,27 @@ describe("useWidgetRefresh", () => {
     act(() => result.current.refreshNow());
 
     expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("WidgetHost", () => {
+  it("honors a refreshable widget's declared interval", () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn();
+    const widget: RefreshableBabyMenuWidget = {
+      id: "quota",
+      title: "quota",
+      refreshIntervalMs: 1000,
+      refresh,
+      render: () => null,
+    };
+
+    render(<WidgetHost widgets={[widget]} />);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(2500));
+
+    expect(refresh).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
   });
 });

--- a/tests/widget-host.test.tsx
+++ b/tests/widget-host.test.tsx
@@ -2,7 +2,7 @@
 import { act, render, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { RefreshableBabyMenuWidget } from "../src/shared/contracts";
-import { WidgetHost } from "../src/renderer/menu/WidgetHost";
+import { WidgetHost, widgetsFromModule } from "../src/renderer/menu/WidgetHost";
 import { useWidgetRefresh } from "../src/renderer/menu/useWidgetRefresh";
 
 describe("useWidgetRefresh", () => {
@@ -52,5 +52,18 @@ describe("WidgetHost", () => {
 
     expect(refresh).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
+  });
+
+  it("ignores runtime widget exports without refresh callbacks", () => {
+    expect(
+      widgetsFromModule({
+        stale: {
+          id: "stale",
+          title: "Stale",
+          refreshIntervalMs: 1000,
+          render: () => null,
+        },
+      }),
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Intent

The developer wanted to understand and then tighten Baby Menu's extension refresh primitive so periodic data updates are represented only by refreshable widgets, not plain widgets. They specifically asked to move refreshIntervalMs from the base BabyMenuWidget type onto RefreshableBabyMenuWidget because an interval is only meaningful with a refresh callback. They also wanted the menu popover to feel more like a native macOS app by using the default arrow cursor for most UI/text, with cursor changes only for text inputs and buttons.

## What Changed

- Updates the popover styles so the default UI uses the native arrow cursor, with text, pointer, and disabled cursors applied only to the appropriate controls.
- Tightens the widget refresh contract so `refreshIntervalMs` belongs to refreshable widgets with a `refresh` callback, and ignores runtime exports that declare intervals without refresh support.
- Adds focused widget host and type-contract coverage, plus authoring/design documentation for the refreshed widget and cursor contracts.

## Risk Assessment

✅ Low: The changes are narrowly scoped to cursor CSS and the widget refresh contract, with runtime validation and type coverage aligned to the stated behavior.

## Testing

The focused widget tests passed for refresh interval scheduling, runtime widget filtering, and the type-contract fixture, and the renderer was loaded in Chrome to capture the popover plus computed cursor evidence showing default cursors for normal UI/text, text cursor for the prompt, pointer for enabled buttons, and not-allowed for the disabled send button.

- Evidence: Rendered Baby Menu popover with cursor stylesheet loaded (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNCS4JET9H13JQCXBM78QSG/popover-renderer-cursors.png</code>)
<details>
<summary>Evidence: Computed cursor values from rendered popover</summary>

```text
{"html":"default","body":"default","appShell":"default","headerText":"default","staticText":"default","loginButton":"pointer","refreshButton":"pointer","promptTextbox":"text","sendButton":"not-allowed"}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed across 2 runs (31m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `src/shared/contracts.ts:63` - `RefreshableBabyMenuWidget` still permits `refreshIntervalMs` without a `refresh` callback because `refresh` remains optional. That leaves the host able to schedule repeated no-op refresh timers for widgets that declare an interval but have no refresh implementation, so the type does not enforce the new invariant that intervals are only meaningful with refresh callbacks.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `tests/contracts-types.test.ts:1` - The first focused Vitest run failed because this file contained only TypeScript contract fixtures and no Vitest test case, so Vitest treated it as an empty failed suite. I added a minimal test-only assertion around the existing refreshable widget fixture and reran the focused tests successfully.
- `git diff --stat 00ac580fb85bfa5fec988455854c3811fef5146a..fc7b2999534d4c54dfedb995f3753c7257873910`
- `git diff --name-only 00ac580fb85bfa5fec988455854c3811fef5146a..fc7b2999534d4c54dfedb995f3753c7257873910`
- <code>`pnpm vitest run tests/widget-host.test.tsx tests/contracts-types.test.ts` (initially exposed the empty-suite test harness issue)</code>
- <code>Test-only fix in `tests/contracts-types.test.ts` to add a real Vitest assertion for the existing refreshable widget fixture</code>
- `pnpm vitest run tests/widget-host.test.tsx tests/contracts-types.test.ts`
- `pnpm vitest run tests/widget-host.test.tsx -t "ignores runtime widget exports without refresh callbacks" --reporter=verbose`
- <code>Attempted `pnpm exec tsx --eval ...` for a direct runtime filtering transcript, but `tsx` is not installed in this repo; used the focused Vitest selector instead</code>
- <code>Started renderer with `pnpm exec vite --host 127.0.0.1 --port 5173` from `src/renderer`</code>
- <code>Opened `http://127.0.0.1:5173` with `chrome-devtools-axi`, captured `popover-cursor-surface.png`, filled the composer, and evaluated computed cursors for root, shell, widget text, login button, refresh button, textarea, and enabled send button</code>

**Round 2** (auto-fix) - passed ✅
- `pnpm vitest run tests/widget-host.test.tsx tests/contracts-types.test.ts`
- `pnpm vitest run tests/renderer-widget-host.test.tsx tests/widget-host.test.tsx tests/contracts-types.test.ts`
- <code>`pnpm exec vite --host 127.0.0.1 --port 5173` from `src/renderer`, then opened `http://127.0.0.1:5173` with `chrome-devtools-axi open`</code>
- <code>`chrome-devtools-axi resize 420 760` and `chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNCS4JET9H13JQCXBM78QSG/popover-renderer-cursors.png`</code>
- <code>`chrome-devtools-axi eval &#34;() =&gt; { ... getComputedStyle(...).cursor ... }&#34;` to verify actual cursor styles on the rendered popover</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `extensions/AGENTS.md:34` - The widget authoring contract now rejects runtime widget exports that declare `refreshIntervalMs` without a `refresh` callback, and the type moved `refreshIntervalMs` off `BabyMenuWidget` onto the refreshable branch. This extension authoring doc still only says to export `RefreshableBabyMenuWidget` or `BabyMenuWidget`, so agents have no documented guidance that periodic updates must use `RefreshableBabyMenuWidget` with both `refresh` and `refreshIntervalMs`, while plain `BabyMenuWidget` must not declare an interval.
- ℹ️ `.agents/skills/baby-menu-design/README.md:185` - The renderer now defines native-feel cursor behavior: default arrow on the popover, text cursor only for editable fields, pointer on buttons/links, and not-allowed on disabled controls. The design system&#39;s interaction states section documents hover, press, focus, disabled, and composer focus states but does not document the cursor rules, leaving the design guidance stale relative to the implemented macOS-native cursor behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
