### PR TITLE
feat(ui): add shared design system for widgets

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -146,7 +146,10 @@ Scale stays compact but readable: `--fs-xxs` / `text-xxs` **11px**, `xs` **12px*
 
 ### Spacing
 
-A 2px base scale: `2 / 4 / 6 / 8 / 12 / 16 / 20 / 24 / 32`. The popover lives on a 12–14px outer padding. Widgets are separated by `1px dashed` dividers, not gutters, so the surface reads as a continuous log rather than separate cards.
+The app-shell and prototype token files use a 2px base scale: `2 / 4 / 6 / 8 / 12 / 16 / 20 / 24 / 32`.
+Widget authors using the shared Tailwind path should use normal Tailwind spacing utilities with the Baby Menu color and type tokens, not custom `--space-*` values.
+The popover lives on a 12–14px outer padding.
+Widgets are separated by `1px dashed` dividers, not gutters, so the surface reads as a continuous log rather than separate cards.
 
 ### Background
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -196,7 +196,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 - Width is fixed at **360px**, **400px max**. Never less than 320px.
 - **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header, composer, and SessionBar stay pinned.
-- The **composer** is always pinned to the bottom.
+- The **composer** is pinned to the bottom on the main menu and agent surface; it is hidden while the settings view is open.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
 - The **RunStrip** is pinned just above the composer **only while** an agent run is in flight, and it replaces any SessionBar that might otherwise be shown.
 - The popover never has horizontal scroll. Long file paths and names truncate with ellipsis.

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -65,7 +65,7 @@ Baby Menu copy is **terse, lowercase, second-person, present-tense**. It sounds 
 - **Tracked-caps for keys.** Anything that classifies - widget key (`CLAUDE · WEEKLY`), source (`OAUTH`, `CLI`, `WEB`, `MOCK`), occasional status word - is rendered uppercase with `0.18em` letter-spacing at 11px minimum. This is the workhorse heading of the entire system.
 - **Address the user as "you"; address the agent as "the agent"** (never "I", "we", or "Claude").
 - **No emoji.** Status is a small glowing mint dot + one tracked-caps word. Live UI dots are 6px in shared components and 8px in RunStrip/SessionBar controls. Never `🟢` or `✅`.
-- **Use ASCII glyphs as iconography.** `›` for prompt, `⟳` for refresh, `+` for add, `·` for separator, `↵` `⌘` for shortcuts. Lucide is the fallback when an ASCII glyph won't read.
+- **Use ASCII glyphs as iconography.** `›` for prompt, `+` for add, `·` for separator, `↵` `⌘` for shortcuts. Lucide is used when an ASCII glyph won't read, including the compact refresh control.
 - **Plain dashes, not em dashes.** (From `AGENTS.md`. Honor it in copy.)
 - **Numbers are confident, units are quiet.** `72%` is 32px / weight 300; `last sync 12:04` is 11px / 48% ink.
 
@@ -134,7 +134,8 @@ The palette is **near-black + white-at-alpha + one mint signal**. Inspect `src/u
 - **Background** is layered near-black: `--bg-void` `#060607` (outside the popover), `--bg-stage` `#0B0B0C` (popover canvas), `--bg-surface` `#101012` (modules in preview cards), `--bg-elevated` `#16161A` (composer field, hover). **Never use `#000` directly** — pure black reads as missing pixels against the macOS desktop.
 - **Ink** is white at progressively lower alpha — `0.96 / 0.86 / 0.65 / 0.48 / 0.34 / 0.22 / 0.12 / 0.07`. The alpha is part of the system; never write `color: #FFF` directly. Use `rgba(255,255,255,…)` or the `--ink-*` tokens.
 - **Signal — mint** (`--signal-live` `#6AE3B6`) is the *only* accent. Used as a 5–8px dot with a soft glow, as a single tracked-caps word, or as a 1px progress fill. Never as a button fill, never as a background of more than 10% alpha. This restraint is the entire point.
-- **Pending** is amber (`--signal-pending` `#FFD86B`) and **error** is coral (`--signal-error` `#FF6A7A`). Both follow the same rules as mint — dot + word, never a fill.
+- **Warning** is amber and **danger** is coral. Production Tailwind uses `--color-signal-warn` / `text-signal-warn` and `--color-signal-danger` / `text-signal-danger`; prototype/app-shell CSS also exposes `--signal-pending` and `--signal-error`.
+  Both follow the same rules as mint - dot + word, never a fill.
 - **No blue, no purple, no orange.** A "second accent" would weaken the system. If a status needs more weight than mint, use a louder mint dot, not a different color.
 
 ### Typography
@@ -191,7 +192,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 ### Interaction states
 
 - **Hover** on text-button: background fades to `--bg-elevated`, border to `--ink-600`, text to `--ink-100` over 160ms.
-- **Hover** on refresh glyph or text-link affordance: color shifts to `--signal-live`.
+- **Hover** on refresh icon or text-link affordance: color shifts to `--signal-live`.
 - **Press** (`:active`): background drops to `--bg-pressed`. No translate, no shrink — keep the surface still.
 - **Focus** (keyboard): `--focus-ring` 1px solid mint + 4px mint glow. Same rule for everything.
 - **Disabled**: `opacity: 0.32`. No filter, no grayscale.
@@ -211,7 +212,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 A widget is a vertical stack inside the popover body, separated from its neighbors by a `1px dashed` divider — *not* a contained card. Top to bottom:
 
-1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left, refresh glyph on the right.
+1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left, compact Lucide `RefreshCw` icon on the right when refresh is available.
 2. **Value row** — the big number (weight 300, 28–36px, tabular numerals, tight tracking) with the unit at small. Optional status word on the right.
 3. **Progress** — a 1px line at `--ink-800` with a `--signal-live` fill plus a 3×5px head at the tip, like a tiny scanline. Optional.
 4. **Foot row** - 11px ink-faint meta on the left (timestamp), an uppercase source tag on the right (`OAUTH`, `CLI`, etc).
@@ -224,8 +225,8 @@ Widgets do **not** have backgrounds, borders, shadows, or padding-as-containers.
 
 Type is the iconography. The system leans on **ASCII glyphs** and **tracked-caps words** instead of a drawn icon set.
 
-1. **ASCII first.** `›` is the prompt and the menu-affordance pointer. `⟳` is refresh. `+` is add. `·` is separator. `↵` and `⌘` appear in shortcut hints. `●` is a status dot. These read crisp at any size because they are real characters in the body font (JetBrains Mono).
-2. **Lucide as fallback.** When an ASCII glyph won't carry a meaning, use [Lucide](https://lucide.dev) at **14×14** in compact controls and **16×16** in roomier controls, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
+1. **ASCII first.** `›` is the prompt and the menu-affordance pointer. `+` is add. `·` is separator. `↵` and `⌘` appear in shortcut hints. `●` is a status dot. These read crisp at any size because they are real characters in the body font (JetBrains Mono).
+2. **Lucide for compact controls.** Use [Lucide](https://lucide.dev) when ASCII won't carry a meaning, including `RefreshCw` for widget refresh. Use **14×14** in compact controls and **16×16** in roomier controls, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
 3. **No emoji as UI.** No `🟢 / ✅ / ⚠️ / 🚫`. Status is the mint dot + word.
 4. **No custom hand-drawn SVG.** The tray glyph is the wordmark's `b` rendered as a template PNG by `src/main/tray.ts`.
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -62,12 +62,12 @@ Baby Menu copy is **terse, lowercase, second-person, present-tense**. It sounds 
 ### Voice rules
 
 - **Lowercase by default.** UI strings stay lowercase unless they're a proper noun, an identifier, or a button label (which is sentence-case-with-no-period). The wordmark is `baby_menu`.
-- **Tracked-caps for keys.** Anything that classifies — widget key (`CLAUDE · WEEKLY`), source (`OAUTH`, `CLI`, `WEB`, `MOCK`), occasional status word — is rendered uppercase with `0.18em` letter-spacing at 10–11px. This is the workhorse heading of the entire system.
+- **Tracked-caps for keys.** Anything that classifies - widget key (`CLAUDE · WEEKLY`), source (`OAUTH`, `CLI`, `WEB`, `MOCK`), occasional status word - is rendered uppercase with `0.18em` letter-spacing at 11px minimum. This is the workhorse heading of the entire system.
 - **Address the user as "you"; address the agent as "the agent"** (never "I", "we", or "Claude").
 - **No emoji.** Status is a 5px glowing mint dot + one tracked-caps word. Never `🟢` or `✅`.
 - **Use ASCII glyphs as iconography.** `›` for prompt, `⟳` for refresh, `+` for add, `·` for separator, `↵` `⌘` for shortcuts. Lucide (16px, stroke 1.5) is the fallback when an ASCII glyph won't read.
 - **Plain dashes, not em dashes.** (From `AGENTS.md`. Honor it in copy.)
-- **Numbers are confident, units are quiet.** `72%` is 32px / weight 300; `last sync 12:04` is 10px / 48% ink.
+- **Numbers are confident, units are quiet.** `72%` is 32px / weight 300; `last sync 12:04` is 11px / 48% ink.
 
 ### Tone
 
@@ -156,7 +156,7 @@ There are no background images, no full-bleed photography, no illustrations. Ima
 
 ### Borders, radius, dividers
 
-- **Outer popover** radius: **10px** (`--radius-xl`). Sharper than most macOS native windows — this is intentional terminal posture.
+- **Outer popover** radius: **10px** (`--radius-xl`). Sharper than most macOS native windows - this is intentional terminal posture.
 - **Modules / cards** inside preview surfaces: **8px** (`--radius-lg`).
 - **Inputs**: **4px** (`--radius-sm`).
 - **Buttons**: full pill (`999px`). The only rounded affordance.
@@ -211,7 +211,7 @@ A widget is a vertical stack inside the popover body, separated from its neighbo
 1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left, refresh glyph on the right.
 2. **Value row** — the big number (weight 300, 28–36px, tabular numerals, tight tracking) with the unit at small. Optional status word on the right.
 3. **Progress** — a 1px line at `--ink-800` with a `--signal-live` fill plus a 3×5px head at the tip, like a tiny scanline. Optional.
-4. **Foot row** — 10px ink-faint meta on the left (timestamp), an uppercase source tag on the right (`OAUTH`, `CLI`, etc).
+4. **Foot row** - 11px ink-faint meta on the left (timestamp), an uppercase source tag on the right (`OAUTH`, `CLI`, etc).
 
 Widgets do **not** have backgrounds, borders, shadows, or padding-as-containers. They use the popover canvas directly and rely on dividers for separation.
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -8,7 +8,7 @@ The visual direction is **Monochrome Lab** — terminal-elegant, near-black, mon
 
 ## What Baby Menu is
 
-Baby Menu is a tray-popover OS-level utility built around a single moving surface: the user looks at and uses the widgets the agent has built, and the agent is one slim prompt away at the bottom of the main menu. There is no build-mode toggle, no separate "build" view, no chat panel. The composer is *the* affordance for talking to the agent in the main surface, and it sits there permanently - a single line of mono type with a `›` prompt prefix. The settings view is the exception: it replaces the body and composer while open.
+Baby Menu is a tray-popover OS-level utility built around a single moving surface: the user looks at and uses the widgets the agent has built, and the agent is one slim prompt away at the bottom of the main menu. There is no build-mode toggle, no separate "build" view, no chat panel. The composer is *the* affordance for talking to the agent in the main surface, and it sits there when idle - a single line of mono type with a `›` prompt prefix. The exceptions are the settings view, which replaces the body and composer while open, and an in-flight agent run, where the RunStrip replaces the composer until the run finishes.
 
 When the user sends a request, the composer momentarily becomes a `RunStrip`: a single live affordance with a pulsing mint dot, the agent's current step, and an elapsed timer. **No log, no step history.** When the agent finishes, a `SessionBar` slides in with a plain-language summary of what was added (`Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. The user never sees commit SHAs, file counts, or the word "git" — those are infrastructure they shouldn't have to think about.
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -142,7 +142,7 @@ The palette is **near-black + white-at-alpha + one mint signal**. Inspect `src/u
 - **Mono** — `JetBrains Mono`, 300 / 400 / 500 / 600. Used for *everything* in the popover surface — body, labels, values, buttons, error messages. Weight 300 is reserved for big numbers; 400 for body; 500 for buttons and titles.
 - **Prose** — `Inter Tight`, 300 / 400 / 500. Used ONLY in long-form explanatory copy (e.g. this README, preview-card notes). Never inside the popover surface itself. Opt in via `.prose`.
 
-Scale stays compact but readable: `--fs-xxs` / `text-xxs` **11px**, `xs` **12px**, `sm` **13px**, `base` **14px**, `md` **16px**, with hero values **28–36px**. Tabular numerals are on by default (`font-feature-settings: "tnum"`) so columns of values align.
+Scale stays compact but readable: `--fs-xxs` / `text-xxs` **11px**, `xs` **12px**, `sm` **13px**, `base` **14px**, `md` **16px**, with hero values **28–36px**. Tabular numerals are on by default (`font-feature-settings: "tnum"`) so columns of values align. The app-shell CSS still uses a few 10px legacy meta treatments for dense widget keys, foot rows, run timers, and SessionBar hints; do not use those as the default widget type scale.
 
 ### Spacing
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -27,6 +27,9 @@ Key files referenced (paths in that repo):
 - `AGENTS.md` — architecture, three-process split, source-vs-packaged change-session invariants, recipe conventions.
 - `src/renderer/styles.css` — the original warm-paper palette (now replaced by this system's monochrome direction).
 - `src/renderer/App.tsx`, `src/renderer/agent/AgentChat.tsx`, `src/renderer/menu/MenuSurface.tsx`, `src/renderer/menu/WidgetHost.tsx` — the components being redesigned here.
+- `src/ui/` — the shared `@babymenu/ui` component kit used by the app shell and extension widgets.
+- `src/ui/theme.css` — the Tailwind `@theme` token source consumed by the renderer and per-widget CSS compiler.
+- `src/shared/ui-exports.ts` — the public export contract for the host-provided design-system surface.
 - `src/shared/contracts.ts` — `BabyMenuWidget`, `RefreshableBabyMenuWidget`, `GitSessionSnapshot`, `AgentChatResult` — the data contracts our redesign remains compatible with.
 - `extensions/hello-world/widget.tsx` — the first-run greeting widget and starter example of widget shape.
 - `extensions/recipes/*.html` — daisyUI/Tailwind "wireframe" recipe docs. Note: recipes use a separate visual system and should not bleed into popover designs.

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -25,7 +25,7 @@ This system was built from the live codebase at:
 Key files referenced (paths in that repo):
 
 - `AGENTS.md` — architecture, three-process split, source-vs-packaged change-session invariants, recipe conventions.
-- `src/renderer/styles.css` — the original warm-paper palette (now replaced by this system's monochrome direction).
+- `src/renderer/styles.css` — the live Monochrome Lab popover shell and app-surface styling.
 - `src/renderer/App.tsx`, `src/renderer/agent/AgentChat.tsx`, `src/renderer/menu/MenuSurface.tsx`, `src/renderer/menu/WidgetHost.tsx` — the components being redesigned here.
 - `src/ui/` — the shared `@babymenu/ui` component kit used by the app shell and extension widgets.
 - `src/ui/theme.css` — the Tailwind `@theme` token source consumed by the renderer and per-widget CSS compiler.
@@ -64,8 +64,8 @@ Baby Menu copy is **terse, lowercase, second-person, present-tense**. It sounds 
 - **Lowercase by default.** UI strings stay lowercase unless they're a proper noun, an identifier, or a button label (which is sentence-case-with-no-period). The wordmark is `baby_menu`.
 - **Tracked-caps for keys.** Anything that classifies - widget key (`CLAUDE · WEEKLY`), source (`OAUTH`, `CLI`, `WEB`, `MOCK`), occasional status word - is rendered uppercase with `0.18em` letter-spacing at 11px minimum. This is the workhorse heading of the entire system.
 - **Address the user as "you"; address the agent as "the agent"** (never "I", "we", or "Claude").
-- **No emoji.** Status is a 5px glowing mint dot + one tracked-caps word. Never `🟢` or `✅`.
-- **Use ASCII glyphs as iconography.** `›` for prompt, `⟳` for refresh, `+` for add, `·` for separator, `↵` `⌘` for shortcuts. Lucide (16px, stroke 1.5) is the fallback when an ASCII glyph won't read.
+- **No emoji.** Status is a small glowing mint dot + one tracked-caps word. Live UI dots are 6px in shared components and 8px in RunStrip/SessionBar controls. Never `🟢` or `✅`.
+- **Use ASCII glyphs as iconography.** `›` for prompt, `⟳` for refresh, `+` for add, `·` for separator, `↵` `⌘` for shortcuts. Lucide is the fallback when an ASCII glyph won't read.
 - **Plain dashes, not em dashes.** (From `AGENTS.md`. Honor it in copy.)
 - **Numbers are confident, units are quiet.** `72%` is 32px / weight 300; `last sync 12:04` is 11px / 48% ink.
 
@@ -200,7 +200,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 ### Layout rules
 
-- Width is fixed at **360px**, **400px max**. Never less than 320px.
+- Width is fixed at **360px** in the live popover. Do not design responsive popover widths unless the runtime sizing code changes.
 - **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header and active agent-control surface stay pinned.
 - The **composer** is pinned to the bottom on the main menu and idle agent surface; it is hidden while the settings view is open and replaced by the RunStrip while an agent run is in flight.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
@@ -225,7 +225,7 @@ Widgets do **not** have backgrounds, borders, shadows, or padding-as-containers.
 Type is the iconography. The system leans on **ASCII glyphs** and **tracked-caps words** instead of a drawn icon set.
 
 1. **ASCII first.** `›` is the prompt and the menu-affordance pointer. `⟳` is refresh. `+` is add. `·` is separator. `↵` and `⌘` appear in shortcut hints. `●` is a status dot. These read crisp at any size because they are real characters in the body font (JetBrains Mono).
-2. **Lucide as fallback.** When an ASCII glyph won't carry a meaning, use [Lucide](https://lucide.dev) at **16×16**, stroke width **1.5**, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
+2. **Lucide as fallback.** When an ASCII glyph won't carry a meaning, use [Lucide](https://lucide.dev) at **14×14** in compact controls and **16×16** in roomier controls, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
 3. **No emoji as UI.** No `🟢 / ✅ / ⚠️ / 🚫`. Status is the mint dot + word.
 4. **No custom hand-drawn SVG.** The tray glyph is the wordmark's `b` rendered as a template PNG by `src/main/tray.ts`.
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -8,11 +8,11 @@ The visual direction is **Monochrome Lab** — terminal-elegant, near-black, mon
 
 ## What Baby Menu is
 
-Baby Menu is a tray-popover OS-level utility built around a single moving surface: the user looks at and uses the widgets the agent has built, and the agent is always one slim prompt away at the bottom. There is no mode toggle, no separate "build" view, no chat panel. The composer is *the* affordance for talking to the agent, and it sits there permanently — a single line of mono type with a `›` prompt prefix.
+Baby Menu is a tray-popover OS-level utility built around a single moving surface: the user looks at and uses the widgets the agent has built, and the agent is one slim prompt away at the bottom of the main menu. There is no build-mode toggle, no separate "build" view, no chat panel. The composer is *the* affordance for talking to the agent in the main surface, and it sits there permanently - a single line of mono type with a `›` prompt prefix. The settings view is the exception: it replaces the body and composer while open.
 
 When the user sends a request, the composer momentarily becomes a `RunStrip`: a single live affordance with a pulsing mint dot, the agent's current step, and an elapsed timer. **No log, no step history.** When the agent finishes, a `SessionBar` slides in with a plain-language summary of what was added (`Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. The user never sees commit SHAs, file counts, or the word "git" — those are infrastructure they shouldn't have to think about.
 
-The popover surface is dynamic-height. The composer is always pinned to the bottom; everything above it stacks and grows.
+The popover surface is dynamic-height. On the main menu, the composer is pinned to the bottom; everything above it stacks and grows.
 
 ---
 
@@ -139,7 +139,7 @@ The palette is **near-black + white-at-alpha + one mint signal**. Inspect `color
 - **Mono** — `JetBrains Mono`, 300 / 400 / 500 / 600. Used for *everything* in the popover surface — body, labels, values, buttons, error messages. Weight 300 is reserved for big numbers; 400 for body; 500 for buttons and titles.
 - **Prose** — `Inter Tight`, 300 / 400 / 500. Used ONLY in long-form explanatory copy (e.g. this README, preview-card notes). Never inside the popover surface itself. Opt in via `.prose`.
 
-Scale stays small. Body **12–13px**, caption **11px**, tracked-caps key **10px**, hero value **28–36px**. Tabular numerals are on by default (`font-feature-settings: "tnum"`) so columns of values align.
+Scale stays compact but readable: `--fs-xxs` / `text-xxs` **11px**, `xs` **12px**, `sm` **13px**, `base` **14px**, `md` **16px**, with hero values **28–36px**. Tabular numerals are on by default (`font-feature-settings: "tnum"`) so columns of values align.
 
 ### Spacing
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -201,10 +201,10 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 ### Layout rules
 
 - Width is fixed at **360px**, **400px max**. Never less than 320px.
-- **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header, composer, and SessionBar stay pinned.
-- The **composer** is pinned to the bottom on the main menu and agent surface; it is hidden while the settings view is open.
+- **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header and active agent-control surface stay pinned.
+- The **composer** is pinned to the bottom on the main menu and idle agent surface; it is hidden while the settings view is open and replaced by the RunStrip while an agent run is in flight.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
-- The **RunStrip** is pinned just above the composer **only while** an agent run is in flight, and it replaces any SessionBar that might otherwise be shown.
+- The **RunStrip** is pinned at the bottom **only while** an agent run is in flight, and it replaces both the composer and any SessionBar that might otherwise be shown.
 - The popover never has horizontal scroll. Long file paths and names truncate with ellipsis.
 
 ### Card anatomy (widget)

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -43,7 +43,7 @@ Key files referenced (paths in that repo):
 | Path | What |
 | --- | --- |
 | `README.md` | This document. Start here. |
-| `colors_and_type.css` | The token source of truth — colors, type, spacing, radius, shadow, motion. Import this. |
+| `colors_and_type.css` | Prototype and app-shell token reference — colors, type, spacing, radius, shadow, motion. Production widgets use `src/ui/theme.css` through `@babymenu/ui` and compiled Tailwind. |
 | `SKILL.md` | Agent-skill manifest. Same folder can be dropped into a Claude Code Skills directory. |
 | `preview/` | Small HTML cards that render in the Design System tab. Type specimens, color swatches, components. |
 | `ui_kits/popup-menu/` | The redesigned tray popover. `index.html` is a clickable prototype; JSX files are the components. See [`ui_kits/popup-menu/README.md`](./ui_kits/popup-menu/README.md). |
@@ -129,7 +129,7 @@ Everything in the system aims for one feeling: **a calm command-line surface tha
 
 ### Color
 
-The palette is **near-black + white-at-alpha + one mint signal**. Inspect `colors_and_type.css` for the source of truth.
+The palette is **near-black + white-at-alpha + one mint signal**. Inspect `src/ui/theme.css` for the live Tailwind token source and `colors_and_type.css` for prototype/app-shell CSS tokens.
 
 - **Background** is layered near-black: `--bg-void` `#060607` (outside the popover), `--bg-stage` `#0B0B0C` (popover canvas), `--bg-surface` `#101012` (modules in preview cards), `--bg-elevated` `#16161A` (composer field, hover). **Never use `#000` directly** — pure black reads as missing pixels against the macOS desktop.
 - **Ink** is white at progressively lower alpha — `0.96 / 0.86 / 0.65 / 0.48 / 0.34 / 0.22 / 0.12 / 0.07`. The alpha is part of the system; never write `color: #FFF` directly. Use `rgba(255,255,255,…)` or the `--ink-*` tokens.
@@ -249,5 +249,5 @@ A designer or agent picking this up:
 1. Read this README top to bottom.
 2. Open the Design System tab to flip through every token as a card.
 3. Open `ui_kits/popup-menu/index.html` to see the popover live as a clickable prototype.
-4. Cross-reference `colors_and_type.css` whenever picking a value — never invent a new color.
+4. Cross-reference `src/ui/theme.css` for production widget values and `colors_and_type.css` for prototype values - never invent a new color.
 5. Cross-reference the [live repo](https://github.com/kunchenguid/baby-menu) for ground truth on data shapes (`src/shared/contracts.ts`) and on extension/widget conventions (`extensions/AGENTS.md`).

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -162,7 +162,7 @@ There are no background images, no full-bleed photography, no illustrations. Ima
 - **Outer popover** radius: **10px** (`--radius-xl`). Sharper than most macOS native windows - this is intentional terminal posture.
 - **Modules / cards** inside preview surfaces: **8px** (`--radius-lg`).
 - **Inputs**: **4px** (`--radius-sm`).
-- **Buttons**: full pill (`999px`). The only rounded affordance.
+- **Buttons**: shared production buttons use compact `--radius-sm` corners. Prototype/app-shell pill controls are allowed for tight terminal affordances, but do not assume pill shape for `@babymenu/ui` buttons.
 - **Borders** are 1px white at low alpha (`--line` `12%`, `--line-faint` `7%`). Inside the popover, the only borders are the outer 1px and the divider between head/body/composer.
 - **Dividers** between widgets: `1px dashed --line-faint`. Between popover sections (head, body, composer): `1px solid --line`. The shift from solid to dashed signals "infrastructure" vs "content".
 

--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -195,7 +195,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 ### Layout rules
 
 - Width is fixed at **360px**, **400px max**. Never less than 320px.
-- **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. When the widget host would exceed 360px, it scrolls internally; the composer and SessionBar stay sticky at the bottom.
+- **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header, composer, and SessionBar stay pinned.
 - The **composer** is always pinned to the bottom.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
 - The **RunStrip** is pinned just above the composer **only while** an agent run is in flight, and it replaces any SessionBar that might otherwise be shown.
@@ -219,7 +219,7 @@ Widgets do **not** have backgrounds, borders, shadows, or padding-as-containers.
 Type is the iconography. The system leans on **ASCII glyphs** and **tracked-caps words** instead of a drawn icon set.
 
 1. **ASCII first.** `›` is the prompt and the menu-affordance pointer. `⟳` is refresh. `+` is add. `·` is separator. `↵` and `⌘` appear in shortcut hints. `●` is a status dot. These read crisp at any size because they are real characters in the body font (JetBrains Mono).
-2. **Lucide as fallback.** When an ASCII glyph won't carry a meaning, use [Lucide](https://lucide.dev) at **16×16**, stroke width **1.5**, color `currentColor`. Lucide is the closest visual match — slightly soft, geometric, monoline — and is CDN-loadable. *Flagged substitution*: Lucide is not currently bundled with the live codebase.
+2. **Lucide as fallback.** When an ASCII glyph won't carry a meaning, use [Lucide](https://lucide.dev) at **16×16**, stroke width **1.5**, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
 3. **No emoji as UI.** No `🟢 / ✅ / ⚠️ / 🚫`. Status is the mint dot + word.
 4. **No custom hand-drawn SVG.** The tray glyph is the wordmark's `b` rendered as a template PNG by `src/main/tray.ts`.
 

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -13,7 +13,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 ## What's here
 
 - `README.md` — full brand brief: product context, content fundamentals, visual foundations, iconography.
-- `colors_and_type.css` — token source of truth. Always import this. Never invent new tokens; if you need a color or size that isn't in this file, add it here first.
+- `colors_and_type.css` — prototype and app-shell token reference. For production widgets, use `@babymenu/ui` and the live Tailwind tokens in `src/ui/theme.css`; never invent new tokens without updating the relevant source first.
 - `preview/` — small HTML cards that document each token / component visually.
 - `ui_kits/popup-menu/` — the canonical UI kit: a clickable recreation of the redesigned tray popover with `MenuBar`, `Composer`, `RunStrip`, `SessionBar`, `WidgetHost` and three sample widgets.
 

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -19,7 +19,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 ## The direction in one paragraph
 
-**Monochrome Lab.** Near-black canvas (`#0B0B0C`), white type at varying alpha, JetBrains Mono everywhere, one mint signal color (`#6AE3B6`). The popover reads as a calm command-line surface. No gradients, no emoji, no second accent. Status is a 5px glowing dot plus one tracked-caps word.
+**Monochrome Lab.** Near-black canvas (`#0B0B0C`), white type at varying alpha, JetBrains Mono everywhere, one mint signal color (`#6AE3B6`). The popover reads as a calm command-line surface. No gradients, no emoji, no second accent. Status is a small glowing dot plus one tracked-caps word, 6px in shared components and 8px in RunStrip/SessionBar controls.
 
 ## Hard rules
 
@@ -28,7 +28,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 3. **No build-mode toggle.** On the main menu, the composer is one slim row pinned to the bottom of the popover and always visible. It auto-grows to a second line when the user types more. The settings view replaces the composer while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.
 5. **No emoji as UI.** No gradients. Status is color + word (rarely needed — usually only on the SessionBar's leading dot).
-6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide @ 16px / 1.5 stroke is the fallback if an ASCII glyph won't carry the meaning.
+6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide is the fallback if an ASCII glyph won't carry the meaning; use 14px in compact controls and 16px in roomier controls.
 7. **JetBrains Mono everywhere** inside the popover surface. Inter Tight only for long prose outside the surface.
 8. **Mint is the only signal color** and is used ONLY as a dot, glow, single word, or 1px progress fill — never as a button fill, never as a background of more than 10% alpha.
 9. Buttons are pill-shaped. Primary is **inverse white** (`--ink-100` on near-black). Default is transparent with a 1px hairline border. Destructive is coral outline.

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -31,7 +31,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide is the fallback if an ASCII glyph won't carry the meaning; use 14px in compact controls and 16px in roomier controls.
 7. **JetBrains Mono everywhere** inside the popover surface. Inter Tight only for long prose outside the surface.
 8. **Mint is the only signal color** and is used ONLY as a dot, glow, single word, or 1px progress fill — never as a button fill, never as a background of more than 10% alpha.
-9. Buttons are pill-shaped. Primary is **inverse white** (`--ink-100` on near-black). Default is transparent with a 1px hairline border. Destructive is coral outline.
+9. Production `@babymenu/ui` buttons use compact `rounded-sm` corners. Primary is **inverse white** (`--ink-100` on near-black). Default is transparent with a 1px hairline border. Destructive is coral outline. Reserve pill buttons for prototype/app-shell affordances where the design brief calls for them.
 
 ## Reference repo
 

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -25,7 +25,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 1. Baby Menu is a **macOS tray popover**, 360px wide, dynamic-height. Never design for a full browser window.
 2. **The agent's work is not a chat.** No transcript, no bubbles, no history. Use the `RunStrip` pattern: one live affordance (pulsing mint dot + current step + timer), replaced by a `SessionBar` when done.
-3. **No mode toggle.** The composer is one slim row pinned to the bottom of the popover, always visible. It auto-grows to a second line when the user types more.
+3. **No build-mode toggle.** On the main menu, the composer is one slim row pinned to the bottom of the popover and always visible. It auto-grows to a second line when the user types more. The settings view replaces the composer while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.
 5. **No emoji as UI.** No gradients. Status is color + word (rarely needed — usually only on the SessionBar's leading dot).
 6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide @ 16px / 1.5 stroke is the fallback if an ASCII glyph won't carry the meaning.

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -28,7 +28,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 3. **No build-mode toggle.** On the main idle surface, the composer is one slim row pinned to the bottom of the popover. It auto-grows to a second line when the user types more. During an active agent run, `RunStrip` replaces the composer; the settings view also replaces it while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.
 5. **No emoji as UI.** No gradients. Status is color + word (rarely needed — usually only on the SessionBar's leading dot).
-6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide is the fallback if an ASCII glyph won't carry the meaning; use 14px in compact controls and 16px in roomier controls.
+6. **Type and ASCII glyphs are the iconography.** `›` `+` `·` `↵` `⌘` `●`. Lucide is used when ASCII won't carry the meaning, including `RefreshCw` for widget refresh; use 14px in compact controls and 16px in roomier controls.
 7. **JetBrains Mono everywhere** inside the popover surface. Inter Tight only for long prose outside the surface.
 8. **Mint is the only signal color** and is used ONLY as a dot, glow, single word, or 1px progress fill — never as a button fill, never as a background of more than 10% alpha.
 9. Production `@babymenu/ui` buttons use compact `rounded-sm` corners. Primary is **inverse white** (`--ink-100` on near-black). Default is transparent with a 1px hairline border. Destructive is coral outline. Reserve pill buttons for prototype/app-shell affordances where the design brief calls for them.

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -25,7 +25,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 1. Baby Menu is a **macOS tray popover**, 360px wide, dynamic-height. Never design for a full browser window.
 2. **The agent's work is not a chat.** No transcript, no bubbles, no history. Use the `RunStrip` pattern: one live affordance (pulsing mint dot + current step + timer), replaced by a `SessionBar` when done.
-3. **No build-mode toggle.** On the main menu, the composer is one slim row pinned to the bottom of the popover and always visible. It auto-grows to a second line when the user types more. The settings view replaces the composer while open.
+3. **No build-mode toggle.** On the main idle surface, the composer is one slim row pinned to the bottom of the popover. It auto-grows to a second line when the user types more. During an active agent run, `RunStrip` replaces the composer; the settings view also replaces it while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.
 5. **No emoji as UI.** No gradients. Status is color + word (rarely needed — usually only on the SessionBar's leading dot).
 6. **Type and ASCII glyphs are the iconography.** `›` `⟳` `+` `·` `↵` `⌘` `●`. Lucide is the fallback if an ASCII glyph won't carry the meaning; use 14px in compact controls and 16px in roomier controls.

--- a/.agents/skills/baby-menu-design/colors_and_type.css
+++ b/.agents/skills/baby-menu-design/colors_and_type.css
@@ -133,7 +133,7 @@
   --radius-md:  6px;
   --radius-lg:  8px;        /* card / module                       */
   --radius-xl:  10px;       /* popover outer                       */
-  --radius-pill: 999px;     /* the *only* rounded affordance       */
+  --radius-pill: 999px;     /* prototype/app-shell pill controls   */
 
   /* Shadows are quiet -- darkness, not depth. The popover floats   */
   /* over the desktop with one deep void cast, never a stack.       */

--- a/.agents/skills/baby-menu-design/colors_and_type.css
+++ b/.agents/skills/baby-menu-design/colors_and_type.css
@@ -88,11 +88,11 @@
 
   /* Scale -- mono runs slightly narrower than sans, so values feel */
   /* smaller for the same px. Numbers are quoted in px equivalents. */
-  --fs-xxs:   0.625rem;     /* 10px  -- tracked-caps keys, footer  */
-  --fs-xs:    0.6875rem;    /* 11px  -- meta, hints, footer        */
-  --fs-sm:    0.75rem;      /* 12px  -- body, button copy          */
-  --fs-base:  0.8125rem;    /* 13px  -- module title, default      */
-  --fs-md:    0.9375rem;    /* 15px  -- subhead                    */
+  --fs-xxs:   0.6875rem;    /* 11px  -- tracked-caps keys, footer  */
+  --fs-xs:    0.75rem;      /* 12px  -- meta, hints, footer        */
+  --fs-sm:    0.8125rem;    /* 13px  -- body, button copy          */
+  --fs-base:  0.875rem;     /* 14px  -- module title, default      */
+  --fs-md:    1rem;         /* 16px  -- subhead                    */
   --fs-lg:    1.125rem;     /* 18px  -- inline value mid           */
   --fs-xl:    1.5rem;       /* 24px  -- inline value lg            */
   --fs-2xl:   1.75rem;      /* 28px  -- hero value                 */

--- a/.agents/skills/baby-menu-design/preview/brand-iconography.html
+++ b/.agents/skills/baby-menu-design/preview/brand-iconography.html
@@ -30,7 +30,6 @@
   <span class="label">iconography · ascii first, lucide fallback</span>
   <div class="row">
     <div class="glyph"><span class="ascii">›</span></div>
-    <div class="glyph"><span class="ascii">⟳</span></div>
     <div class="glyph"><span class="ascii">+</span></div>
     <div class="glyph"><span class="ascii">·</span></div>
     <div class="glyph"><span class="ascii">↵</span></div>
@@ -48,7 +47,7 @@
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
     </div>
   </div>
-  <p class="note">Type and unicode are the iconography. <span style="color:var(--ink-strong)">› ⟳ + · ↵ ⌘ ●</span> cover almost every popover affordance. When a glyph is unavoidable, fall back to <span style="color:var(--ink-strong)">Lucide</span> at 14px in compact controls and 16px in roomier controls, color <span style="color:var(--ink-strong)">currentColor</span>. No emoji ever.</p>
+  <p class="note">Type and unicode are the iconography. <span style="color:var(--ink-strong)">› + · ↵ ⌘ ●</span> cover most popover affordances. Use <span style="color:var(--ink-strong)">Lucide</span> for compact controls that need clearer semantics, including refresh, at 14px in compact controls and 16px in roomier controls, color <span style="color:var(--ink-strong)">currentColor</span>. No emoji ever.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/brand-iconography.html
+++ b/.agents/skills/baby-menu-design/preview/brand-iconography.html
@@ -39,16 +39,16 @@
   </div>
   <div class="row">
     <div class="glyph">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
     </div>
     <div class="glyph">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
     </div>
     <div class="glyph">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
     </div>
   </div>
-  <p class="note">Type and unicode are the iconography. <span style="color:var(--ink-strong)">› ⟳ + · ↵ ⌘ ●</span> cover almost every popover affordance. When a glyph is unavoidable, fall back to <span style="color:var(--ink-strong)">Lucide</span> at 16px, stroke 1.5, color <span style="color:var(--ink-strong)">currentColor</span>. No emoji ever.</p>
+  <p class="note">Type and unicode are the iconography. <span style="color:var(--ink-strong)">› ⟳ + · ↵ ⌘ ●</span> cover almost every popover affordance. When a glyph is unavoidable, fall back to <span style="color:var(--ink-strong)">Lucide</span> at 14px in compact controls and 16px in roomier controls, color <span style="color:var(--ink-strong)">currentColor</span>. No emoji ever.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/brand-popover.html
+++ b/.agents/skills/baby-menu-design/preview/brand-popover.html
@@ -37,7 +37,7 @@
     display: grid; place-items: center;
     color: white;
     font-weight: var(--weight-semi);
-    font-size: 10px;
+    font-size: 11px;
   }
   .popover {
     width: 360px;

--- a/.agents/skills/baby-menu-design/preview/color-accent.html
+++ b/.agents/skills/baby-menu-design/preview/color-accent.html
@@ -35,14 +35,14 @@
   <div class="row">
     <div class="demo">
       <span class="label">running · 3s</span>
-      <div style="display:flex;align-items:center;gap:8px;color:var(--ink-strong);font-size:13px"><span class="dot"></span> editing src/main/ipc.ts</div>
+      <div style="display:flex;align-items:center;gap:8px;color:var(--ink-strong);font-size:13px"><span class="dot"></span> writing the widget</div>
     </div>
     <div class="demo">
-      <span class="label">git change session</span>
-      <div style="display:flex;align-items:center;gap:8px;color:var(--signal-live);font-size:13px"><span class="dot"></span> saved · b8d3a2c</div>
+      <span class="label">latest change</span>
+      <div style="display:flex;align-items:center;gap:8px;color:var(--signal-live);font-size:13px"><span class="dot"></span> kept</div>
     </div>
   </div>
-  <p class="note">Mint is the only signal color. Used as a 5–8px dot with a soft glow, or as a single word at 10px tracked-caps. Never as a button fill, never as a background of more than 10% alpha.</p>
+  <p class="note">Mint is the only signal color. Used as a 5–8px dot with a soft glow, or as a single word at 11px tracked-caps. Never as a button fill, never as a background of more than 10% alpha.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/color-status.html
+++ b/.agents/skills/baby-menu-design/preview/color-status.html
@@ -42,8 +42,8 @@
     </div>
     <div class="demo">
       <div class="status danger">refused</div>
-      <span class="top">working tree dirty</span>
-      <span class="bot">commit or stash before asking</span>
+      <span class="top">finish this change first</span>
+      <span class="bot">keep or undo before asking again</span>
     </div>
   </div>
 </div>

--- a/.agents/skills/baby-menu-design/preview/color-status.html
+++ b/.agents/skills/baby-menu-design/preview/color-status.html
@@ -32,13 +32,13 @@
   <div class="row">
     <div class="demo">
       <div class="status">live</div>
-      <span class="top">saved · b8d3a2c</span>
-      <span class="bot">git change session committed</span>
+      <span class="top">kept</span>
+      <span class="bot">ready for the next request</span>
     </div>
     <div class="demo">
       <div class="status warn">pending</div>
-      <span class="top">3 files modified</span>
-      <span class="bot">save or rollback before next request</span>
+      <span class="top">review needed</span>
+      <span class="bot">keep or undo before the next request</span>
     </div>
     <div class="demo">
       <div class="status danger">refused</div>

--- a/.agents/skills/baby-menu-design/preview/comp-buttons.html
+++ b/.agents/skills/baby-menu-design/preview/comp-buttons.html
@@ -12,7 +12,7 @@
     font-weight: var(--weight-med);
     letter-spacing: 0.02em;
     padding: 6px 14px;
-    border-radius: 999px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--line);
     background: transparent;
     color: var(--ink-200);
@@ -43,7 +43,7 @@
 </head>
 <body>
 <div class="card">
-  <span class="label">buttons · pill is the only roundness · primary = inverse, danger = coral outline</span>
+  <span class="label">buttons · production uses compact corners · primary = inverse, danger = coral outline</span>
   <div class="row">
     <button class="btn-primary">Keep</button>
     <button>Send</button>

--- a/.agents/skills/baby-menu-design/preview/comp-buttons.html
+++ b/.agents/skills/baby-menu-design/preview/comp-buttons.html
@@ -45,16 +45,16 @@
 <div class="card">
   <span class="label">buttons · pill is the only roundness · primary = inverse, danger = coral outline</span>
   <div class="row">
-    <button class="btn-primary">Save</button>
+    <button class="btn-primary">Keep</button>
     <button>Send</button>
-    <button class="btn-danger">Rollback</button>
+    <button class="btn-danger">Undo</button>
     <button class="btn-ghost">Dismiss</button>
     <button disabled>Running</button>
   </div>
   <div class="row">
-    <button class="btn-primary btn-sm">Save</button>
+    <button class="btn-primary btn-sm">Keep</button>
     <button class="btn-sm">Refresh</button>
-    <button class="btn-danger btn-sm">Rollback</button>
+    <button class="btn-danger btn-sm">Undo</button>
     <button class="btn-ghost btn-sm">esc</button>
   </div>
 </div>

--- a/.agents/skills/baby-menu-design/preview/comp-composer.html
+++ b/.agents/skills/baby-menu-design/preview/comp-composer.html
@@ -43,13 +43,13 @@
   .hint {
     display: flex; justify-content: space-between;
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     color: var(--ink-faint);
     letter-spacing: 0.06em;
   }
   .hint kbd {
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     padding: 1px 5px;
     background: var(--bg-elevated);
     border: 1px solid var(--line);
@@ -68,7 +68,7 @@
       <span class="caret"></span>
     </div>
     <div class="hint">
-      <span>git change session begins on send</span>
+      <span>review changes after the agent finishes</span>
       <span><kbd>⌘</kbd> <kbd>↵</kbd> send</span>
     </div>
   </div>

--- a/.agents/skills/baby-menu-design/preview/comp-empty.html
+++ b/.agents/skills/baby-menu-design/preview/comp-empty.html
@@ -27,7 +27,7 @@
   <span class="label">empty state · no widgets · no illustration</span>
   <div class="empty">
     <span class="top">› no widgets</span>
-    <p>switch to build, ask the agent to add one.</p>
+    <p>ask the agent to add one.</p>
     <span class="ex">try: <span style="color:var(--ink-strong)">show my battery</span> · <span style="color:var(--ink-strong)">cpu temp</span> · <span style="color:var(--ink-strong)">remind me to drink water</span></span>
   </div>
 </div>

--- a/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
+++ b/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
@@ -72,7 +72,7 @@
     <span class="send">send</span>
   </div>
 
-  <p class="note">One slim row pinned to the bottom of the popover at all times. Border glows mint when focused. The composer auto-grows to a second line if the user keeps typing, but never reserves vertical space pre-emptively. Recipes (when relevant) appear as a single subtle suggestion inline, not as a chip strip.</p>
+  <p class="note">One slim row pinned to the bottom of the main menu and agent surface; settings replaces the body and hides the composer. Border glows mint when focused. The composer auto-grows to a second line if the user keeps typing, but never reserves vertical space pre-emptively. Recipes (when relevant) appear as a single subtle suggestion inline, not as a chip strip.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
+++ b/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
@@ -72,7 +72,7 @@
     <span class="send">send</span>
   </div>
 
-  <p class="note">One slim row pinned to the bottom of the main menu and agent surface; settings replaces the body and hides the composer. Border glows mint when focused. The composer auto-grows to a second line if the user keeps typing, but never reserves vertical space pre-emptively. Recipes (when relevant) appear as a single subtle suggestion inline, not as a chip strip.</p>
+  <p class="note">One slim row pinned to the bottom of the main menu and idle agent surface; settings replaces the body and hides the composer, and an in-flight run replaces it with the RunStrip. Border glows mint when focused. The composer auto-grows to a second line if the user keeps typing, but never reserves vertical space pre-emptively. Recipes (when relevant) appear as a single subtle suggestion inline, not as a chip strip.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
+++ b/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
@@ -40,7 +40,7 @@
   }
   .wrap .send {
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: var(--weight-med);
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -51,7 +51,7 @@
   @keyframes blink { to { visibility: hidden; } }
 
   .label-row { display: flex; align-items: center; gap: 8px; }
-  .ix { font-family: var(--font-mono); font-size: 10px; color: var(--ink-faint); letter-spacing: 0.14em; text-transform: uppercase; }
+  .ix { font-family: var(--font-mono); font-size: 11px; color: var(--ink-faint); letter-spacing: 0.14em; text-transform: uppercase; }
 </style>
 </head>
 <body>

--- a/.agents/skills/baby-menu-design/preview/comp-pills.html
+++ b/.agents/skills/baby-menu-design/preview/comp-pills.html
@@ -11,7 +11,7 @@
     align-items: center;
     gap: 6px;
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     letter-spacing: 0.18em;
     text-transform: uppercase;
   }
@@ -33,7 +33,7 @@
     align-items: center;
     padding: 2px 7px;
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     letter-spacing: 0.14em;
     text-transform: uppercase;
     color: var(--ink-soft);
@@ -49,8 +49,8 @@
   <span class="label">status chips · dot + word · the only decorated affordance</span>
   <div class="row">
     <span class="chip live">live</span>
-    <span class="chip live">saved · b8d3a2c</span>
-    <span class="chip pending">pending · 3 files</span>
+    <span class="chip live">kept</span>
+    <span class="chip pending">needs review</span>
     <span class="chip danger">refused</span>
     <span class="chip muted">idle</span>
   </div>

--- a/.agents/skills/baby-menu-design/preview/comp-runstrip.html
+++ b/.agents/skills/baby-menu-design/preview/comp-runstrip.html
@@ -46,7 +46,7 @@
     <span class="dot"></span>
     <div class="lines">
       <span class="task">› add cpu temp widget</span>
-      <span class="step">editing src/main/ipc.ts</span>
+      <span class="step">writing the widget</span>
     </div>
     <span class="timer">3.2s</span>
   </div>

--- a/.agents/skills/baby-menu-design/preview/comp-sessionbar.html
+++ b/.agents/skills/baby-menu-design/preview/comp-sessionbar.html
@@ -43,7 +43,7 @@
     font-size: 11px;
     font-weight: var(--weight-med);
     padding: 4px 12px;
-    border-radius: 999px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--line);
     background: transparent;
     color: var(--ink-200);

--- a/.agents/skills/baby-menu-design/preview/comp-sessionbar.html
+++ b/.agents/skills/baby-menu-design/preview/comp-sessionbar.html
@@ -36,7 +36,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
-  .msg .hint { font-size: 10px; color: var(--ink-soft); font-weight: var(--weight-reg); }
+  .msg .hint { font-size: 11px; color: var(--ink-soft); font-weight: var(--weight-reg); }
 
   button {
     font-family: var(--font-mono);

--- a/.agents/skills/baby-menu-design/preview/comp-widget-card.html
+++ b/.agents/skills/baby-menu-design/preview/comp-widget-card.html
@@ -16,9 +16,10 @@
   .widget .key { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-label); }
   .widget .refresh {
     background: transparent; border: 0; cursor: pointer;
-    color: var(--ink-faint); font-family: var(--font-mono); font-size: 11px;
+    color: var(--ink-faint);
     padding: 2px 4px;
   }
+  .widget .refresh svg { display: block; }
   .widget .refresh:hover { color: var(--ink-200); }
   .value-row { display: flex; align-items: baseline; justify-content: space-between; }
   .value-row .value { font-size: 36px; }
@@ -52,7 +53,7 @@
   <div class="widget">
     <div class="head">
       <span class="key">claude · weekly</span>
-      <button class="refresh">⟳</button>
+      <button class="refresh" aria-label="refresh claude weekly"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg></button>
     </div>
     <div class="value-row">
       <span class="value">72<small>%</small></span>

--- a/.agents/skills/baby-menu-design/preview/comp-widget-card.html
+++ b/.agents/skills/baby-menu-design/preview/comp-widget-card.html
@@ -13,7 +13,7 @@
     display: flex; flex-direction: column; gap: 12px;
   }
   .widget .head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-  .widget .key { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-label); }
+  .widget .key { font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-label); }
   .widget .refresh {
     background: transparent; border: 0; cursor: pointer;
     color: var(--ink-faint); font-family: var(--font-mono); font-size: 11px;

--- a/.agents/skills/baby-menu-design/preview/spacing-radius.html
+++ b/.agents/skills/baby-menu-design/preview/spacing-radius.html
@@ -24,9 +24,9 @@
     <div class="col"><div class="box" style="border-radius:6px"></div><span class="swatch-name">6 · md</span></div>
     <div class="col"><div class="box" style="border-radius:8px"></div><span class="swatch-name">8 · lg</span></div>
     <div class="col"><div class="box" style="border-radius:10px"></div><span class="swatch-name">10 · xl · popover</span></div>
-    <div class="col"><div class="box" style="border-radius:999px;height:28px;width:96px"></div><span class="swatch-name">pill · buttons</span></div>
+    <div class="col"><div class="box" style="border-radius:4px;height:28px;width:96px"></div><span class="swatch-name">4 · sm · buttons</span></div>
   </div>
-  <p class="note">Small radii by design. Popover outer = 10. Cards = 8. Buttons = pill. The terminal aesthetic wants edges to be sharp, not soft.</p>
+  <p class="note">Small radii by design. Popover outer = 10. Cards = 8. Shared production buttons = 4. Prototype/app-shell pills are exceptions for tight terminal affordances.</p>
 </div>
 </body>
 </html>

--- a/.agents/skills/baby-menu-design/preview/type-display.html
+++ b/.agents/skills/baby-menu-design/preview/type-display.html
@@ -36,7 +36,7 @@
     <div class="row">
       <span class="meta">15 · inline</span>
       <span class="value v15">72<small>%</small></span>
-      <span class="value v15">b8d3a2c</span>
+      <span class="value v15">ready</span>
     </div>
   </div>
 </div>

--- a/.agents/skills/baby-menu-design/preview/type-eyebrow.html
+++ b/.agents/skills/baby-menu-design/preview/type-eyebrow.html
@@ -19,7 +19,7 @@
 </head>
 <body>
 <div class="card">
-  <span class="label">tracked-caps · 10px · 0.18em · the workhorse heading</span>
+  <span class="label">tracked-caps · 11px · 0.18em · the workhorse heading</span>
   <div class="stack">
     <div class="lockup">
       <span class="label">claude · weekly</span>
@@ -27,9 +27,9 @@
       <span class="meta">last sync 12:04 · oauth</span>
     </div>
     <div class="lockup">
-      <span class="label">git change session</span>
-      <span class="value">b8d3a2c</span>
-      <span class="meta">3 files in extensions/cpu-temp/</span>
+      <span class="label">latest change</span>
+      <span class="value">Kept</span>
+      <span class="meta">ready for the next request</span>
     </div>
   </div>
 </div>

--- a/.agents/skills/baby-menu-design/preview/type-sans-scale.html
+++ b/.agents/skills/baby-menu-design/preview/type-sans-scale.html
@@ -17,7 +17,7 @@
   .row:last-child { border-bottom: 0; }
   .row .size, .row .weight {
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     color: var(--ink-faint);
     letter-spacing: 0.04em;
   }
@@ -26,15 +26,15 @@
 </head>
 <body>
 <div class="card">
-  <span class="label">jetbrains mono · 10 to 18 px · 300 / 400 / 500</span>
+  <span class="label">jetbrains mono · 11 to 36 px · 300 / 400 / 500</span>
   <div class="stack">
-    <div class="row"><span class="size">18</span><span class="weight">500</span><span class="sample" style="font-size:18px;font-weight:500">Module title</span></div>
-    <div class="row"><span class="size">15</span><span class="weight">500</span><span class="sample" style="font-size:15px;font-weight:500">Subhead</span></div>
+    <div class="row"><span class="size">36</span><span class="weight">300</span><span class="sample" style="font-size:36px;font-weight:300">Hero value</span></div>
+    <div class="row"><span class="size">28</span><span class="weight">300</span><span class="sample" style="font-size:28px;font-weight:300">Large value</span></div>
+    <div class="row"><span class="size">16</span><span class="weight">500</span><span class="sample" style="font-size:16px;font-weight:500">Module title</span></div>
+    <div class="row"><span class="size">14</span><span class="weight">400</span><span class="sample" style="font-size:14px;font-weight:400;color:var(--ink-muted)">Body copy in the popover surface.</span></div>
     <div class="row"><span class="size">13</span><span class="weight">500</span><span class="sample" style="font-size:13px;font-weight:500">Widget title</span></div>
-    <div class="row"><span class="size">13</span><span class="weight">400</span><span class="sample" style="font-size:13px;font-weight:400;color:var(--ink-muted)">Body copy in the popover surface.</span></div>
-    <div class="row"><span class="size">12</span><span class="weight">400</span><span class="sample" style="font-size:12px;font-weight:400;color:var(--ink-muted)">caption · secondary copy</span></div>
-    <div class="row"><span class="size">11</span><span class="weight">400</span><span class="sample" style="font-size:11px;font-weight:400;color:var(--ink-soft)">meta · timestamp · hint</span></div>
-    <div class="row"><span class="size">10</span><span class="weight">400</span><span class="sample label" style="font-size:10px">TRACKED CAPS LABEL</span></div>
+    <div class="row"><span class="size">12</span><span class="weight">400</span><span class="sample" style="font-size:12px;font-weight:400;color:var(--ink-soft)">caption · secondary copy</span></div>
+    <div class="row"><span class="size">11</span><span class="weight">400</span><span class="sample label" style="font-size:11px">TRACKED CAPS LABEL</span></div>
   </div>
 </div>
 </body>

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx
@@ -89,15 +89,20 @@ function App() {
             <WidgetHost widgets={widgets} />
           </div>
 
-          {run && <RunStrip run={run} />}
-          <SessionBar
-            session={session}
-            onSave={save}
-            onRollback={rollback}
-            onDismiss={dismissSession}
-          />
+          {run ? (
+            <RunStrip run={run} />
+          ) : (
+            <>
+              <SessionBar
+                session={session}
+                onSave={save}
+                onRollback={rollback}
+                onDismiss={dismissSession}
+              />
 
-          <Composer running={!!run && !run.done} onSend={send} />
+              <Composer running={false} onSend={send} />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx
@@ -4,7 +4,7 @@ const { useState, useEffect, useRef } = React;
 // ─── App ──────────────────────────────────────────────────────────
 // Top-level shell. Owns popover open/closed, widgets, the active
 // Run, and the change session (renamed internally — the user never
-// sees git). No more mode toggle: the composer is always there.
+// sees git). No more mode toggle: the composer stays on the main agent surface.
 function App() {
   const [open, setOpen] = useState(true);
   const [widgets, setWidgets] = useState(DEFAULT_WIDGETS);

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/Composer.jsx
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/Composer.jsx
@@ -2,9 +2,9 @@
 const { useState, useRef, useEffect } = React;
 
 // ─── Composer ─────────────────────────────────────────────────────
-// Persistent slim bar pinned to the bottom of the popover. Auto-grows
-// to a second line as the user keeps typing, but never reserves extra
-// vertical space ahead of time. Submitting fires a single Run.
+// Slim bar pinned on the main idle surface. Auto-grows to a second line
+// as the user keeps typing, but never reserves extra vertical space ahead
+// of time. Submitting fires a single Run, which temporarily replaces it.
 function Composer({ running, onSend }) {
   const [draft, setDraft] = useState("");
   const ref = useRef(null);

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -21,6 +21,8 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 2. **Type a request** in the composer and press Enter (or click `send`). The composer flips into a `RunStrip` with a pulsing mint dot, a current-step subtitle that fades up each time the agent advances, and a live timer. No checklist, no log.
 3. **When the agent finishes**, a `SessionBar` slides in with a plain-language summary (e.g. `Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. Click **Keep** to add the new widget to the surface; click **Undo** to discard. Either way, the bar auto-dismisses after a moment.
 4. **Send a second request while a session is still pending** — the SessionBar flips to an amber-dot `Finish this change first` state. Click **Dismiss** and try again.
+5. **Open settings from the header** in the live app to change `open at login`.
+   The settings view replaces the menu body and hides the composer until you return to the main surface; this prototype documents that flow but does not implement the settings screen.
 
 ## What this kit *does not* try to do
 

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -10,7 +10,7 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 | `popup.css` | All layout + component CSS for the kit. Imports tokens from `../../colors_and_type.css`. |
 | `MenuBar.jsx` | Fake macOS menu bar with the tray button. |
 | `App.jsx` | Top-level shell. Owns popover open state, widgets, the active Run, and the session. |
-| `Composer.jsx` | Slim 1-line prompt with `›` prefix, blinking caret, auto-grow on multi-line typing. Always pinned to bottom. |
+| `Composer.jsx` | Slim 1-line prompt with `›` prefix, blinking caret, auto-grow on multi-line typing. Pinned on the main idle surface; replaced by `RunStrip` during a run and hidden in settings. |
 | `RunStrip.jsx` | Single live affordance — pulsing mint dot, agent's task + current step, elapsed timer. No log history. |
 | `SessionBar.jsx` | Human-language summary from the agent (`Added a CPU temperature widget`) with **Keep** / **Undo** actions. |
 | `WidgetHost.jsx` | Widget shell + three sample widgets (claude · weekly, battery, now playing). |

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -38,4 +38,4 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 | `menu/MenuSurface.tsx` + `menu/WidgetHost.tsx` | `WidgetHost.jsx` | Recipes pill row removed — recipes are an agent-side concept, not user UI. |
 | `styles.css` | `popup.css` + `colors_and_type.css` | |
 
-`AgentChatMessage[]` from `src/shared/contracts.ts` is not used in this design — there is no transcript. `GitSessionSnapshot` still maps to the SessionBar's internal `session.kind` field, but its `head`, `commit`, and similar git-shaped fields are never rendered. The agent should pass a plain-language `summary` string (e.g. `"Added a CPU temperature widget"`) alongside the snapshot for the UI to display.
+`AgentChatMessage[]` from `src/shared/contracts.ts` is not used in this design — there is no transcript. The live `AgentChatResult` returns `assistantText` plus an optional `GitSessionSnapshot`; `useAgentRuntime` derives the SessionBar notice from that text and from `canSave` / `canRollback`. Git-shaped fields such as `head` and `commit` are never rendered.

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -31,7 +31,7 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 
 | Live file | Kit equivalent | Notes |
 | --- | --- | --- |
-| `App.tsx` | `App.jsx` | The mode toggle is gone; the composer is always rendered. |
+| `App.tsx` | `App.jsx` | The mode toggle is gone; the live app has a settings view, and the composer is hidden while settings are open. |
 | `agent/AgentChat.tsx` | `Composer.jsx` + `RunStrip.jsx` + `SessionBar.jsx` | Three components from one chat surface. There is no message history. |
 | `menu/MenuSurface.tsx` + `menu/WidgetHost.tsx` | `WidgetHost.jsx` | Recipes pill row removed — recipes are an agent-side concept, not user UI. |
 | `styles.css` | `popup.css` + `colors_and_type.css` | |

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/WidgetHost.jsx
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/WidgetHost.jsx
@@ -11,7 +11,14 @@ function Widget({ keyLabel, value, unit, status, progress, foot, source, onRefre
       <div className="w-head">
         <span className="key">{keyLabel}</span>
         {onRefresh && (
-          <button type="button" className="refresh" onClick={onRefresh} title="refresh">⟳</button>
+          <button type="button" className="refresh" onClick={onRefresh} title="refresh" aria-label="refresh">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M3 12a9 9 0 0 1 15-6.7L21 8" />
+              <path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
+              <path d="M3 21v-5h5" />
+            </svg>
+          </button>
         )}
       </div>
       {children ? (
@@ -114,7 +121,7 @@ function WidgetHost({ widgets }) {
     return (
       <div className="empty">
         <span className="top">› no widgets</span>
-        <p>switch to build, ask the agent to add one.</p>
+        <p>ask the agent to add one.</p>
         <span className="ex">
           try: <strong>show my battery</strong> · <strong>cpu temp</strong> · <strong>remind me to drink water</strong>
         </span>

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css
@@ -78,7 +78,7 @@ body {
   bottom: 22px; left: 22px;
   color: rgba(255,255,255,0.30);
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   letter-spacing: 0.08em;
   pointer-events: none;
 }
@@ -138,8 +138,6 @@ body {
 .widget-host {
   display: flex;
   flex-direction: column;
-  max-height: 360px;
-  overflow-y: auto;
   margin: 0 -4px;
   padding: 0 4px;
 }
@@ -161,7 +159,7 @@ body {
 }
 .widget .key {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: var(--weight-reg);
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -223,7 +221,7 @@ body {
 
 .widget .foot {
   display: flex; justify-content: space-between; align-items: center;
-  font-size: 10px;
+  font-size: 11px;
   color: var(--ink-faint);
   font-feature-settings: "tnum";
 }
@@ -256,7 +254,7 @@ body {
 }
 .empty .top { font-size: 12px; color: var(--ink-200); }
 .empty p { font-size: 11px; color: var(--ink-soft); margin: 0; }
-.empty .ex { font-size: 10px; color: var(--ink-faint); }
+.empty .ex { font-size: 11px; color: var(--ink-faint); }
 .empty .ex strong { color: var(--ink-200); font-weight: var(--weight-med); }
 
 /* ─── RunStrip ─────────────────────────────────────────────── */
@@ -294,7 +292,7 @@ body {
   animation: stepFade var(--motion-slow) var(--ease);
 }
 .runstrip .timer {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--ink-faint);
   font-feature-settings: "tnum";
 }
@@ -336,7 +334,7 @@ body {
   text-overflow: ellipsis;
 }
 .sessionbar .sb-hint {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--ink-soft);
   font-weight: var(--weight-reg);
 }
@@ -424,7 +422,7 @@ body {
 
 .composer .send {
   font-family: var(--font-mono);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: var(--weight-med);
   letter-spacing: 0.18em;
   text-transform: uppercase;

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css
@@ -346,7 +346,7 @@ body {
   font-weight: var(--weight-med);
   letter-spacing: 0.02em;
   padding: 4px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-sm);
   border: 1px solid var(--line);
   appearance: none;
   -webkit-appearance: none;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Do not write generated extension files, compiled modules, preferences, logs, sna
 - For privileged work, explicitly say that filesystem, shell, network, credential, and token access belongs in extension-owned server actions behind `window.babyMenu.capabilities.invoke`.
 - Renderer widgets should receive normalized data over `window.babyMenu` and should not add new preload methods for each capability.
 - If a real data source may be unavailable, define the mock fallback and require the UI to label it as mock data.
-- Define normalized TypeScript shapes in the recipe so the agent knows what data the main process should return to the renderer.
+- Define normalized TypeScript shapes in the recipe so the agent knows what data extension server actions should return to widgets.
 - Include parser guidance for command or API output, including timeout behavior, stale-data behavior, and user-visible errors.
 - Never include or ask for committed secrets, tokens, cookie values, or local credential dumps.
 - Standalone recipe HTML should use daisyUI from CDN and the `wireframe` theme.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Three processes, kept deliberately separate:
 
 1. **Main** (`src/main/`) - app lifecycle, tray, popover window, IPC, git, agent runtime. Never call agent or git from the renderer directly.
 2. **Preload** (`src/preload/index.ts`) - the stable bridge. Exposes `window.babyMenu` via `contextBridge`. Do not add one-off preload methods for each widget.
-3. **Renderer** (`src/renderer/`) - React UI: `AgentChat` + `WidgetHost`. Widgets should be hot reloadable and should not require an Electron restart for each new capability. The app shell and extension widgets share one design system, `@babymenu/ui` (`src/ui/`); see "Design system" below.
+3. **Renderer** (`src/renderer/`) - React UI: `AgentChat`, `WidgetHost`, and `SettingsView`. Widgets should be hot reloadable and should not require an Electron restart for each new capability. The app shell and extension widgets share one design system, `@babymenu/ui` (`src/ui/`); see "Design system" below.
 4. **Extension server actions** - privileged filesystem, shell, network, credential, and token work should live behind extension-owned server actions invoked through the stable generic capability bridge.
    Renderer widgets call these actions with `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
    Server actions live in the active extension workspace under `<extension-id>/server.ts` and export an `actions` object.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Embedded agents launched from baby-menu should work from the active extension wo
 - `pnpm typecheck` / `pnpm lint` - both run `tsc --noEmit` against `tsconfig.json`.
 - Single test: `pnpm vitest run tests/<name>.test.ts` (or `pnpm vitest run -t "<name pattern>"`).
 
-Use `pnpm` (declared `packageManager: pnpm@11.1.1`). Renderer dev server is pinned to port 5173 (`strictPort: true`).
+Use `pnpm` (declared `packageManager: pnpm@11.1.1`). Renderer dev server is pinned to port 5273 (`strictPort: true`).
 
 ## Dev mode helpers
 
@@ -32,7 +32,7 @@ Three processes, kept deliberately separate:
 
 1. **Main** (`src/main/`) - app lifecycle, tray, popover window, IPC, git, agent runtime. Never call agent or git from the renderer directly.
 2. **Preload** (`src/preload/index.ts`) - the stable bridge. Exposes `window.babyMenu` via `contextBridge`. Do not add one-off preload methods for each widget.
-3. **Renderer** (`src/renderer/`) - React UI: `AgentChat` + `WidgetHost`. Widgets should be hot reloadable and should not require an Electron restart for each new capability.
+3. **Renderer** (`src/renderer/`) - React UI: `AgentChat` + `WidgetHost`. Widgets should be hot reloadable and should not require an Electron restart for each new capability. The app shell and extension widgets share one design system, `@babymenu/ui` (`src/ui/`); see "Design system" below.
 4. **Extension server actions** - privileged filesystem, shell, network, credential, and token work should live behind extension-owned server actions invoked through the stable generic capability bridge.
    Renderer widgets call these actions with `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
    Server actions live in the active extension workspace under `<extension-id>/server.ts` and export an `actions` object.
@@ -52,8 +52,10 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
 - `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
 - `extension-seeder.ts` - seeds bundled extension templates into the packaged extension workspace.
-- `extension-module-compiler.ts` - compiles extension widget and server modules for production loading.
-- `widget-protocol.ts` - registers custom protocols for compiled widget modules and the renderer host shim.
+- `extension-module-compiler.ts` - compiles extension widget and server modules for production loading; rewrites the `react` and `@babymenu/ui` imports to host protocol modules and rejects any other external import.
+- `widget-tailwind-css.ts` - compiles a widget's authored Tailwind utilities against the `@babymenu/ui` `@theme` (single source of truth, `src/ui/theme.css`) for packaged loading.
+- `widget-module-registry.ts` - discovers widget modules, returning a renderer `/@fs` URL in dev and, in packaged mode, a compiled `baby-menu-widget://` module URL plus a sibling compiled `cssUrl`.
+- `widget-protocol.ts` - registers custom protocols for compiled widget modules, the per-widget `.css`, and the renderer host shims (`react`, `react/jsx-runtime`, and `@babymenu/ui` re-exported from the host global).
 - `preferences.ts` - stores app preferences under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
 - `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `recipe-loader.ts` - discovers and parses `recipes/*.html` from the active extension workspace.
@@ -69,6 +71,17 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 
 `typescript` is intentionally externalized from the production main bundle because `extension-module-compiler.ts` imports it at runtime to compile packaged extensions.
 Keep `typescript` in runtime dependencies unless that compiler path changes.
+`tailwindcss`, `@tailwindcss/postcss`, and `postcss` are externalized for the same reason: `widget-tailwind-css.ts` runs Tailwind in the main process to compile per-widget CSS in packaged mode.
+Keep them in runtime dependencies, and keep the single pinned `postcss` (`pnpm-workspace.yaml` `overrides`) so the Tailwind plugin and the processor share one version.
+The renderer build adds `@tailwindcss/vite` and aliases `@babymenu/ui` to `src/ui/index.ts` so dev-mode widgets resolve the design system directly.
+
+### Design system (`@babymenu/ui`)
+
+`src/ui/` is a shadcn-derived component kit (Radix + Tailwind v4) restyled to the Monochrome Lab tokens, shared by the app shell and extension widgets.
+`src/ui/theme.css` is the single `@theme` source of truth: it wipes Tailwind's default palette so only token colors exist, and it is consumed by both the renderer build (`src/ui/styles.css`) and the per-widget compiler (imported `?raw` into the main bundle).
+Delivery mirrors the React shim exactly: `main.tsx` installs the kit on `window.__BABY_MENU_WIDGET_HOST__.ui`, `widget-protocol.ts` serves `baby-menu-host://ui/index.mjs` as a thin re-export, and the compiler rewrites the bare `@babymenu/ui` specifier to that URL - so Radix, cva, and lucide stay inside the host bundle and never reach the widget import allowlist.
+`src/shared/ui-exports.ts` is the public surface contract (treated like the preload bridge): the barrel, the contract list, and the generated host shim are kept in lockstep by `tests/ui-export-contract.test.ts`, so changing a public export is a deliberate, tested act.
+Extension widgets may additionally import only `@babymenu/ui`; they author token-scoped Tailwind utilities, and the per-widget stylesheet is compiled and injected automatically.
 
 `createPopoverOptions` enforces `frame:false`, `contextIsolation:true`, `nodeIntegration:false`, `skipTaskbar:true`, `alwaysOnTop:true`. Do not relax these without a reason.
 On macOS, `app.ts` appends Chromium's `use-mock-keychain` switch before app readiness, so do not rely on Chromium or renderer storage for keychain-backed secrets.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Keep credential and token work in extension server actions.
 
 `BabyMenuAgentRuntime` (`src/main/agent-runtime.ts`) wraps `acpx/runtime`. It allows only one active `send()` call at a time; overlapping sends return an "already running" assistant response before any change session begins. Every accepted `send()` call:
 
-1. Resolves the active extension workspace from runtime paths. Source mode honors `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`; packaged mode uses `~/.baby-menu/extensions` after seeding bundled templates.
+1. Resolves the active extension workspace from runtime paths. Source mode honors `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`; packaged mode uses `~/.baby-menu/extensions` after seeding bundled templates. Dev/source Tailwind utility generation scans only `extensions/` and `extensions-dev/` unless `src/ui/styles.css` or `src/ui/styles.dev.css` is given an additional `@source` path, so custom overrides outside those directories may load widget modules without their utility CSS.
 2. Uses `DevExtensionChangeSession` for snapshot workspaces such as `extensions-dev/` and packaged `~/.baby-menu/extensions`, so Save keeps generated files and Rollback restores the pre-turn contents.
 3. Uses `GitChangeSession.begin(rootDir)` only for the tracked source `extensions/` workspace when that workspace is selected explicitly. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
 4. Lazily constructs the ACP runtime with `createFileSessionStore({ stateDir })` under `.cache/baby-menu/acp-sessions` in source mode or `~/.baby-menu/cache/acp-sessions` in packaged mode, with `permissionMode: "approve-all"`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You ask for a feature in plain English, the agent writes an extension and it hot
 
 - **Personal self-evolving software** - this is a glimpse into a future where every piece of software is personal and self-evolving towards your exact needs.
 - **Ask, don't configure** - tweak the menu using natural language, not configuration.
-- **Worry-free** - every agent turn can be kept or rolled back.
+- **Worry-free** - every agent turn can be kept or undone.
 
 ## Quick Start
 
@@ -72,7 +72,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 ```
    ┌─────────────────────┐
    │  macOS tray popover │   (React renderer, 360px wide)
-   │     + AgentChat     │
+   │ + Menu / Settings   │
    └──────────┬──────────┘
               │  send()
               ▼

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ add a CPU temp widget that shows current temperature and fan status
 Baby Menu writes the extension under `~/.baby-menu/extensions`, mounts the widget live, and shows Save / Rollback controls for the turn.
 Use Save to keep it, or Rollback to throw it away.
 The packaged app opens at login by default.
-Use the `login on/off` toggle in the popover header to turn that off or back on.
+Open settings from the popover header to turn `open at login` off or back on.
 
 ## Install Details
 
@@ -111,7 +111,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | --------------------------- | ----------------------------------------------------------- |
 | `src/main/`                 | Electron lifecycle, tray, popover, IPC, git, agent runtime  |
 | `src/preload/index.ts`      | The stable `window.babyMenu` bridge                         |
-| `src/renderer/`             | React UI: `AgentChat` + `WidgetHost`                        |
+| `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, and settings            |
+| `src/ui/`                   | Shared `@babymenu/ui` design system for shell and widgets    |
 | `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `GitSessionSnapshot`, etc. |
 | `extensions/<id>/`          | Tracked extensions (`widget.tsx`, `server.ts`)              |
 | `extensions/recipes/*.html` | Self-contained widget specs the agent reads                 |

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Click the tray icon, then ask for a widget in the popover chat such as:
 add a CPU temp widget that shows current temperature and fan status
 ```
 
-Baby Menu writes the extension under `~/.baby-menu/extensions`, mounts the widget live, and shows Save / Rollback controls for the turn.
-Use Save to keep it, or Rollback to throw it away.
+Baby Menu writes the extension under `~/.baby-menu/extensions`, mounts the widget live, and shows Keep / Undo controls for the turn.
+Use Keep to keep it, or Undo to throw it away.
 The packaged app opens at login by default.
 Open settings from the popover header to turn `open at login` off or back on.
 
@@ -81,7 +81,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
    │   wraps acpx/runtime │       │   git or snapshot    │
    └──────────┬──────────┘       │   by runtime mode    │
               │                   └──────────┬───────────┘
-              │ edits files                  │ Save / Rollback
+              │ edits files                  │ save / rollback
               ▼                              ▼
    ┌─────────────────────┐       ┌──────────────────────┐
    │ active extensions/  │       │   save snapshot or   │
@@ -102,7 +102,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
   The agent reads the matching recipe before implementing.
 - **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets via `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
   No per-widget IPC channels.
-- **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with snapshot Save/Rollback.
+- **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with internal snapshot save/rollback.
   Tracked `extensions/` remain the source templates for dev and packaged extension workspaces.
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install --cask kunchenguid/tap/baby-menu
 open -a "Baby Menu"
 ```
 
-Click the tray icon, then ask for a widget in the popover chat such as:
+Click the tray icon, then ask for a widget in the composer such as:
 
 ```text
 add a CPU temp widget that shows current temperature and fan status

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | -------------------------------- | ------------------------------------------------------------ |
 | `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up |
 | `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)            |
-| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs  |
+| `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs. Dev Tailwind scans only `extensions/` and `extensions-dev/`, so overrides outside those paths need matching `@source` coverage for widget utilities. |
 
 ## Development
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
 export default defineConfig({
@@ -7,7 +8,10 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
     build: {
       rollupOptions: {
-        external: ["electron", "typescript"],
+        // typescript + the Tailwind compiler are imported at runtime by the
+        // extension/widget compile path, so they stay external (resolved from
+        // node_modules in the packaged app) rather than bundled.
+        external: ["electron", "typescript", "tailwindcss", "@tailwindcss/postcss", "postcss"],
         input: {
           index: resolve(__dirname, "src/main/app.ts"),
         },
@@ -31,9 +35,17 @@ export default defineConfig({
   },
   renderer: {
     root: "src/renderer",
-    plugins: [react()],
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      // Dev/source mode serves widgets through Vite, so the bare design-system
+      // specifier resolves to the real module here (sharing the renderer's React
+      // instance). Packaged mode rewrites it to the host protocol instead.
+      alias: {
+        "@babymenu/ui": resolve(__dirname, "src/ui/index.ts"),
+      },
+    },
     server: {
-      port: 5173,
+      port: 5273,
       strictPort: true,
       fs: {
         allow: [resolve(__dirname)],

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -71,7 +71,9 @@ Overlays such as `Dialog`, `Select`, and `Tooltip` are already sized to fit the 
 ### Style with Tailwind tokens
 
 Widgets are styled with Tailwind utility classes, and the per-widget stylesheet is compiled for you - you never configure Tailwind.
-The palette is restricted to Baby Menu tokens, so off-brand colors literally do not exist: there is no `bg-red-500` and no `text-blue-300`.
+Prefer Baby Menu token utilities for color, type, radius, and surfaces so widgets match the host app.
+Default Tailwind palette colors such as `bg-red-500` and `text-blue-300` are unavailable, but arbitrary Tailwind values can still compile.
+Use arbitrary color values only when a widget genuinely needs them, and keep them rare.
 
 Use these token utilities:
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -77,6 +77,13 @@ Common API patterns:
 - `Progress` takes `value={0..100}` and optional `tone="live" | "warn" | "danger"`.
 - `Sparkline` takes `data={number[]}` and optional `width`, `height`, `tone="live" | "ink"`, and `area`.
 - `Select` and `Dialog` follow Radix composition: root, trigger, content, then item/body/footer pieces.
+- `Button` supports `variant="default" | "primary" | "ghost" | "danger"`, `size="sm" | "md"`, and defaults to `type="button"`.
+- `Field` takes `label`, optional `hint`, and exactly one control child; it wires the label to the child `id` or generates one.
+- `Input` and `Textarea` accept normal HTML control props and are already styled for the popover.
+- `Switch` uses Radix switch props such as `checked`, `defaultChecked`, `onCheckedChange`, and `disabled`.
+- `Tabs` follow Radix composition: `Tabs defaultValue`, `TabsList`, matching `TabsTrigger value`, and `TabsContent value`.
+- `DropdownMenu` follows Radix composition: root, `DropdownMenuTrigger`, `DropdownMenuContent`, then `DropdownMenuItem` rows.
+- `Tooltip` wraps one trigger child and takes `content`, optional `side`, and optional `className`; do not mount a separate provider.
 
 ```tsx
 import {

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -68,6 +68,83 @@ Available components:
 `@babymenu/ui` is the only extra import a widget may add beyond `react` and local files.
 Overlays such as `Dialog`, `Select`, and `Tooltip` are already sized to fit the tray popover; do not reposition them.
 
+Common API patterns:
+
+- `DataTable` takes `columns`, `rows`, optional `getRowKey`, and optional `empty` content.
+- `DataTable` columns use `{ key, header, align?, render? }`; omit `render` only when the row has a value at `row[column.key]`.
+- `Badge` supports `tone="neutral" | "live" | "warn" | "danger"`.
+- `StatusDot` supports `tone="live" | "warn" | "danger" | "muted"` and should sit next to a short status label.
+- `Progress` takes `value={0..100}` and optional `tone="live" | "warn" | "danger"`.
+- `Sparkline` takes `data={number[]}` and optional `width`, `height`, `tone="live" | "ink"`, and `area`.
+- `Select` and `Dialog` follow Radix composition: root, trigger, content, then item/body/footer pieces.
+
+```tsx
+import {
+  Badge,
+  Button,
+  DataTable,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sparkline,
+  StatusDot,
+} from "@babymenu/ui";
+
+type Row = { name: string; status: "live" | "warn"; load: number };
+
+const rows: Row[] = [
+  { name: "api", status: "live", load: 41 },
+  { name: "queue", status: "warn", load: 88 },
+];
+
+export function render() {
+  return (
+    <div className="flex flex-col gap-3">
+      <DataTable
+        rows={rows}
+        getRowKey={(row) => row.name}
+        columns={[
+          { key: "name", header: "service" },
+          {
+            key: "status",
+            header: "state",
+            render: (row) => <Badge tone={row.status}>{row.status}</Badge>,
+          },
+          { key: "load", header: "load", align: "right", render: (row) => `${row.load}%` },
+        ]}
+      />
+      <div className="flex items-center justify-between text-xs text-ink-muted">
+        <span className="flex items-center gap-1.5"><StatusDot tone="live" /> healthy</span>
+        <Sparkline data={[12, 18, 14, 31, 29, 41]} area />
+      </div>
+      <Select defaultValue="hour">
+        <SelectTrigger><SelectValue placeholder="window" /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="hour">last hour</SelectItem>
+          <SelectItem value="day">last day</SelectItem>
+        </SelectContent>
+      </Select>
+      <Dialog>
+        <DialogTrigger asChild><Button>details</Button></DialogTrigger>
+        <DialogContent>
+          <DialogTitle>service details</DialogTitle>
+          <DialogBody>Keep dialog copy short enough for the tray window.</DialogBody>
+          <DialogFooter><Button>close</Button></DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+```
+
 ### Style with Tailwind tokens
 
 Widgets are styled with Tailwind utility classes, and the per-widget stylesheet is compiled for you - you never configure Tailwind.

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -160,6 +160,8 @@ Widgets are styled with Tailwind utility classes, and the per-widget stylesheet 
 Prefer Baby Menu token utilities for color, type, radius, and surfaces so widgets match the host app.
 Default Tailwind palette colors such as `bg-red-500` and `text-blue-300` are unavailable, but arbitrary Tailwind values can still compile.
 Use arbitrary color values only when a widget genuinely needs them, and keep them rare.
+Keep class names statically visible in the widget source so the dev stylesheet and packaged per-widget compiler can discover them.
+Avoid constructing Tailwind class fragments dynamically; choose complete class strings from a small map instead.
 
 Use these token utilities:
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -17,7 +17,7 @@ Common files are:
 - Optional notes that make the extension understandable and shareable.
 
 Packaged Baby Menu compiles extension modules before loading them.
-Keep imports package-safe: widgets may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, and local helper files only.
+Keep imports package-safe: widgets may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, the design system `@babymenu/ui`, and local helper files only.
 Server actions may import Node built-ins such as `node:fs` plus local helper files only.
 Do not add arbitrary npm package imports to extension code unless the host compiler is updated to support them.
 
@@ -48,82 +48,91 @@ The host owns the outer widget wrapper, title row, refresh button, dashed divide
 `widget.title` should be a terse tracked-caps key such as `BATTERY`, `CPU TEMP`, or `CLAUDE · WEEKLY`.
 `render()` should return only the body content that belongs below the host title row.
 
-Use the existing global design tokens and widget classes from the renderer CSS.
-Prefer `value-row`, `value`, `progress`, `fill`, `foot`, `src`, `status`, and `label` before writing custom CSS.
-Custom classes must be extension-prefixed and use `var(--...)` tokens rather than raw colors, font stacks, shadows, or spacing scales.
+### Build with @babymenu/ui first
 
-Public tokens available to widgets:
-
-- Type: `--font-mono`, `--fs-xxs`, `--fs-xs`, `--fs-sm`, `--fs-base`, `--fs-lg`, `--fs-xl`, `--fs-2xl`, `--fs-3xl`, `--weight-light`, `--weight-reg`, `--weight-med`, `--tracking-caps`, `--tracking-value`, `--lh-tight`, `--lh-body`.
-- Ink: `--ink-strong`, `--ink`, `--ink-muted`, `--ink-soft`, `--ink-label`, `--ink-faint`.
-- Lines: `--line`, `--line-faint`.
-- Signals: `--signal-live`, `--signal-warn`, `--signal-danger`, `--signal-live-glow`, `--signal-live-tint`, `--signal-pending-tint`, `--signal-error-tint`.
-- Space: `--space-1` through `--space-9` for the 2px-based spacing scale.
-- Radius: `--radius-xs`, `--radius-sm`, `--radius-md`, `--radius-lg`, `--radius-pill`.
-- Motion: `--motion-fast`, `--motion-base`, `--motion-slow`, `--ease`, `--ease-in-out`.
-
-Public widget classes available to widgets:
-
-- `value-row` lays out the primary value and optional right-side status.
-- `value` styles the main numeric or short text value; put units in a nested `small` element.
-- `progress` creates the 1px scanline track; `fill` is the mint progress segment inside it.
-- `foot` lays out quiet metadata and source text only.
-- `src` styles an uppercase source tag inside `foot` such as `CLI`, `OAUTH`, or `MOCK`.
-- `status` renders a mint dot and tracked-caps status word.
-- `status warn`, `status danger`, and `status muted` switch status tone.
-- `label` renders a small tracked-caps label.
-- `btn`, `btn-primary`, `btn-danger`, and `btn-ghost` are available for rare interactive widget controls.
-
-Readable hierarchy rules:
-
-- The host `widget.title`, `label`, `src`, and `foot` text may be tiny because they are metadata.
-- Primary user-facing content should be at least `--fs-sm`; use `--fs-md`, `--fs-lg`, or a `value` class for the main thing the user should read first.
-- Use `--fs-xs` only for optional hints and metadata.
-- Do not use `foot` for primary instructions, onboarding copy, warnings, or calls to action.
-- If every line is small, the design is wrong even if it uses the right tokens.
-- One element should clearly win: a number, title, current state, or next action.
-
-Onboarding widgets are not data widgets.
-For greeting, setup, empty, or explanatory widgets, do not force `value`, `progress`, `foot`, or `src` into the layout just to match the data-widget anatomy.
-Onboarding widget headlines should usually use `--fs-md` or `--fs-lg`.
-Starter empty states may use `--fs-2xl` or `--fs-3xl` for a single display line because the menu is otherwise empty.
-Use readable body copy at `--fs-base`, and keep examples or hints outside `foot`.
-Example prompts should be complete pasteable user asks, not one-word labels.
-Label them `examples` and phrase each one as something likely to produce a useful widget.
-
-Canonical widget body pattern:
+Import ready-made, on-brand components from `@babymenu/ui` instead of hand-rolling tables, inputs, charts, or status chips.
+These are the same components the Baby Menu app uses, so widgets stay visually consistent for free.
 
 ```tsx
-<div className="value-row">
-  <span className="value">
-    72<small>%</small>
-  </span>
-  <span className="status">live</span>
-</div>
-<div className="progress">
-  <div className="fill" style={{ width: "72%" }} />
-</div>
-<div className="foot">
-  <span>last sync 12:04</span>
-  <span className="src">mock</span>
-</div>
+import { DataTable, StatusDot, Progress, Badge, Sparkline } from "@babymenu/ui";
 ```
 
-Recommended widget body anatomy:
+Available components:
 
-- A value row with one confident numeric or textual value.
-- An optional `status` word for live, pending, error, or muted state.
-- An optional 1px `progress` scanline with a `fill`.
-- A `foot` row with quiet metadata on the left and an uppercase source tag with `src` on the right.
+- Data display: `DataTable`, `Sparkline`, `Progress`, `Badge`, `StatusDot`, `Skeleton`.
+- Layout: `Card`, `CardHeader`, `CardBody`.
+- Input: `Button`, `Field`, `Input`, `Textarea`, `Switch`, and `Select` with `SelectTrigger`, `SelectContent`, `SelectItem`, `SelectValue`.
+- Disclosure: `Tabs` with `TabsList`, `TabsTrigger`, `TabsContent`; `Dialog` with `DialogTrigger`, `DialogContent`, `DialogTitle`, `DialogDescription`, `DialogBody`, `DialogFooter`; `DropdownMenu` with `DropdownMenuTrigger`, `DropdownMenuContent`, `DropdownMenuItem`; and `Tooltip`.
+- `cn(...)` merges Tailwind class strings safely.
 
-Visual rules:
+`@babymenu/ui` is the only extra import a widget may add beyond `react` and local files.
+Overlays such as `Dialog`, `Select`, and `Tooltip` are already sized to fit the tray popover; do not reposition them.
 
-- Use JetBrains Mono through `var(--font-mono)` and keep copy terse, lowercase, present tense unless text is a proper noun or tracked-caps label.
-- Use mint only as a signal dot, glow, single word, or progress fill.
+### Style with Tailwind tokens
+
+Widgets are styled with Tailwind utility classes, and the per-widget stylesheet is compiled for you - you never configure Tailwind.
+The palette is restricted to Baby Menu tokens, so off-brand colors literally do not exist: there is no `bg-red-500` and no `text-blue-300`.
+
+Use these token utilities:
+
+- Surfaces: `bg-stage`, `bg-surface`, `bg-elevated`, `bg-pressed`.
+- Ink (text): `text-ink-strong`, `text-ink`, `text-ink-muted`, `text-ink-soft`, `text-ink-label`.
+- Lines: `border-line`, `border-line-faint`.
+- Signals: `text-signal-live` and `bg-signal-live` for mint, `text-signal-warn` for amber, `text-signal-danger` for coral.
+- Type: `font-mono`, the `text-xxs` through `text-3xl` scale, `tracking-caps`, and `tracking-value`.
+- Radius: `rounded-xs` through `rounded-xl`, and `rounded-pill`.
+
+Spacing, flex, and grid utilities are standard Tailwind.
+
+### Readable hierarchy
+
+- Primary user-facing content should be at least `text-sm`; use `text-md`, `text-lg`, or larger for the main thing the user should read first.
+- Use `text-xs` and `text-xxs` only for optional hints, metadata, and tracked-caps labels.
+- One element should clearly win: a number, title, current state, or next action.
+- If every line is small, the design is wrong even if it uses the right tokens.
+
+### Visual rules
+
+- Use JetBrains Mono via `font-mono` and keep copy terse, lowercase, present tense unless text is a proper noun or tracked-caps label.
+- Use mint only as a signal: a `StatusDot`, a glow, a single word, or a `Progress` fill.
 - Use amber and coral only for pending and error status.
 - Do not add gradients, emoji, large icons, card shadows, full-card accent fills, custom palettes, or new typefaces.
 - Do not wrap widget bodies in their own card background, border, or shadow.
 - Keep layouts narrow and resilient; truncate long labels and avoid horizontal scrolling.
+
+### Example data-widget body
+
+```tsx
+import { Progress, StatusDot } from "@babymenu/ui";
+
+export function render() {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-baseline justify-between">
+        <span className="text-2xl font-light tracking-value text-ink-strong">
+          72<span className="ml-0.5 text-sm text-ink-soft">%</span>
+        </span>
+        <span className="flex items-center gap-1.5 text-xxs uppercase tracking-caps text-signal-live">
+          <StatusDot /> live
+        </span>
+      </div>
+      <Progress value={72} />
+      <div className="flex justify-between text-xxs uppercase tracking-caps text-ink-label">
+        <span>last sync 12:04</span>
+        <span>cli</span>
+      </div>
+    </div>
+  );
+}
+```
+
+### Onboarding widgets are not data widgets
+
+For greeting, setup, empty, or explanatory widgets, do not force the data-widget anatomy.
+Onboarding widget headlines should usually use `text-md` or `text-lg`.
+Starter empty states may use `text-2xl` or `text-3xl` for a single display line because the menu is otherwise empty.
+Use readable body copy at `text-base`, and keep examples or hints small but legible.
+Example prompts should be complete pasteable user asks, not one-word labels.
 
 ## Server Actions
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -105,8 +105,10 @@ const rows: Row[] = [
   { name: "queue", status: "warn", load: 88 },
 ];
 
-export function render() {
-  return (
+export const serviceWidget = {
+  id: "service-status",
+  title: "SERVICES",
+  render: () => (
     <div className="flex flex-col gap-3">
       <DataTable
         rows={rows}
@@ -141,8 +143,8 @@ export function render() {
         </DialogContent>
       </Dialog>
     </div>
-  );
-}
+  ),
+};
 ```
 
 ### Style with Tailwind tokens
@@ -184,8 +186,10 @@ Spacing, flex, and grid utilities are standard Tailwind.
 ```tsx
 import { Progress, StatusDot } from "@babymenu/ui";
 
-export function render() {
-  return (
+export const quotaWidget = {
+  id: "quota",
+  title: "QUOTA",
+  render: () => (
     <div className="flex flex-col gap-2">
       <div className="flex items-baseline justify-between">
         <span className="text-2xl font-light tracking-value text-ink-strong">
@@ -201,8 +205,8 @@ export function render() {
         <span>cli</span>
       </div>
     </div>
-  );
-}
+  ),
+};
 ```
 
 ### Onboarding widgets are not data widgets

--- a/extensions/hello-world/widget.tsx
+++ b/extensions/hello-world/widget.tsx
@@ -1,4 +1,5 @@
 import type { RefreshableBabyMenuWidget } from "../../src/shared/contracts";
+import { StatusDot } from "@babymenu/ui";
 
 const examplePrompts = [
   "add a battery widget that shows current charge and power source",
@@ -8,80 +9,28 @@ const examplePrompts = [
 
 function HelloWorldView() {
   return (
-    <div
-      className="hello-world-widget"
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "var(--space-7)",
-        padding: "var(--space-3) 0 var(--space-4)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--space-4)",
-        }}
-      >
-        <span className="status">ready</span>
-        <span
-          style={{
-            color: "var(--ink-strong)",
-            fontSize: "var(--fs-3xl)",
-            fontWeight: "var(--weight-light)",
-            letterSpacing: "var(--tracking-value)",
-            lineHeight: "var(--lh-tight)",
-          }}
-        >
-          hello world
+    <div className="flex flex-col gap-7 pb-2 pt-1.5">
+      <div className="flex flex-col gap-3">
+        <span className="flex items-center gap-1.5 text-xxs uppercase tracking-caps text-signal-live">
+          <StatusDot /> ready
         </span>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-2)",
-          }}
-        >
-          <p style={{ color: "var(--ink-strong)", fontSize: "var(--fs-md)" }}>
-            tell baby_menu what to build.
-          </p>
-          <p style={{ color: "var(--ink-muted)", fontSize: "var(--fs-base)" }}>
+        <span className="text-3xl font-light tracking-value text-ink-strong">hello world</span>
+        <div className="flex flex-col gap-1">
+          <p className="text-md text-ink-strong">tell baby_menu what to build.</p>
+          <p className="text-base text-ink-muted">
             paste an example into the prompt below, or ask for any widget you want.
           </p>
         </div>
       </div>
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "var(--space-4)",
-        }}
-      >
-        <span className="label">examples</span>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-3)",
-          }}
-        >
+      <div className="flex flex-col gap-3">
+        <span className="text-xxs uppercase tracking-caps text-ink-label">examples</span>
+        <div className="flex flex-col gap-2">
           {examplePrompts.map((example) => (
             <span
               key={example}
-              style={{
-                alignItems: "flex-start",
-                border: "1px solid var(--line)",
-                borderRadius: "var(--radius-sm)",
-                color: "var(--ink)",
-                display: "flex",
-                fontSize: "var(--fs-sm)",
-                gap: "var(--space-3)",
-                lineHeight: "var(--lh-body)",
-                padding: "var(--space-4) var(--space-5)",
-              }}
+              className="flex items-start gap-2 rounded-sm border border-line px-3 py-2 text-sm leading-snug text-ink"
             >
-              <span style={{ color: "var(--signal-live)", flex: "0 0 auto" }}>›</span>
+              <span className="shrink-0 text-signal-live">›</span>
               <span>{example}</span>
             </span>
           ))}

--- a/extensions/recipes/claude-code-quota.html
+++ b/extensions/recipes/claude-code-quota.html
@@ -153,16 +153,15 @@ Cookie: sessionKey=&lt;value&gt;</code></pre>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Implementation Contract</h2>
-        <p>Create or edit these files:</p>
+        <p>Create or edit these extension files:</p>
         <ul>
-          <li><code>src/main/claude-quota.ts</code> for main-process data fetching and parsing.</li>
-          <li><code>src/main/ipc.ts</code> to expose <code>baby-menu:quota:claude</code>.</li>
-          <li><code>src/preload/index.ts</code> to expose <code>window.babyMenu.quota.claude()</code>.</li>
-          <li><code>src/renderer/widgets/claude-code-quota-widget.tsx</code> for the renderer widget.</li>
-          <li><code>src/renderer/menu/WidgetHost.tsx</code> or a widget registry file to register the widget.</li>
+          <li><code>claude-code-quota/server.ts</code> for privileged token, CLI, network, timeout, and parser work.</li>
+          <li><code>claude-code-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
+          <li>The widget should call <code>window.babyMenu.capabilities.invoke("claude-code-quota", "getQuota", input)</code>.</li>
+          <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
           <li><code>tests/claude-quota.test.ts</code> for parser and fallback tests.</li>
         </ul>
-        <p>IPC response shape:</p>
+        <p>Server action response shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type QuotaResult&lt;T&gt; =
   | { ok: true; data: T }
   | { ok: false; error: string; sourceTried: string[]; mock?: T };</code></pre>

--- a/extensions/recipes/claude-code-quota.html
+++ b/extensions/recipes/claude-code-quota.html
@@ -70,7 +70,7 @@
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>OAuth Usage API Details</h2>
-        <p>Credential locations to check from the main process only:</p>
+        <p>Credential locations to check from <code>claude-code-quota/server.ts</code> only:</p>
         <ul>
           <li><code>~/.claude/.credentials.json</code></li>
           <li>Future app-local credential cache under Electron user data, not committed to the repo.</li>
@@ -110,7 +110,7 @@ anthropic-beta: oauth-2025-04-20</code></pre>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Claude CLI Probe Details</h2>
-        <p>Run privileged CLI work in the Electron main process. Do not expose Node APIs to the renderer.</p>
+        <p>Run privileged CLI work in <code>claude-code-quota/server.ts</code> behind <code>window.babyMenu.capabilities.invoke</code>. Do not expose Node APIs to the renderer.</p>
         <p>Command strategy:</p>
         <ul>
           <li>Check whether <code>claude</code> exists on <code>PATH</code>.</li>

--- a/extensions/recipes/claude-code-quota.html
+++ b/extensions/recipes/claude-code-quota.html
@@ -156,8 +156,9 @@ Cookie: sessionKey=&lt;value&gt;</code></pre>
         <p>Create or edit these extension files:</p>
         <ul>
           <li><code>claude-code-quota/server.ts</code> for privileged token, CLI, network, timeout, and parser work.</li>
-          <li><code>claude-code-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
+          <li><code>claude-code-quota/widget.tsx</code> for a <code>RefreshableBabyMenuWidget</code>, using <code>@babymenu/ui</code>.</li>
           <li>The widget should call <code>window.babyMenu.capabilities.invoke("claude-code-quota", "getQuota", input)</code>.</li>
+          <li>Put quota reload logic in the widget's exported <code>refresh</code> method and set <code>refreshIntervalMs</code> to 5 minutes; <code>WidgetHost</code> owns timer and manual refresh calls.</li>
           <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
         </ul>
         <p>Add repo-level tests:</p>

--- a/extensions/recipes/claude-code-quota.html
+++ b/extensions/recipes/claude-code-quota.html
@@ -159,6 +159,9 @@ Cookie: sessionKey=&lt;value&gt;</code></pre>
           <li><code>claude-code-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
           <li>The widget should call <code>window.babyMenu.capabilities.invoke("claude-code-quota", "getQuota", input)</code>.</li>
           <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
+        </ul>
+        <p>Add repo-level tests:</p>
+        <ul>
           <li><code>tests/claude-quota.test.ts</code> for parser and fallback tests.</li>
         </ul>
         <p>Server action response shape:</p>

--- a/extensions/recipes/codex-quota.html
+++ b/extensions/recipes/codex-quota.html
@@ -146,7 +146,7 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Optional Web Dashboard Extras</h2>
         <p>Do not implement browser-cookie scraping in the first widget unless the user explicitly asks for richer dashboard extras.</p>
-        <p>If implemented later, it must be opt-in and main-process only.</p>
+        <p>If implemented later, it must be opt-in and server-action only.</p>
         <p>Dashboard URL: <code>https://chatgpt.com/codex/settings/usage</code>.</p>
         <p>Potential extras include code review remaining, usage breakdown chart data, credits history, and credits purchase URL.</p>
         <p>Cookie handling must never write secrets to committed files or renderer logs.</p>
@@ -154,16 +154,15 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Implementation Contract</h2>
-        <p>Create or edit these files:</p>
+        <p>Create or edit these extension files:</p>
         <ul>
-          <li><code>src/main/codex-quota.ts</code> for main-process data fetching, RPC, and parsing.</li>
-          <li><code>src/main/ipc.ts</code> to expose <code>baby-menu:quota:codex</code>.</li>
-          <li><code>src/preload/index.ts</code> to expose <code>window.babyMenu.quota.codex()</code>.</li>
-          <li><code>src/renderer/widgets/codex-quota-widget.tsx</code> for the renderer widget.</li>
-          <li><code>src/renderer/menu/WidgetHost.tsx</code> or a widget registry file to register the widget.</li>
+          <li><code>codex-quota/server.ts</code> for privileged token, CLI RPC, timeout, and parser work.</li>
+          <li><code>codex-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
+          <li>The widget should call <code>window.babyMenu.capabilities.invoke("codex-quota", "getQuota", input)</code>.</li>
+          <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
           <li><code>tests/codex-quota.test.ts</code> for parser, RPC fallback, timeout, and mock tests.</li>
         </ul>
-        <p>IPC response shape:</p>
+        <p>Server action response shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type QuotaResult&lt;T&gt; =
   | { ok: true; data: T }
   | { ok: false; error: string; sourceTried: string[]; mock?: T };</code></pre>

--- a/extensions/recipes/codex-quota.html
+++ b/extensions/recipes/codex-quota.html
@@ -160,6 +160,9 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
           <li><code>codex-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
           <li>The widget should call <code>window.babyMenu.capabilities.invoke("codex-quota", "getQuota", input)</code>.</li>
           <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
+        </ul>
+        <p>Add repo-level tests:</p>
+        <ul>
           <li><code>tests/codex-quota.test.ts</code> for parser, RPC fallback, timeout, and mock tests.</li>
         </ul>
         <p>Server action response shape:</p>

--- a/extensions/recipes/codex-quota.html
+++ b/extensions/recipes/codex-quota.html
@@ -157,8 +157,9 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
         <p>Create or edit these extension files:</p>
         <ul>
           <li><code>codex-quota/server.ts</code> for privileged token, CLI RPC, timeout, and parser work.</li>
-          <li><code>codex-quota/widget.tsx</code> for the renderer widget, using <code>@babymenu/ui</code>.</li>
+          <li><code>codex-quota/widget.tsx</code> for a <code>RefreshableBabyMenuWidget</code>, using <code>@babymenu/ui</code>.</li>
           <li>The widget should call <code>window.babyMenu.capabilities.invoke("codex-quota", "getQuota", input)</code>.</li>
+          <li>Put quota reload logic in the widget's exported <code>refresh</code> method and set <code>refreshIntervalMs</code> to 5 minutes; <code>WidgetHost</code> owns timer and manual refresh calls.</li>
           <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
         </ul>
         <p>Add repo-level tests:</p>

--- a/extensions/recipes/codex-quota.html
+++ b/extensions/recipes/codex-quota.html
@@ -70,7 +70,7 @@
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>OAuth Usage API Details</h2>
-        <p>Credential locations to check from the main process only:</p>
+        <p>Credential locations to check from <code>codex-quota/server.ts</code> only:</p>
         <ul>
           <li><code>$CODEX_HOME/auth.json</code> if <code>CODEX_HOME</code> is set.</li>
           <li><code>~/.codex/auth.json</code> otherwise.</li>
@@ -104,7 +104,7 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Codex CLI RPC Details</h2>
-        <p>Run privileged CLI work in the Electron main process. Do not expose Node APIs to the renderer.</p>
+        <p>Run privileged CLI work in <code>codex-quota/server.ts</code> behind <code>window.babyMenu.capabilities.invoke</code>. Do not expose Node APIs to the renderer.</p>
         <p>Command:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>codex -s read-only -a untrusted app-server</code></pre>
         <p>JSON-RPC flow over stdin/stdout:</p>

--- a/package.json
+++ b/package.json
@@ -23,12 +23,27 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "@tailwindcss/postcss": "^4.3.0",
     "acpx": "0.7.0",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.16.0",
+    "postcss": "^8.5.15",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "tailwind-merge": "^3.6.0",
+    "tailwindcss": "^4.3.0",
     "typescript": "6.0.3"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
     "@testing-library/react": "16.3.2",
     "@types/node": "25.8.0",
     "@types/react": "19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,23 +4,71 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss: ^8.5.15
+
 importers:
 
   .:
     dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tailwindcss/postcss':
+        specifier: ^4.3.0
+        version: 4.3.0
       acpx:
         specifier: 0.7.0
         version: 0.7.0
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      postcss:
+        specifier: ^8.5.15
+        version: 8.5.15
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      tailwind-merge:
+        specifier: ^3.6.0
+        version: 3.6.0
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.0
+        version: 4.3.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))
       '@testing-library/react':
         specifier: 16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -67,6 +115,10 @@ packages:
     resolution: {integrity: sha512-ZTLH+o9QxcZDLX/9ww+W7C2iExnXFM+vD/uGFVSlR61Kzj9FaxUqBC6Rv/kwgA7qVWYUEI9c5ZNqCuO9PM4rKg==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -586,6 +638,21 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -622,6 +689,406 @@ packages:
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -731,6 +1198,103 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution: {integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution: {integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution: {integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution: {integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.0':
+    resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -911,6 +1475,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -1084,6 +1652,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
@@ -1094,6 +1665,10 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1192,6 +1767,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
@@ -1266,6 +1844,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -1423,6 +2005,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1690,6 +2276,11 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1848,8 +2439,8 @@ packages:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
     engines: {node: '>=10.4.0'}
 
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -1894,6 +2485,36 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react@19.2.6:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
@@ -2061,6 +2682,16 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwind-merge@3.6.0:
+    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
+
+  tailwindcss@4.3.0:
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
@@ -2171,6 +2802,26 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
@@ -2356,6 +3007,8 @@ snapshots:
   '@agentclientprotocol/sdk@0.21.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
+
+  '@alloc/quick-lru@5.2.0': {}
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -2797,6 +3450,23 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -2841,6 +3511,397 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.130.0': {}
+
+  '@radix-ui/number@1.1.1': {}
+
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      aria-hidden: 1.2.6
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.6)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -2900,6 +3961,82 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/postcss@4.3.0':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      postcss: 8.5.15
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -3135,6 +4272,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -3299,6 +4440,10 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-truncate@2.1.0:
     dependencies:
       slice-ansi: 3.0.0
@@ -3314,6 +4459,8 @@ snapshots:
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3400,6 +4547,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0:
     optional: true
@@ -3529,6 +4678,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   entities@8.0.0: {}
 
@@ -3738,6 +4892,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -4003,6 +5159,10 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lucide-react@1.16.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -4140,7 +5300,7 @@ snapshots:
       xmlbuilder: 15.1.1
     optional: true
 
-  postcss@8.5.14:
+  postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -4187,6 +5347,33 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.6)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.6: {}
 
@@ -4361,6 +5548,12 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
   tar-stream@3.2.0:
     dependencies:
       b4a: 1.8.1
@@ -4442,8 +5635,7 @@ snapshots:
     dependencies:
       utf8-byte-length: 1.0.5
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.22.0:
     dependencies:
@@ -4478,6 +5670,21 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.6
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   utf8-byte-length@1.0.5: {}
 
   verror@1.10.1:
@@ -4491,7 +5698,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ allowBuilds:
   electron: true
   electron-winstaller: false
   esbuild: true
+
+overrides:
+  postcss: ^8.5.15

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -31,6 +31,11 @@ type ResolvedLocalImport = {
   path: string;
 };
 
+// Host-provided design system. Widgets import this bare specifier; it is
+// rewritten to the host protocol so Radix/cva/lucide stay inside the host
+// bundle and never reach the widget compiler. Mirrors how `react` is handled.
+export const UI_IMPORT_SPECIFIER = "@babymenu/ui";
+
 const LOCAL_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mjs"];
 const STATIC_IMPORT_PATTERN = /(\b(?:import|export)\b[\s\S]*?\bfrom\s*["'])([^"']+)(["'])/g;
 const SIDE_EFFECT_IMPORT_PATTERN = /(\bimport\s*["'])([^"']+)(["'])/g;
@@ -205,6 +210,7 @@ function rewriteWidgetExternalImport(options: {
   if (options.specifier === "react/jsx-runtime" || options.specifier === "react/jsx-dev-runtime") {
     return "baby-menu-host://react-jsx-runtime/index.mjs";
   }
+  if (options.specifier === UI_IMPORT_SPECIFIER) return "baby-menu-host://ui/index.mjs";
   if (options.validateExternalImports) {
     assertSupportedExternalImport("widget", options.specifier, options.extensionId, options.extensionDir, options.filePath);
   }
@@ -218,7 +224,13 @@ function assertSupportedExternalImport(
   extensionDir: string,
   filePath: string,
 ) {
-  if (kind === "widget" && (specifier === "react" || specifier === "react/jsx-runtime" || specifier === "react/jsx-dev-runtime")) {
+  if (
+    kind === "widget" &&
+    (specifier === "react" ||
+      specifier === "react/jsx-runtime" ||
+      specifier === "react/jsx-dev-runtime" ||
+      specifier === UI_IMPORT_SPECIFIER)
+  ) {
     return;
   }
   if (kind === "server" && (specifier.startsWith("node:") || builtinModules.includes(specifier))) return;

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -36,8 +36,10 @@ export function registerIpcHandlers(
   },
   runtimeOptions: IpcRuntimeOptions = {},
 ) {
+  const recipesDir = runtimeOptions.recipesDir ?? getRecipesDir(rootDir);
+
   ipcMain.handle("baby-menu:recipes:list", async (): Promise<RecipeMetadata[]> => {
-    return loadRecipes(pathToFileURL(`${runtimeOptions.recipesDir ?? getRecipesDir(rootDir)}/`));
+    return loadRecipes(pathToFileURL(`${recipesDir}/`));
   });
 
   ipcMain.handle("baby-menu:agent:send", async (event, prompt: string): Promise<AgentChatResult> => {

--- a/src/main/widget-module-registry.ts
+++ b/src/main/widget-module-registry.ts
@@ -1,10 +1,10 @@
 import type { Dirent } from "node:fs";
-import { access, readdir, stat, writeFile } from "node:fs/promises";
+import { access, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { BabyMenuWidgetModuleDescriptor } from "../shared/contracts";
 import { getExtensionsDir } from "../shared/paths";
 import { compileExtensionModule } from "./extension-module-compiler";
-import { compileWidgetTailwindCss } from "./widget-tailwind-css";
+import { compileWidgetTailwindCss, widgetTailwindCssCacheKey } from "./widget-tailwind-css";
 // The single @theme source, inlined into the main bundle so it ships with the
 // packaged app. electron-vite (dev + build) resolves `?raw` to the file text;
 // note vitest returns "" for `.css?raw`, so token-mapping coverage lives in
@@ -12,6 +12,7 @@ import { compileWidgetTailwindCss } from "./widget-tailwind-css";
 import themeCss from "../ui/theme.css?raw";
 
 const WIDGET_CSS_FILENAME = "widget.css";
+const WIDGET_CSS_CACHE_KEY_FILENAME = "widget.css.cache-key";
 
 export type WidgetModuleRegistry = {
   list: () => Promise<BabyMenuWidgetModuleDescriptor[]>;
@@ -134,11 +135,22 @@ async function compiledWidgetModuleUrls({
 // already keys the output dir by source hash), so polling list() is cheap.
 async function ensureWidgetCss({ extensionDir, outputDir }: { extensionDir: string; outputDir: string }): Promise<string> {
   const cssPath = join(outputDir, WIDGET_CSS_FILENAME);
-  if (!(await pathExists(cssPath))) {
+  const cacheKeyPath = join(outputDir, WIDGET_CSS_CACHE_KEY_FILENAME);
+  const cacheKey = widgetTailwindCssCacheKey(themeCss);
+  if (!(await pathExists(cssPath)) || (await readCacheKey(cacheKeyPath)) !== cacheKey) {
     const css = await compileWidgetTailwindCss({ sourceDir: extensionDir, themeCss });
     await writeFile(cssPath, css, "utf8");
+    await writeFile(cacheKeyPath, cacheKey, "utf8");
   }
   return cssPath;
+}
+
+async function readCacheKey(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
 }
 
 async function pathExists(filePath: string): Promise<boolean> {

--- a/src/main/widget-module-registry.ts
+++ b/src/main/widget-module-registry.ts
@@ -1,9 +1,17 @@
 import type { Dirent } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { access, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { BabyMenuWidgetModuleDescriptor } from "../shared/contracts";
 import { getExtensionsDir } from "../shared/paths";
 import { compileExtensionModule } from "./extension-module-compiler";
+import { compileWidgetTailwindCss } from "./widget-tailwind-css";
+// The single @theme source, inlined into the main bundle so it ships with the
+// packaged app. electron-vite (dev + build) resolves `?raw` to the file text;
+// note vitest returns "" for `.css?raw`, so token-mapping coverage lives in
+// tests/widget-tailwind-css.test.ts which reads theme.css via fs instead.
+import themeCss from "../ui/theme.css?raw";
+
+const WIDGET_CSS_FILENAME = "widget.css";
 
 export type WidgetModuleRegistry = {
   list: () => Promise<BabyMenuWidgetModuleDescriptor[]>;
@@ -74,14 +82,14 @@ async function widgetModuleDescriptor(options: Required<Pick<DiscoverWidgetModul
   if (!extensionId || extensionId === STARTER_EXTENSION_ID) return null;
 
   const fileStat = await stat(filePath);
-  const moduleUrl =
+  const urls =
     options.mode === "compiled"
-      ? await compiledWidgetModuleUrl({ extensionsDir: options.extensionsDir, extensionId, filePath, widgetCacheDir: options.widgetCacheDir })
-      : rendererModuleUrl(filePath, fileStat.mtimeMs);
+      ? await compiledWidgetModuleUrls({ extensionsDir: options.extensionsDir, extensionId, filePath, widgetCacheDir: options.widgetCacheDir })
+      : { moduleUrl: rendererModuleUrl(filePath, fileStat.mtimeMs) };
   return {
     id: `${extensionId}.widget`,
     extensionId,
-    moduleUrl,
+    ...urls,
   };
 }
 
@@ -94,7 +102,7 @@ function inferExtensionId(extensionsDir: string, filePath: string): string | nul
   return parent && parent !== "." ? parent : basename(filePath, extname(filePath));
 }
 
-async function compiledWidgetModuleUrl({
+async function compiledWidgetModuleUrls({
   extensionsDir,
   extensionId,
   filePath,
@@ -104,7 +112,7 @@ async function compiledWidgetModuleUrl({
   extensionId: string;
   filePath: string;
   widgetCacheDir?: string;
-}): Promise<string> {
+}): Promise<{ moduleUrl: string; cssUrl: string }> {
   if (!widgetCacheDir) throw new Error("widgetCacheDir is required for compiled widget modules");
   const extensionDir = join(resolve(extensionsDir), extensionId);
   const compiled = await compileExtensionModule({
@@ -114,10 +122,37 @@ async function compiledWidgetModuleUrl({
     entryFile: filePath,
     cacheRoot: widgetCacheDir,
   });
-  const outputRelativePath = relative(compiled.outputDir, compiled.outputPath).split("\\").join("/");
+
+  const cssFileUrl = await ensureWidgetCss({ extensionDir, outputDir: compiled.outputDir });
   const encodedExtensionId = encodeURIComponent(extensionId);
-  const encodedPath = outputRelativePath.split("/").map(encodeURIComponent).join("/");
-  return `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodedPath}`;
+  const moduleUrl = `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodeModulePath(compiled.outputDir, compiled.outputPath)}`;
+  const cssUrl = `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodeModulePath(compiled.outputDir, cssFileUrl)}`;
+  return { moduleUrl, cssUrl };
+}
+
+// Compiles the widget's Tailwind utilities once per content hash (the JS compile
+// already keys the output dir by source hash), so polling list() is cheap.
+async function ensureWidgetCss({ extensionDir, outputDir }: { extensionDir: string; outputDir: string }): Promise<string> {
+  const cssPath = join(outputDir, WIDGET_CSS_FILENAME);
+  if (!(await pathExists(cssPath))) {
+    const css = await compileWidgetTailwindCss({ sourceDir: extensionDir, themeCss });
+    await writeFile(cssPath, css, "utf8");
+  }
+  return cssPath;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function encodeModulePath(outputDir: string, filePath: string): string {
+  const relativePath = relative(outputDir, filePath).split("\\").join("/");
+  return relativePath.split("/").map(encodeURIComponent).join("/");
 }
 
 function rendererModuleUrl(filePath: string, mtimeMs: number): string {

--- a/src/main/widget-protocol.ts
+++ b/src/main/widget-protocol.ts
@@ -1,6 +1,7 @@
 import { protocol } from "electron";
 import { readFile } from "node:fs/promises";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { extname, isAbsolute, join, relative, resolve } from "node:path";
+import { UI_EXPORT_NAMES } from "../shared/ui-exports";
 
 const WIDGET_SCHEME = "baby-menu-widget";
 const HOST_SCHEME = "baby-menu-host";
@@ -32,7 +33,7 @@ export function registerBabyMenuProtocolHandlers(options: { widgetCacheDir: stri
   protocol.handle(WIDGET_SCHEME, async (request) => {
     const filePath = resolveWidgetProtocolFilePath(options.widgetCacheDir, request.url);
     const source = await readFile(filePath, "utf8");
-    return new Response(source, { headers: { "content-type": "text/javascript; charset=utf-8" } });
+    return new Response(source, { headers: { "content-type": widgetContentType(filePath) } });
   });
 
   protocol.handle(HOST_SCHEME, async (request) => {
@@ -50,7 +51,8 @@ export function resolveWidgetProtocolFilePath(widgetCacheDir: string, rawUrl: st
   if (!extensionId || pathSegments.length < 2 || pathSegments.some((segment) => segment === "." || segment === "..")) {
     throw new Error("Invalid widget module URL");
   }
-  if (!pathSegments.at(-1)?.endsWith(".mjs")) throw new Error("Invalid widget module URL");
+  const lastSegment = pathSegments.at(-1) ?? "";
+  if (!lastSegment.endsWith(".mjs") && !lastSegment.endsWith(".css")) throw new Error("Invalid widget module URL");
 
   const filePath = resolve(join(widgetCacheDir, extensionId, ...pathSegments));
   const relativePath = relative(resolve(widgetCacheDir), filePath);
@@ -114,5 +116,20 @@ export const Fragment = runtime.Fragment;
 `;
   }
 
+  if (moduleId === "ui/index.mjs") {
+    // Re-export the design system from the host global, mirroring the React
+    // shim. The export list is the contract in shared/ui-exports.ts; Radix, cva,
+    // and lucide are bundled inside the host build and never seen by the widget
+    // compiler, so widget import constraints stay intact.
+    const reexports = UI_EXPORT_NAMES.map((name) => `export const ${name} = ui.${name};`).join("\n");
+    return `const ui = window.__BABY_MENU_WIDGET_HOST__.ui;\n${reexports}\n`;
+  }
+
   throw new Error("Unknown host module URL");
+}
+
+function widgetContentType(filePath: string): string {
+  return extname(filePath) === ".css"
+    ? "text/css; charset=utf-8"
+    : "text/javascript; charset=utf-8";
 }

--- a/src/main/widget-tailwind-css.ts
+++ b/src/main/widget-tailwind-css.ts
@@ -1,11 +1,11 @@
 import postcss from "postcss";
 import tailwind from "@tailwindcss/postcss";
 import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join, sep } from "node:path";
-import packageJson from "../../package.json";
+import { dirname, join, sep } from "node:path";
 
 const require = createRequire(import.meta.url);
 
@@ -46,17 +46,25 @@ export async function compileWidgetTailwindCss({ sourceDir, themeCss }: CompileW
 }
 
 export function widgetTailwindCssCacheKey(themeCss: string): string {
-  const dependencies = packageJson.dependencies;
+  const compilerPackageMetadata = ["tailwindcss", "@tailwindcss/postcss", "postcss"].map((packageName) =>
+    readFileSync(resolvePackageJson(packageName), "utf8"),
+  );
   return createHash("sha256")
     .update("widget-tailwind-css-v1")
     .update("\0")
     .update(themeCss)
     .update("\0")
-    .update(dependencies.tailwindcss ?? "")
-    .update("\0")
-    .update(dependencies["@tailwindcss/postcss"] ?? "")
-    .update("\0")
-    .update(dependencies.postcss ?? "")
+    .update(compilerPackageMetadata.join("\0"))
     .digest("hex")
     .slice(0, 16);
+}
+
+function resolvePackageJson(packageName: string): string {
+  let currentDir = dirname(require.resolve(packageName));
+  while (currentDir !== dirname(currentDir)) {
+    const packageJsonPath = join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) return packageJsonPath;
+    currentDir = dirname(currentDir);
+  }
+  throw new Error(`Could not resolve package.json for ${packageName}`);
 }

--- a/src/main/widget-tailwind-css.ts
+++ b/src/main/widget-tailwind-css.ts
@@ -1,0 +1,44 @@
+import postcss from "postcss";
+import tailwind from "@tailwindcss/postcss";
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+// Anchor PostCSS's `from` at the install root that owns `node_modules/tailwindcss`
+// so `@import "tailwindcss"` resolves in both source and packaged runtimes,
+// independent of process.cwd() (which is unreliable in a packaged Electron app).
+function tailwindResolveBase(): string {
+  const entry = require.resolve("tailwindcss");
+  const [base] = entry.split(`${sep}node_modules${sep}`);
+  return base || process.cwd();
+}
+
+export type CompileWidgetTailwindCssOptions = {
+  // Directory scanned for Tailwind class candidates (the extension workspace).
+  sourceDir: string;
+  // The `@theme { ... }` block defining Baby Menu tokens, read from the single
+  // source of truth at src/ui/theme.css. Off-palette utilities do not exist.
+  themeCss: string;
+};
+
+// Compiles the utility CSS an agent authored in a widget's source. Used only in
+// compiled/packaged mode; dev mode gets utilities from the global stylesheet.
+export async function compileWidgetTailwindCss({ sourceDir, themeCss }: CompileWidgetTailwindCssOptions): Promise<string> {
+  // Tailwind's scanner skips hidden path segments, and the packaged workspace
+  // lives under ~/.baby-menu. Copy the sources into a clean, non-hidden temp dir
+  // so scanning works regardless of where the extension actually resides.
+  const scanDir = await mkdtemp(join(tmpdir(), "baby-menu-widget-scan-"));
+  try {
+    await cp(sourceDir, scanDir, { recursive: true });
+    const input = `@import "tailwindcss" source(none);\n@source "${scanDir}";\n${themeCss}\n`;
+    const result = await postcss([tailwind()]).process(input, {
+      from: join(tailwindResolveBase(), "widget-tailwind-input.css"),
+    });
+    return result.css;
+  } finally {
+    await rm(scanDir, { recursive: true, force: true });
+  }
+}

--- a/src/main/widget-tailwind-css.ts
+++ b/src/main/widget-tailwind-css.ts
@@ -1,9 +1,11 @@
 import postcss from "postcss";
 import tailwind from "@tailwindcss/postcss";
+import { createHash } from "node:crypto";
 import { cp, mkdtemp, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
+import packageJson from "../../package.json";
 
 const require = createRequire(import.meta.url);
 
@@ -41,4 +43,20 @@ export async function compileWidgetTailwindCss({ sourceDir, themeCss }: CompileW
   } finally {
     await rm(scanDir, { recursive: true, force: true });
   }
+}
+
+export function widgetTailwindCssCacheKey(themeCss: string): string {
+  const dependencies = packageJson.dependencies;
+  return createHash("sha256")
+    .update("widget-tailwind-css-v1")
+    .update("\0")
+    .update(themeCss)
+    .update("\0")
+    .update(dependencies.tailwindcss ?? "")
+    .update("\0")
+    .update(dependencies["@tailwindcss/postcss"] ?? "")
+    .update("\0")
+    .update(dependencies.postcss ?? "")
+    .digest("hex")
+    .slice(0, 16);
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,55 +1,98 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Settings, X } from "lucide-react";
+import { Button } from "../ui";
 import { AgentChat } from "./agent/AgentChat";
 import { MenuSurface } from "./menu/MenuSurface";
+import { SettingsView } from "./settings/SettingsView";
+
+type AppView = "menu" | "settings";
 
 export function App() {
+  const [view, setView] = useState<AppView>("menu");
+  const shellRef = useRef<HTMLElement>(null);
+  // Hold the popover at the menu's height while in settings so toggling never
+  // resizes the window or shrinks the visible card to the smaller settings body.
+  const [frozenHeight, setFrozenHeight] = useState<number | null>(null);
   usePopoverContentHeight();
+  useDropHeaderAutoFocus();
+
+  function openSettings() {
+    setFrozenHeight(shellRef.current?.offsetHeight ?? null);
+    setView("settings");
+  }
+
+  function closeSettings() {
+    setFrozenHeight(null);
+    setView("menu");
+  }
 
   return (
-    <main className="app-shell" aria-label="baby_menu tray popover">
+    <main
+      ref={shellRef}
+      className="app-shell"
+      aria-label="baby_menu tray popover"
+      style={view === "settings" && frozenHeight ? { minHeight: `${frozenHeight}px` } : undefined}
+    >
       <header className="pop-head">
-        <span className="mark">
-          baby<span className="sep">_</span>menu
-        </span>
-        <OpenAtLoginToggle />
+        {view === "settings" ? (
+          <span className="mark">settings</span>
+        ) : (
+          <span className="mark">
+            baby<span className="sep">_</span>menu
+          </span>
+        )}
+        {view === "settings" ? (
+          <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="close settings" onClick={closeSettings}>
+            <X className="size-4" />
+          </Button>
+        ) : (
+          <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="open settings" onClick={openSettings}>
+            <Settings className="size-4" />
+          </Button>
+        )}
       </header>
-      <div className="pop-body">
-        <MenuSurface />
-      </div>
-      <AgentChat />
+      {view === "settings" ? (
+        <div className="pop-body">
+          <SettingsView />
+        </div>
+      ) : (
+        <>
+          <div className="pop-body">
+            <MenuSurface />
+          </div>
+          <AgentChat />
+        </>
+      )}
     </main>
   );
 }
 
-function OpenAtLoginToggle() {
-  const [openAtLogin, setOpenAtLogin] = useState<boolean | null>(null);
+// Matches MAX_POPOVER_HEIGHT in src/main/popover.ts. While a design-system
+// overlay is open we ask for the full window so the overlay has room rather than
+// clipping; the main process clamps to the same max, so the value is stable.
+const OVERLAY_POPOVER_HEIGHT = 720;
 
+function measurePopoverContentHeight(shell: HTMLElement): number {
+  const shellHeight = Math.ceil(shell.getBoundingClientRect().height);
+  const overlayOpen = document.querySelector("[data-bm-overlay]") !== null;
+  return overlayOpen ? Math.max(shellHeight, OVERLAY_POPOVER_HEIGHT) : shellHeight;
+}
+
+// The popover opens focused (main calls window.focus()); if that focus lands on a
+// header control it gets ring-highlighted before the user does anything. Clear
+// that auto-focus without touching genuine keyboard focus elsewhere.
+function useDropHeaderAutoFocus() {
   useEffect(() => {
-    let cancelled = false;
-    void window.babyMenu?.settings?.get().then((settings) => {
-      if (!cancelled) setOpenAtLogin(settings.openAtLogin);
-    });
-    return () => {
-      cancelled = true;
+    const drop = () => {
+      requestAnimationFrame(() => {
+        const active = document.activeElement as HTMLElement | null;
+        if (active && active.closest(".pop-head")) active.blur();
+      });
     };
+    drop();
+    window.addEventListener("focus", drop);
+    return () => window.removeEventListener("focus", drop);
   }, []);
-
-  async function toggle() {
-    if (openAtLogin === null || !window.babyMenu?.settings) return;
-    const next = await window.babyMenu.settings.setOpenAtLogin(!openAtLogin);
-    setOpenAtLogin(next.openAtLogin);
-  }
-
-  return (
-    <button
-      type="button"
-      className={`settings-toggle${openAtLogin ? " enabled" : ""}`}
-      aria-pressed={openAtLogin ? "true" : "false"}
-      onClick={() => void toggle()}
-    >
-      login {openAtLogin ? "on" : "off"}
-    </button>
-  );
 }
 
 function usePopoverContentHeight() {
@@ -63,7 +106,7 @@ function usePopoverContentHeight() {
       if (animationFrame) window.cancelAnimationFrame(animationFrame);
       animationFrame = window.requestAnimationFrame(() => {
         animationFrame = 0;
-        const height = Math.ceil(element.getBoundingClientRect().height);
+        const height = measurePopoverContentHeight(element);
         if (!height || height === lastHeight) return;
         lastHeight = height;
         void window.babyMenu?.popover.setContentHeight(height);
@@ -71,16 +114,17 @@ function usePopoverContentHeight() {
     };
 
     report();
-    if (typeof ResizeObserver === "undefined") {
-      return () => {
-        if (animationFrame) window.cancelAnimationFrame(animationFrame);
-      };
-    }
 
-    const observer = new ResizeObserver(report);
-    observer.observe(element);
+    const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(report);
+    resizeObserver?.observe(element);
+    // Overlays (Dialog/Select/Dropdown) portal outside .app-shell, so watch the
+    // body subtree to react when one opens or closes.
+    const mutationObserver = typeof MutationObserver === "undefined" ? null : new MutationObserver(report);
+    mutationObserver?.observe(document.body, { childList: true, subtree: true });
+
     return () => {
-      observer.disconnect();
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
       if (animationFrame) window.cancelAnimationFrame(animationFrame);
     };
   }, []);

--- a/src/renderer/agent/AgentChat.tsx
+++ b/src/renderer/agent/AgentChat.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, KeyboardEvent, useEffect, useRef, useState } from "react";
+import { Button } from "../../ui";
 import { useAgentRuntime, type AgentRun, type AgentSessionNotice } from "./useAgentRuntime";
 
 export function AgentChat() {
@@ -121,12 +122,12 @@ function SessionBar({
           {session.summary}
           <span className="sb-hint">{session.hint}</span>
         </div>
-        <button type="button" className="btn btn-primary" disabled={!session.canKeep} onClick={() => void onKeep()}>
+        <Button variant="primary" size="sm" disabled={!session.canKeep} onClick={() => void onKeep()}>
           Keep
-        </button>
-        <button type="button" className="btn btn-danger" disabled={!session.canUndo} onClick={() => void onUndo()}>
+        </Button>
+        <Button variant="danger" size="sm" disabled={!session.canUndo} onClick={() => void onUndo()}>
           Undo
-        </button>
+        </Button>
       </div>
     );
   }
@@ -138,9 +139,9 @@ function SessionBar({
         {session.summary}
         {session.hint ? <span className="sb-hint">{session.hint}</span> : null}
       </div>
-      <button type="button" className="btn btn-ghost" onClick={onDismiss}>
+      <Button variant="ghost" size="sm" onClick={onDismiss}>
         Dismiss
-      </button>
+      </Button>
       <span />
     </div>
   );

--- a/src/renderer/colors_and_type.css
+++ b/src/renderer/colors_and_type.css
@@ -57,11 +57,11 @@
   --font-prose: "Inter Tight", -apple-system, BlinkMacSystemFont,
     "SF Pro Text", "Segoe UI", sans-serif;
 
-  --fs-xxs: 0.625rem;
-  --fs-xs: 0.6875rem;
-  --fs-sm: 0.75rem;
-  --fs-base: 0.8125rem;
-  --fs-md: 0.9375rem;
+  --fs-xxs: 0.6875rem;
+  --fs-xs: 0.75rem;
+  --fs-sm: 0.8125rem;
+  --fs-base: 0.875rem;
+  --fs-md: 1rem;
   --fs-lg: 1.125rem;
   --fs-xl: 1.5rem;
   --fs-2xl: 1.75rem;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -2,13 +2,15 @@ import * as React from "react";
 import * as jsxRuntime from "react/jsx-runtime";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import * as babyMenuUi from "../ui";
 import { installWidgetHostShims } from "./widget-host-shim";
+import "../ui/styles.css";
 import "./styles.css";
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing root element");
 
-installWidgetHostShims(window, React, jsxRuntime);
+installWidgetHostShims(window, React, jsxRuntime, babyMenuUi);
 
 createRoot(root).render(
   <React.StrictMode>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -7,6 +7,10 @@ import { installWidgetHostShims } from "./widget-host-shim";
 import "../ui/styles.css";
 import "./styles.css";
 
+if (import.meta.env.DEV) {
+  void import("../ui/styles.dev.css");
+}
+
 const root = document.getElementById("root");
 if (!root) throw new Error("Missing root element");
 

--- a/src/renderer/menu/WidgetHost.tsx
+++ b/src/renderer/menu/WidgetHost.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
 import type { RefreshableBabyMenuWidget } from "../../shared/contracts";
 import { helloWorldWidget } from "../../../extensions/hello-world/widget";
+import { Button } from "../../ui";
 import { useWidgetRefresh } from "./useWidgetRefresh";
 
 export type RuntimeWidgetImporter = (moduleUrl: string) => Promise<unknown>;
@@ -18,9 +20,15 @@ function WidgetCard({ widget }: { widget: RefreshableBabyMenuWidget }) {
     <article className="widget">
       <header className="w-head">
         <h3 className="key">{widget.title}</h3>
-        <button type="button" className="refresh" onClick={refreshNow} aria-label={`refresh ${widget.title}`}>
-          ⟳
-        </button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="refresh -mr-1 px-1.5"
+          onClick={refreshNow}
+          aria-label={`refresh ${widget.title}`}
+        >
+          <RefreshCw className="size-3.5" />
+        </Button>
       </header>
       <div>{widget.render()}</div>
     </article>
@@ -104,6 +112,7 @@ export async function loadRuntimeWidgets(importer: RuntimeWidgetImporter = impor
   const widgetGroups = await Promise.all(
     descriptors.map(async (descriptor) => {
       try {
+        if (descriptor.cssUrl) ensureWidgetStylesheet(descriptor.cssUrl);
         return widgetsFromModule(await importer(descriptor.moduleUrl));
       } catch {
         return [];
@@ -111,6 +120,18 @@ export async function loadRuntimeWidgets(importer: RuntimeWidgetImporter = impor
     }),
   );
   return widgetGroups.flat();
+}
+
+// Injects a compiled widget's Tailwind stylesheet (packaged mode only). Dev mode
+// descriptors carry no cssUrl because utilities come from the global stylesheet.
+function ensureWidgetStylesheet(href: string) {
+  if (typeof document === "undefined") return;
+  if (document.querySelector(`link[data-baby-menu-widget-css="${CSS.escape(href)}"]`)) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = href;
+  link.dataset.babyMenuWidgetCss = href;
+  document.head.appendChild(link);
 }
 
 export function widgetsFromModule(module: unknown): RefreshableBabyMenuWidget[] {

--- a/src/renderer/settings/SettingsView.tsx
+++ b/src/renderer/settings/SettingsView.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+import { Switch } from "../../ui";
+
+export function SettingsView() {
+  const [openAtLogin, setOpenAtLogin] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.babyMenu?.settings?.get().then((settings) => {
+      if (!cancelled) setOpenAtLogin(settings.openAtLogin);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function toggle(next: boolean) {
+    if (!window.babyMenu?.settings) return;
+    const result = await window.babyMenu.settings.setOpenAtLogin(next);
+    setOpenAtLogin(result.openAtLogin);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-xxs uppercase tracking-caps text-ink-label">preferences</span>
+      <div className="flex items-center justify-between gap-4">
+        <span className="flex flex-col gap-0.5">
+          <span className="text-sm text-ink">open at login</span>
+          <span className="text-xs text-ink-soft">launch baby_menu when you sign in</span>
+        </span>
+        <Switch checked={openAtLogin} onCheckedChange={(next) => void toggle(next)} aria-label="open at login" />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -53,7 +53,10 @@ button:disabled,
 .app-shell {
   width: 360px;
   height: auto;
-  max-height: min(720px, 100vh);
+  /* A fixed cap, not a viewport-relative one: the viewport height equals the
+     auto-sized window, so capping to it would ratchet the popover - it could
+     shrink but never grow back. The main process clamps the reported height. */
+  max-height: 720px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -66,6 +69,7 @@ button:disabled,
 }
 
 .pop-head {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -86,29 +90,24 @@ button:disabled,
   color: var(--signal-live);
 }
 
-.settings-toggle {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--ink-faint);
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.12em;
-  padding: 3px 8px;
-  text-transform: uppercase;
-}
-
-.settings-toggle.enabled {
-  border-color: rgba(106, 227, 182, 0.35);
-  color: var(--signal-live);
-}
-
+/* The scroll region. The window auto-extends to fit content (app-shell grows to
+   its 720px max), so this only scrolls once the window is actually maxed out -
+   the header and composer stay pinned via flex: 0 0 auto. */
 .pop-body {
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
   padding: 12px 14px;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.pop-body::-webkit-scrollbar {
+  width: 4px;
+}
+
+.pop-body::-webkit-scrollbar-thumb {
+  background: var(--ink-800);
+  border-radius: var(--radius-pill);
 }
 
 .menu-surface {
@@ -118,19 +117,8 @@ button:disabled,
 .widget-host {
   display: flex;
   flex-direction: column;
-  max-height: 360px;
-  overflow-y: auto;
   margin: 0 -4px;
   padding: 0 4px;
-}
-
-.widget-host::-webkit-scrollbar {
-  width: 4px;
-}
-
-.widget-host::-webkit-scrollbar-thumb {
-  background: var(--ink-800);
-  border-radius: var(--radius-pill);
 }
 
 .widget {
@@ -268,6 +256,7 @@ button:disabled,
 }
 
 .runstrip {
+  flex: 0 0 auto;
   display: grid;
   grid-template-columns: 14px 1fr auto;
   align-items: center;
@@ -343,6 +332,7 @@ button:disabled,
 }
 
 .sessionbar {
+  flex: 0 0 auto;
   display: grid;
   grid-template-columns: 14px 1fr auto auto;
   align-items: center;
@@ -469,6 +459,7 @@ button:disabled,
 }
 
 .composer-wrap {
+  flex: 0 0 auto;
   padding: 8px 12px 10px;
   border-top: 1px solid var(--line);
   background: var(--bg-stage);

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module "*.css";
 
 declare module "*.css?raw" {

--- a/src/renderer/vite-env.d.ts
+++ b/src/renderer/vite-env.d.ts
@@ -1,1 +1,6 @@
 declare module "*.css";
+
+declare module "*.css?raw" {
+  const content: string;
+  export default content;
+}

--- a/src/renderer/widget-host-shim.ts
+++ b/src/renderer/widget-host-shim.ts
@@ -1,3 +1,3 @@
-export function installWidgetHostShims(target: Window, React: unknown, jsxRuntime: unknown) {
-  target.__BABY_MENU_WIDGET_HOST__ = { React, jsxRuntime };
+export function installWidgetHostShims(target: Window, React: unknown, jsxRuntime: unknown, ui: unknown) {
+  target.__BABY_MENU_WIDGET_HOST__ = { React, jsxRuntime, ui };
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -51,6 +51,9 @@ export type BabyMenuWidgetModuleDescriptor = {
   id: string;
   extensionId: string;
   moduleUrl: string;
+  // Compiled per-widget Tailwind stylesheet, present only in packaged/compiled
+  // mode. In dev/source mode widget utilities come from the global stylesheet.
+  cssUrl?: string;
 };
 
 export type BabyMenuWidget = {
@@ -105,6 +108,7 @@ declare global {
     __BABY_MENU_WIDGET_HOST__?: {
       React: unknown;
       jsxRuntime: unknown;
+      ui: unknown;
     };
   }
 }

--- a/src/shared/ui-exports.ts
+++ b/src/shared/ui-exports.ts
@@ -1,0 +1,49 @@
+/**
+ * The public surface of the @babymenu/ui design system.
+ *
+ * This is the stability contract for extension widgets, treated with the same
+ * care as the preload bridge: removing or renaming an entry can break already
+ * installed widgets. The host re-export shim (widget-protocol.ts) is generated
+ * from this list, and a test asserts it stays in sync with the src/ui barrel,
+ * so the three can never drift apart.
+ */
+export const UI_EXPORT_NAMES = [
+  "cn",
+  "Badge",
+  "Button",
+  "Card",
+  "CardBody",
+  "CardHeader",
+  "DataTable",
+  "Dialog",
+  "DialogBody",
+  "DialogContent",
+  "DialogDescription",
+  "DialogFooter",
+  "DialogTitle",
+  "DialogTrigger",
+  "DropdownMenu",
+  "DropdownMenuContent",
+  "DropdownMenuItem",
+  "DropdownMenuTrigger",
+  "Field",
+  "Input",
+  "Progress",
+  "Select",
+  "SelectContent",
+  "SelectItem",
+  "SelectTrigger",
+  "SelectValue",
+  "Skeleton",
+  "Sparkline",
+  "StatusDot",
+  "Switch",
+  "Tabs",
+  "TabsContent",
+  "TabsList",
+  "TabsTrigger",
+  "Textarea",
+  "Tooltip",
+] as const;
+
+export type UiExportName = (typeof UI_EXPORT_NAMES)[number];

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -1,0 +1,46 @@
+import type { ComponentProps } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "./lib/cn";
+
+const badge = cva(
+  "inline-flex items-center gap-1.5 rounded-pill border px-2 py-0.5 font-mono text-xxs uppercase tracking-caps",
+  {
+    variants: {
+      tone: {
+        neutral: "border-line text-ink-muted",
+        live: "border-signal-live/30 text-signal-live",
+        warn: "border-signal-warn/30 text-signal-warn",
+        danger: "border-signal-danger/30 text-signal-danger",
+      },
+    },
+    defaultVariants: { tone: "neutral" },
+  },
+);
+
+export type BadgeProps = ComponentProps<"span"> & VariantProps<typeof badge>;
+
+export function Badge({ className, tone, ...props }: BadgeProps) {
+  return <span data-slot="badge" className={cn(badge({ tone }), className)} {...props} />;
+}
+
+const dotTone = {
+  live: "bg-signal-live shadow-[0_0_6px_currentColor] text-signal-live",
+  warn: "bg-signal-warn shadow-[0_0_6px_currentColor] text-signal-warn",
+  danger: "bg-signal-danger shadow-[0_0_6px_currentColor] text-signal-danger",
+  muted: "bg-ink-soft",
+} as const;
+
+export type StatusDotProps = ComponentProps<"span"> & { tone?: keyof typeof dotTone };
+
+// The canonical Monochrome Lab signal: a small glowing dot. Pair with a terse
+// uppercase status word next to it.
+export function StatusDot({ className, tone = "live", ...props }: StatusDotProps) {
+  return (
+    <span
+      data-slot="status-dot"
+      aria-hidden="true"
+      className={cn("inline-block size-1.5 rounded-full", dotTone[tone], className)}
+      {...props}
+    />
+  );
+}

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "./lib/cn";
+
+const button = cva(
+  "inline-flex items-center justify-center gap-2 rounded-sm font-mono tracking-tight outline-none transition-colors focus-visible:ring-1 focus-visible:ring-signal-live disabled:pointer-events-none disabled:opacity-40",
+  {
+    variants: {
+      // Monochrome Lab: emphasis comes from inversion, not color. Mint stays a
+      // signal; coral is reserved for destructive intent.
+      variant: {
+        default: "border border-line bg-elevated text-ink hover:bg-pressed",
+        primary: "bg-ink-strong text-stage hover:bg-ink",
+        ghost: "text-ink-muted hover:bg-pressed hover:text-ink",
+        danger: "border border-line text-signal-danger hover:bg-pressed",
+      },
+      size: {
+        sm: "h-7 px-2.5 text-xs",
+        md: "h-8 px-3 text-sm",
+      },
+    },
+    defaultVariants: { variant: "default", size: "md" },
+  },
+);
+
+export type ButtonProps = ComponentProps<"button"> & VariantProps<typeof button>;
+
+export function Button({ className, variant, size, type = "button", ...props }: ButtonProps) {
+  return <button type={type} data-slot="button" className={cn(button({ variant, size }), className)} {...props} />;
+}

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from "react";
+import { cn } from "./lib/cn";
+
+// A quiet grouping surface. Tray widgets usually do not need their own card
+// (the host owns the outer chrome); use this for nested grouping inside a widget.
+export function Card({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn("rounded-md border border-line bg-surface", className)}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn("flex items-center justify-between border-b border-line-faint px-3 py-2", className)}
+      {...props}
+    />
+  );
+}
+
+export function CardBody({ className, ...props }: ComponentProps<"div">) {
+  return <div data-slot="card-body" className={cn("px-3 py-2.5", className)} {...props} />;
+}

--- a/src/ui/DataTable.tsx
+++ b/src/ui/DataTable.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+import { cn } from "./lib/cn";
+
+export type DataTableColumn<Row> = {
+  key: string;
+  header: ReactNode;
+  align?: "left" | "right";
+  render?: (row: Row) => ReactNode;
+};
+
+export type DataTableProps<Row> = {
+  columns: DataTableColumn<Row>[];
+  rows: Row[];
+  getRowKey?: (row: Row, index: number) => string | number;
+  className?: string;
+  empty?: ReactNode;
+};
+
+// A compact, scannable table for tray reports. Numbers right-align and use
+// tabular figures; headers are quiet tracked-caps metadata.
+export function DataTable<Row>({ columns, rows, getRowKey, className, empty = "no data" }: DataTableProps<Row>) {
+  if (rows.length === 0) {
+    return <div className="py-3 text-center text-xs text-ink-soft">{empty}</div>;
+  }
+
+  return (
+    <table data-slot="data-table" className={cn("w-full border-collapse font-mono text-sm tabular-nums", className)}>
+      <thead>
+        <tr className="border-b border-line">
+          {columns.map((column) => (
+            <th
+              key={column.key}
+              className={cn(
+                "px-1.5 py-1 text-xxs font-normal uppercase tracking-caps text-ink-label",
+                column.align === "right" ? "text-right" : "text-left",
+              )}
+            >
+              {column.header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={getRowKey?.(row, index) ?? index} className="border-b border-line-faint last:border-0">
+            {columns.map((column) => (
+              <td
+                key={column.key}
+                className={cn("px-1.5 py-1 text-ink", column.align === "right" ? "text-right" : "text-left")}
+              >
+                {column.render ? column.render(row) : (row as Record<string, ReactNode>)[column.key]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/ui/Dialog.tsx
+++ b/src/ui/Dialog.tsx
@@ -1,0 +1,69 @@
+import type { ComponentProps } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "./lib/cn";
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+export function DialogContent({ className, children, ...props }: DialogPrimitive.DialogContentProps) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay data-slot="dialog-overlay" className="fixed inset-0 z-50 bg-void/70" />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        data-bm-overlay=""
+        // Sized to live inside the small tray window: never wider/taller than
+        // the popover, with internal scroll for overflow.
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 flex max-h-[calc(100vh-1rem)] w-[calc(100vw-1rem)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-md border border-line bg-surface font-mono text-sm text-ink shadow-2xl",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close
+          data-slot="dialog-close"
+          aria-label="close"
+          className="absolute right-3 top-3 text-ink-soft outline-none transition-colors hover:text-ink-strong focus-visible:text-ink-strong"
+        >
+          <X className="size-4" />
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+
+export function DialogTitle({ className, ...props }: DialogPrimitive.DialogTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("px-4 pt-4 pr-9 text-md text-ink-strong", className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogDescription({ className, ...props }: DialogPrimitive.DialogDescriptionProps) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("px-4 pt-1 text-sm text-ink-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export function DialogBody({ className, ...props }: ComponentProps<"div">) {
+  return <div data-slot="dialog-body" className={cn("overflow-y-auto px-4 py-3", className)} {...props} />;
+}
+
+export function DialogFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex justify-end gap-2 border-t border-line-faint px-4 py-3", className)}
+      {...props}
+    />
+  );
+}

--- a/src/ui/DropdownMenu.tsx
+++ b/src/ui/DropdownMenu.tsx
@@ -1,0 +1,35 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "./lib/cn";
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+export function DropdownMenuContent({ className, ...props }: DropdownMenuPrimitive.DropdownMenuContentProps) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        data-bm-overlay=""
+        sideOffset={4}
+        className={cn(
+          "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-40 overflow-y-auto rounded-sm border border-line bg-surface p-1 font-mono text-sm text-ink shadow-lg",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+export function DropdownMenuItem({ className, ...props }: DropdownMenuPrimitive.DropdownMenuItemProps) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "flex cursor-default items-center rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-pressed data-[highlighted]:text-ink-strong",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/ui/Field.tsx
+++ b/src/ui/Field.tsx
@@ -1,0 +1,39 @@
+import type { ComponentProps, ReactElement, ReactNode } from "react";
+import { cloneElement, isValidElement, useId } from "react";
+import { cn } from "./lib/cn";
+
+const controlClass =
+  "w-full rounded-sm border border-line bg-elevated px-2.5 py-1.5 font-mono text-sm text-ink outline-none placeholder:text-ink-soft focus-visible:border-signal-live disabled:opacity-40";
+
+export function Input({ className, type = "text", ...props }: ComponentProps<"input">) {
+  return <input type={type} data-slot="input" className={cn(controlClass, className)} {...props} />;
+}
+
+export function Textarea({ className, ...props }: ComponentProps<"textarea">) {
+  return <textarea data-slot="textarea" className={cn(controlClass, "resize-y", className)} {...props} />;
+}
+
+export type FieldProps = {
+  label: ReactNode;
+  hint?: ReactNode;
+  children: ReactElement<{ id?: string }>;
+  className?: string;
+};
+
+// Wraps a single control with a tracked-caps label and optional hint, wiring
+// label htmlFor to the control id (generated if the control has none).
+export function Field({ label, hint, children, className }: FieldProps) {
+  const generatedId = useId();
+  const id = (isValidElement(children) && children.props.id) || generatedId;
+  const control = isValidElement(children) ? cloneElement(children, { id }) : children;
+
+  return (
+    <div data-slot="field" className={cn("flex flex-col gap-1.5", className)}>
+      <label htmlFor={id} className="text-xxs uppercase tracking-caps text-ink-label">
+        {label}
+      </label>
+      {control}
+      {hint ? <span className="text-xs text-ink-soft">{hint}</span> : null}
+    </div>
+  );
+}

--- a/src/ui/Progress.tsx
+++ b/src/ui/Progress.tsx
@@ -1,0 +1,32 @@
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import { cn } from "./lib/cn";
+
+export type ProgressProps = ProgressPrimitive.ProgressProps & {
+  // Tone of the fill. Mint by default (a signal); use warn/danger for alerts.
+  tone?: "live" | "warn" | "danger";
+};
+
+const fillTone = {
+  live: "bg-signal-live",
+  warn: "bg-signal-warn",
+  danger: "bg-signal-danger",
+} as const;
+
+// The 1px scanline progress track from the design language.
+export function Progress({ className, value, tone = "live", ...props }: ProgressProps) {
+  const pct = Math.max(0, Math.min(100, value ?? 0));
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      value={value}
+      className={cn("h-px w-full overflow-hidden bg-line", className)}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className={cn("h-full transition-[width] duration-300", fillTone[tone])}
+        style={{ width: `${pct}%` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -1,0 +1,64 @@
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "./lib/cn";
+
+export const Select = SelectPrimitive.Root;
+export const SelectValue = SelectPrimitive.Value;
+
+export function SelectTrigger({ className, children, ...props }: SelectPrimitive.SelectTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      className={cn(
+        "flex w-full items-center justify-between gap-2 rounded-sm border border-line bg-elevated px-3 py-1.5 font-mono text-sm text-ink outline-none focus-visible:border-signal-live data-[placeholder]:text-ink-soft",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon>
+        <ChevronDown className="size-3.5 text-ink-soft" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+export function SelectContent({ className, children, ...props }: SelectPrimitive.SelectContentProps) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-bm-overlay=""
+        position="popper"
+        sideOffset={4}
+        // Cap to the space Radix measured against the viewport (the popover
+        // window) and scroll internally, so the list can never exceed bounds.
+        className={cn(
+          "z-50 max-h-[var(--radix-select-content-available-height)] min-w-[var(--radix-select-trigger-width)] overflow-y-auto rounded-sm border border-line bg-surface p-1 font-mono text-sm text-ink shadow-lg",
+          className,
+        )}
+        {...props}
+      >
+        <SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+export function SelectItem({ className, children, ...props }: SelectPrimitive.SelectItemProps) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "flex cursor-default items-center justify-between rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-pressed data-[highlighted]:text-ink-strong",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator>
+        <Check className="size-3.5 text-signal-live" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}

--- a/src/ui/Skeleton.tsx
+++ b/src/ui/Skeleton.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from "react";
+import { cn } from "./lib/cn";
+
+// A muted loading placeholder. Size it with width/height utilities.
+export function Skeleton({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-sm bg-line-faint", className)}
+      {...props}
+    />
+  );
+}

--- a/src/ui/Sparkline.tsx
+++ b/src/ui/Sparkline.tsx
@@ -1,0 +1,63 @@
+import { useId } from "react";
+
+export type SparklineProps = {
+  data: number[];
+  width?: number;
+  height?: number;
+  tone?: "live" | "ink";
+  className?: string;
+  // Fill the area under the line with a faint gradient.
+  area?: boolean;
+};
+
+const stroke = {
+  live: "var(--color-signal-live)",
+  ink: "var(--color-ink-muted)",
+} as const;
+
+// Dependency-free SVG sparkline. Charts in a tray should be small and quiet;
+// this avoids pulling a charting library into the host bundle.
+export function Sparkline({ data, width = 120, height = 28, tone = "live", className, area = false }: SparklineProps) {
+  const gradientId = useId();
+  if (data.length < 2) {
+    return <svg data-slot="sparkline" width={width} height={height} className={className} aria-hidden="true" />;
+  }
+
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const span = max - min || 1;
+  const stepX = width / (data.length - 1);
+  const points = data.map((value, index) => {
+    const x = index * stepX;
+    const y = height - ((value - min) / span) * height;
+    return [x, y] as const;
+  });
+
+  const line = points.map(([x, y], index) => `${index === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`).join(" ");
+  const areaPath = `${line} L${width.toFixed(2)},${height} L0,${height} Z`;
+
+  return (
+    <svg
+      data-slot="sparkline"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      {area ? (
+        <>
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={stroke[tone]} stopOpacity="0.25" />
+              <stop offset="100%" stopColor={stroke[tone]} stopOpacity="0" />
+            </linearGradient>
+          </defs>
+          <path d={areaPath} fill={`url(#${gradientId})`} stroke="none" />
+        </>
+      ) : null}
+      <path d={line} fill="none" stroke={stroke[tone]} strokeWidth="1" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/ui/Switch.tsx
+++ b/src/ui/Switch.tsx
@@ -1,0 +1,17 @@
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { cn } from "./lib/cn";
+
+export function Switch({ className, ...props }: SwitchPrimitive.SwitchProps) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-4 w-7 shrink-0 items-center rounded-pill border border-line bg-elevated outline-none transition-colors focus-visible:ring-1 focus-visible:ring-signal-live data-[state=checked]:border-signal-live/40 data-[state=checked]:bg-signal-live/15 disabled:opacity-40",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb className="pointer-events-none ml-0.5 size-3 rounded-full bg-ink-soft transition-transform data-[state=checked]:translate-x-3 data-[state=checked]:bg-signal-live data-[state=checked]:shadow-[0_0_6px_currentColor]" />
+    </SwitchPrimitive.Root>
+  );
+}

--- a/src/ui/Tabs.tsx
+++ b/src/ui/Tabs.tsx
@@ -1,0 +1,31 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "./lib/cn";
+
+export const Tabs = TabsPrimitive.Root;
+
+export function TabsList({ className, ...props }: TabsPrimitive.TabsListProps) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn("inline-flex items-center gap-4 border-b border-line-faint", className)}
+      {...props}
+    />
+  );
+}
+
+export function TabsTrigger({ className, ...props }: TabsPrimitive.TabsTriggerProps) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "-mb-px border-b border-transparent pb-1.5 font-mono text-xs uppercase tracking-caps text-ink-soft outline-none transition-colors hover:text-ink-muted focus-visible:text-ink data-[state=active]:border-signal-live data-[state=active]:text-ink-strong",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TabsContent({ className, ...props }: TabsPrimitive.TabsContentProps) {
+  return <TabsPrimitive.Content data-slot="tabs-content" className={cn("pt-3 outline-none", className)} {...props} />;
+}

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { cn } from "./lib/cn";
+
+export type TooltipProps = {
+  content: ReactNode;
+  children: ReactNode;
+  className?: string;
+  side?: TooltipPrimitive.TooltipContentProps["side"];
+};
+
+// Self-contained tooltip: wraps a trigger and shows quiet help text. Provider is
+// included so widgets do not need to mount one.
+export function Tooltip({ content, children, className, side = "top" }: TooltipProps) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={200}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            data-slot="tooltip-content"
+            data-bm-overlay=""
+            side={side}
+            sideOffset={6}
+            className={cn(
+              "z-50 max-w-48 rounded-sm border border-line bg-surface px-2 py-1 font-mono text-xs text-ink-muted shadow-lg",
+              className,
+            )}
+          >
+            {content}
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,48 @@
+// Public barrel for @babymenu/ui. The set of *value* names exported here is the
+// stability contract in src/shared/ui-exports.ts (a test keeps them in sync, and
+// the host re-export shim is generated from it). Type-only exports are erased and
+// do not count toward the runtime surface.
+export { cn } from "./lib/cn";
+
+export { Badge, StatusDot } from "./Badge";
+export type { BadgeProps, StatusDotProps } from "./Badge";
+
+export { Button } from "./Button";
+export type { ButtonProps } from "./Button";
+
+export { Card, CardBody, CardHeader } from "./Card";
+
+export { DataTable } from "./DataTable";
+export type { DataTableColumn, DataTableProps } from "./DataTable";
+
+export {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  DialogTrigger,
+} from "./Dialog";
+
+export { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "./DropdownMenu";
+
+export { Field, Input, Textarea } from "./Field";
+export type { FieldProps } from "./Field";
+
+export { Progress } from "./Progress";
+export type { ProgressProps } from "./Progress";
+
+export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./Select";
+
+export { Skeleton } from "./Skeleton";
+
+export { Sparkline } from "./Sparkline";
+export type { SparklineProps } from "./Sparkline";
+
+export { Switch } from "./Switch";
+
+export { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
+
+export { Tooltip } from "./Tooltip";
+export type { TooltipProps } from "./Tooltip";

--- a/src/ui/lib/cn.ts
+++ b/src/ui/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,10 +1,10 @@
 /*
  * Renderer entry for the design system. Imported once by src/renderer/main.tsx.
  *
- * Tailwind scans the host components and the app renderer at build time. It also
- * scans the extension workspaces so that in dev/source mode (which serves widgets
- * through Vite, not the per-widget compiler) the utilities an agent authors in a
- * widget are present in the global stylesheet. Missing @source dirs are ignored.
+ * Tailwind scans the host components, app renderer, and tracked source
+ * extensions at build time. Dev-only generated extensions are scanned by
+ * styles.dev.css so production builds do not depend on gitignored workspace
+ * contents. Missing @source dirs are ignored.
  */
 @import "tailwindcss";
 @import "./theme.css";
@@ -12,4 +12,3 @@
 @source "../ui";
 @source "../renderer";
 @source "../../extensions";
-@source "../../extensions-dev";

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1,0 +1,15 @@
+/*
+ * Renderer entry for the design system. Imported once by src/renderer/main.tsx.
+ *
+ * Tailwind scans the host components and the app renderer at build time. It also
+ * scans the extension workspaces so that in dev/source mode (which serves widgets
+ * through Vite, not the per-widget compiler) the utilities an agent authors in a
+ * widget are present in the global stylesheet. Missing @source dirs are ignored.
+ */
+@import "tailwindcss";
+@import "./theme.css";
+
+@source "../ui";
+@source "../renderer";
+@source "../../extensions";
+@source "../../extensions-dev";

--- a/src/ui/styles.dev.css
+++ b/src/ui/styles.dev.css
@@ -1,0 +1,3 @@
+@import "./styles.css";
+
+@source "../../extensions-dev";

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -6,11 +6,11 @@
  *   2. The per-widget Tailwind compiler in the main process
  *      (src/main/widget-tailwind-css.ts reads this file ?raw).
  *
- * Monochrome Lab is framework-enforced: `--color-*: initial` wipes Tailwind's
- * default palette, so only the tokens below exist as color utilities. There is
- * no `bg-red-500`. Spacing keeps Tailwind's conventional 4px base so ported
- * component dimensions stay correct; the 2px --space-* scale lives in
- * colors_and_type.css for the legacy app-shell CSS.
+ * Monochrome Lab is token-first: `--color-*: initial` wipes Tailwind's default
+ * palette so named color utilities come from the tokens below. Arbitrary values
+ * remain available for rare widget-specific needs. Spacing keeps Tailwind's
+ * conventional 4px base so ported component dimensions stay correct; the 2px
+ * --space-* scale lives in colors_and_type.css for the legacy app-shell CSS.
  */
 @theme {
   --color-*: initial;

--- a/src/ui/theme.css
+++ b/src/ui/theme.css
@@ -1,0 +1,64 @@
+/*
+ * Single source of truth for the Baby Menu design-system @theme.
+ *
+ * Consumed by two places, which is the whole point of having one file:
+ *   1. The renderer build (src/ui/styles.css imports this).
+ *   2. The per-widget Tailwind compiler in the main process
+ *      (src/main/widget-tailwind-css.ts reads this file ?raw).
+ *
+ * Monochrome Lab is framework-enforced: `--color-*: initial` wipes Tailwind's
+ * default palette, so only the tokens below exist as color utilities. There is
+ * no `bg-red-500`. Spacing keeps Tailwind's conventional 4px base so ported
+ * component dimensions stay correct; the 2px --space-* scale lives in
+ * colors_and_type.css for the legacy app-shell CSS.
+ */
+@theme {
+  --color-*: initial;
+
+  --color-void: #060607;
+  --color-stage: #0b0b0c;
+  --color-surface: #101012;
+  --color-elevated: #16161a;
+  --color-pressed: #1c1c21;
+
+  --color-ink-strong: rgba(255, 255, 255, 0.96);
+  --color-ink: rgba(255, 255, 255, 0.86);
+  --color-ink-muted: rgba(255, 255, 255, 0.65);
+  --color-ink-soft: rgba(255, 255, 255, 0.48);
+  --color-ink-label: rgba(255, 255, 255, 0.34);
+  --color-ink-faint: rgba(255, 255, 255, 0.22);
+
+  --color-line: rgba(255, 255, 255, 0.12);
+  --color-line-faint: rgba(255, 255, 255, 0.07);
+
+  --color-signal-live: #6ae3b6;
+  --color-signal-warn: #ffd86b;
+  --color-signal-danger: #ff6a7a;
+
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --font-prose: "Inter Tight", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  /* Type scale matches colors_and_type.css --fs-*. Wiped so only the design
+     scale exists (text-md is added; Tailwind has no default text-md). */
+  --text-*: initial;
+  --text-xxs: 0.6875rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+  --text-2xl: 1.75rem;
+  --text-3xl: 2.25rem;
+
+  --tracking-tight: -0.01em;
+  --tracking-value: -0.04em;
+  --tracking-caps: 0.18em;
+
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+  --radius-pill: 9999px;
+}

--- a/tests/design-system-styles.test.ts
+++ b/tests/design-system-styles.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rootDir = resolve(import.meta.dirname, "..");
+
+describe("design system styles", () => {
+  it("keeps the gitignored dev extension workspace out of the production stylesheet", async () => {
+    const styles = await readFile(resolve(rootDir, "src/ui/styles.css"), "utf8");
+
+    expect(styles).not.toContain("extensions-dev");
+  });
+});

--- a/tests/design-type-scale.test.ts
+++ b/tests/design-type-scale.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+// The type scale is declared twice: --fs-* in colors_and_type.css (consumed by
+// the app-shell CSS) and --text-* in the @theme (which generates the Tailwind
+// utilities the kit and widgets use). They must stay identical or the same
+// nominal size renders differently across the two surfaces.
+function extractTokens(css: string, prefix: string): Map<string, string> {
+  const pattern = new RegExp(`--${prefix}-(\\w+):\\s*([^;]+);`, "g");
+  const tokens = new Map<string, string>();
+  for (const match of css.matchAll(pattern)) {
+    tokens.set(match[1], match[2].trim());
+  }
+  return tokens;
+}
+
+describe("design system type scale", () => {
+  let fsTokens: Map<string, string>;
+  let textTokens: Map<string, string>;
+
+  beforeAll(async () => {
+    fsTokens = extractTokens(await readFile(resolve(__dirname, "../src/renderer/colors_and_type.css"), "utf8"), "fs");
+    textTokens = extractTokens(await readFile(resolve(__dirname, "../src/ui/theme.css"), "utf8"), "text");
+  });
+
+  it("defines the same step names in both scales", () => {
+    expect([...textTokens.keys()].sort()).toEqual([...fsTokens.keys()].sort());
+  });
+
+  it("keeps --fs-* and --text-* values identical for every step", () => {
+    for (const [step, value] of fsTokens) {
+      expect(`${step}=${textTokens.get(step)}`).toBe(`${step}=${value}`);
+    }
+  });
+});

--- a/tests/extension-layout.test.ts
+++ b/tests/extension-layout.test.ts
@@ -13,12 +13,16 @@ describe("extension layout", () => {
     expect(widget).toContain("RefreshableBabyMenuWidget");
     expect(widget).toContain("hello world");
     expect(widget).toContain("tell baby_menu what to build");
-    expect(widget).toContain("fontSize: \"var(--fs-3xl)\"");
-    expect(widget).toContain("fontSize: \"var(--fs-md)\"");
+    // The starter widget exemplifies the design system: kit component + token utilities.
+    expect(widget).toContain("@babymenu/ui");
+    expect(widget).toContain("StatusDot");
+    expect(widget).toContain("text-3xl");
     expect(widget).toContain("examples");
     expect(widget).toContain("add a battery widget that shows current charge and power source");
     expect(widget).not.toContain("quick asks");
     expect(widget).not.toContain("className=\"src\"");
+    // Migrated off legacy inline token styles.
+    expect(widget).not.toContain("var(--fs-");
   });
 
   it("documents extension authoring separately from core development", async () => {
@@ -38,23 +42,24 @@ describe("extension layout", () => {
 
     expect(instructions).toContain("Monochrome Lab");
     expect(instructions).toContain("Design for a 360px macOS tray popover");
-    expect(instructions).toContain("Prefer `value-row`, `value`, `progress`, `fill`, `foot`, `src`, `status`, and `label`");
-    expect(instructions).toContain("Public tokens available to widgets");
-    expect(instructions).toContain("`--font-mono`");
-    expect(instructions).toContain("`--ink-strong`");
-    expect(instructions).toContain("`--signal-live`");
-    expect(instructions).toContain("`--space-1` through `--space-9`");
-    expect(instructions).toContain("Public widget classes available to widgets");
-    expect(instructions).toContain("Canonical widget body pattern");
-    expect(instructions).toContain("Readable hierarchy rules");
-    expect(instructions).toContain("Do not use `foot` for primary instructions");
+    // The design system is delivered as components, not a wall of CSS classes.
+    expect(instructions).toContain("@babymenu/ui");
+    expect(instructions).toContain("DataTable");
+    expect(instructions).toContain("StatusDot");
+    expect(instructions).toContain("Progress");
+    expect(instructions).toContain("Field");
+    // Tailwind utilities are token-restricted; off-palette colors do not exist.
+    expect(instructions).toContain("bg-red-500");
+    expect(instructions).toContain("text-signal-live");
+    expect(instructions).toContain("font-mono");
+    expect(instructions).toContain("Readable hierarchy");
     expect(instructions).toContain("Onboarding widgets are not data widgets");
-    expect(instructions).toContain("Onboarding widget headlines should usually use `--fs-md` or `--fs-lg`");
-    expect(instructions).toContain("Starter empty states may use `--fs-2xl` or `--fs-3xl`");
     expect(instructions).toContain("Example prompts should be complete pasteable user asks");
     expect(instructions).toContain("Do not add gradients, emoji");
     expect(instructions).toContain("The host hides `hello-world` automatically once real widgets are discovered");
     expect(instructions).not.toContain("Remove the `hello-world` starter widget");
+    // The old CSS-class catalogue is gone in favor of components + tokens.
+    expect(instructions).not.toContain("Public widget classes available to widgets");
   });
 
   it("keeps the dev extension workspace out of git", async () => {

--- a/tests/extension-layout.test.ts
+++ b/tests/extension-layout.test.ts
@@ -48,8 +48,10 @@ describe("extension layout", () => {
     expect(instructions).toContain("StatusDot");
     expect(instructions).toContain("Progress");
     expect(instructions).toContain("Field");
-    // Tailwind utilities are token-restricted; off-palette colors do not exist.
+    // Tailwind guidance prefers tokens while allowing rare arbitrary-color exceptions.
     expect(instructions).toContain("bg-red-500");
+    expect(instructions).toContain("Prefer Baby Menu token utilities for color");
+    expect(instructions).toContain("Use arbitrary color values only when a widget genuinely needs them");
     expect(instructions).toContain("text-signal-live");
     expect(instructions).toContain("font-mono");
     expect(instructions).toContain("Readable hierarchy");
@@ -60,6 +62,7 @@ describe("extension layout", () => {
     expect(instructions).not.toContain("Remove the `hello-world` starter widget");
     // The old CSS-class catalogue is gone in favor of components + tokens.
     expect(instructions).not.toContain("Public widget classes available to widgets");
+    expect(instructions).not.toContain("off-brand colors literally do not exist");
   });
 
   it("keeps the dev extension workspace out of git", async () => {

--- a/tests/ipc-capabilities.test.ts
+++ b/tests/ipc-capabilities.test.ts
@@ -28,7 +28,6 @@ describe("capabilities IPC", () => {
       join(recipesDir, "daily-standup.html"),
       `<html><head><title>Daily Standup</title></head><body><h1>Fallback</h1></body></html>\n`,
     );
-    vi.stubEnv("BABY_MENU_EXTENSIONS_DIR", join(rootDir, "extensions-dev"));
     const { registerIpcHandlers } = await import("../src/main/ipc");
     const agentRuntime = {
       send: vi.fn(),
@@ -36,7 +35,7 @@ describe("capabilities IPC", () => {
       rollback: vi.fn(),
     };
 
-    registerIpcHandlers(rootDir, agentRuntime);
+    registerIpcHandlers(rootDir, agentRuntime, undefined, undefined, undefined, undefined, { recipesDir });
 
     await expect(handlers.get("baby-menu:recipes:list")?.({})).resolves.toEqual([
       {
@@ -79,15 +78,19 @@ describe("capabilities IPC", () => {
       join(actionDir, "server.mjs"),
       `export const actions = { ping: async (input, context) => ({ input, rootDir: context.rootDir }) };\n`,
     );
-    vi.stubEnv("BABY_MENU_EXTENSIONS_DIR", join(rootDir, "extensions-dev"));
     const { registerIpcHandlers } = await import("../src/main/ipc");
+    const { createServerActionRegistry } = await import("../src/main/server-action-registry");
     const agentRuntime = {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
     };
 
-    registerIpcHandlers(rootDir, agentRuntime);
+    registerIpcHandlers(
+      rootDir,
+      agentRuntime,
+      createServerActionRegistry({ rootDir, actionRoots: [join(rootDir, "extensions-dev")] }),
+    );
 
     await expect(handlers.get("baby-menu:capabilities:list")?.({})).resolves.toEqual([
       { id: "demo.ping", extensionId: "demo", action: "ping" },

--- a/tests/popover-position.test.ts
+++ b/tests/popover-position.test.ts
@@ -69,9 +69,9 @@ describe("calculatePopoverBounds", () => {
   it("loads localhost renderer URLs during development", async () => {
     const window = createRendererWindow();
 
-    await loadPopoverRenderer(window, "http://localhost:5173/", "/app/out/renderer/index.html");
+    await loadPopoverRenderer(window, "http://localhost:5273/", "/app/out/renderer/index.html");
 
-    expect(window.loadURL).toHaveBeenCalledWith("http://localhost:5173/");
+    expect(window.loadURL).toHaveBeenCalledWith("http://localhost:5273/");
     expect(window.loadFile).not.toHaveBeenCalled();
   });
 
@@ -87,7 +87,7 @@ describe("calculatePopoverBounds", () => {
   it("ignores dev renderer URLs in packaged builds", async () => {
     const window = createRendererWindow();
 
-    await loadPopoverRenderer(window, "http://localhost:5173/", "/app/out/renderer/index.html", {
+    await loadPopoverRenderer(window, "http://localhost:5273/", "/app/out/renderer/index.html", {
       isPackaged: true,
     });
 

--- a/tests/recipe-loader.test.ts
+++ b/tests/recipe-loader.test.ts
@@ -29,7 +29,7 @@ describe("loadRecipes", () => {
       expect(html).toContain("This recipe is self-contained");
       expect(html).toContain("Recommended Data Source Order");
       expect(html).toContain("Implementation Contract");
-      expect(html).toContain("IPC response shape");
+      expect(html).toContain("Server action response shape");
       expect(html).toContain('data-theme="wireframe"');
       expect(html).toContain("https://cdn.jsdelivr.net/npm/daisyui@5");
       expect(html).toContain("https://cdn.jsdelivr.net/npm/daisyui@5/themes.css");

--- a/tests/renderer-layout.test.ts
+++ b/tests/renderer-layout.test.ts
@@ -14,10 +14,16 @@ describe("renderer layout styles", () => {
     expect(css).toMatch(/\.app-shell\s*\{[^}]*border-radius:\s*var\(--radius-xl\)/s);
   });
 
-  it("keeps widgets as dashed log sections above a pinned composer", async () => {
+  it("keeps widgets as dashed log sections in a scroll region above a pinned composer", async () => {
     const css = await readFile(stylesPath, "utf8");
 
-    expect(css).toMatch(/\.widget-host\s*\{[^}]*max-height:\s*360px/s);
+    // The widget region scrolls via .pop-body, which flexes to fill the window
+    // (so the popover auto-extends to fit content) while the composer stays pinned.
+    expect(css).toMatch(/\.pop-body\s*\{[^}]*flex:\s*1 1 auto/s);
+    expect(css).toMatch(/\.pop-body\s*\{[^}]*min-height:\s*0/s);
+    expect(css).toMatch(/\.pop-body\s*\{[^}]*overflow-y:\s*auto/s);
+    expect(css).not.toMatch(/\.widget-host\s*\{[^}]*max-height/s);
+    expect(css).toMatch(/\.composer-wrap\s*\{[^}]*flex:\s*0 0 auto/s);
     expect(css).toMatch(/\.widget\s*\{[^}]*border-bottom:\s*1px\s+dashed\s+var\(--line-faint\)/s);
     expect(css).toMatch(/\.composer-wrap\s*\{[^}]*border-top:\s*1px\s+solid\s+var\(--line\)/s);
     expect(css).not.toMatch(/\.message-list/);
@@ -28,14 +34,9 @@ describe("renderer layout styles", () => {
 
     expect(css).toMatch(/html,\s*\nbody,\s*\n#root\s*\{[^}]*background:\s*var\(--bg-stage\)/s);
     expect(css).toMatch(/\.app-shell\s*\{[^}]*height:\s*auto/s);
-    expect(css).toMatch(/\.app-shell\s*\{[^}]*max-height:\s*min\(720px,\s*100vh\)/s);
-    expect(css).not.toMatch(/\.app-shell\s*\{[^}]*height:\s*100vh/s);
+    expect(css).toMatch(/\.app-shell\s*\{[^}]*max-height:\s*720px/s);
+    // 100vh equals the auto-sized window height, which ratchets the popover.
+    expect(css).not.toMatch(/\.app-shell\s*\{[^}]*100vh/s);
   });
 
-  it("includes compact settings styles for the open-at-login toggle", async () => {
-    const css = await readFile(stylesPath, "utf8");
-
-    expect(css).toMatch(/\.settings-toggle\s*\{/);
-    expect(css).toMatch(/\.settings-toggle\.enabled\s*\{/);
-  });
 });

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App } from "../src/renderer/App";
+import type { BabyMenuApi } from "../src/shared/contracts";
+
+function installBabyMenuApi(): BabyMenuApi {
+  const api: BabyMenuApi = {
+    recipes: { list: vi.fn(async () => []) },
+    git: { save: vi.fn(async () => ({ ok: true })), rollback: vi.fn(async () => ({ ok: true })) },
+    agent: { send: vi.fn(async () => ({ assistantText: "" })), onStatus: vi.fn(() => () => undefined) },
+    capabilities: { list: vi.fn(async () => []), invoke: vi.fn(async () => undefined) as BabyMenuApi["capabilities"]["invoke"] },
+    widgets: { list: vi.fn(async () => []) },
+    popover: { setContentHeight: vi.fn(async () => ({ ok: true })) },
+    settings: {
+      get: vi.fn(async () => ({ openAtLogin: false })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+    },
+  };
+  window.babyMenu = api;
+  return api;
+}
+
+afterEach(() => {
+  cleanup();
+  delete window.babyMenu;
+});
+
+describe("settings view", () => {
+  it("opens settings from the header gear, toggles open-at-login, and returns to the menu", async () => {
+    const api = installBabyMenuApi();
+    render(<App />);
+
+    // Menu view: composer present, no settings controls.
+    expect(screen.getByPlaceholderText("ask the agent")).toBeTruthy();
+    expect(screen.queryByText("open at login")).toBeNull();
+
+    // Open settings.
+    fireEvent.click(screen.getByRole("button", { name: "open settings" }));
+    expect(await screen.findByText("open at login")).toBeTruthy();
+    const toggle = screen.getByRole("switch", { name: "open at login" });
+    expect(toggle).toBeTruthy();
+    // The agent composer is hidden in the settings context.
+    expect(screen.queryByPlaceholderText("ask the agent")).toBeNull();
+
+    // Toggle the setting.
+    fireEvent.click(toggle);
+    await waitFor(() => expect(api.settings.setOpenAtLogin).toHaveBeenCalledWith(true));
+
+    // Return to the menu.
+    fireEvent.click(screen.getByRole("button", { name: "close settings" }));
+    expect(await screen.findByPlaceholderText("ask the agent")).toBeTruthy();
+    expect(screen.queryByText("open at login")).toBeNull();
+  });
+});

--- a/tests/ui-components.test.tsx
+++ b/tests/ui-components.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge, Button, DataTable, Field, Input, Progress, Skeleton, Sparkline, StatusDot } from "../src/ui";
+
+describe("@babymenu/ui components", () => {
+  it("renders a button with variant styling and a safe default type", () => {
+    const { getByRole } = render(<Button variant="danger">delete</Button>);
+    const button = getByRole("button", { name: "delete" });
+    expect(button.getAttribute("type")).toBe("button");
+    expect(button.className).toContain("text-signal-danger");
+  });
+
+  it("renders status signals with tone", () => {
+    const { container } = render(
+      <span>
+        <StatusDot tone="warn" />
+        <Badge tone="live">live</Badge>
+      </span>,
+    );
+    expect(container.querySelector("[data-slot='status-dot']")?.className).toContain("bg-signal-warn");
+    expect(container.querySelector("[data-slot='badge']")?.textContent).toBe("live");
+  });
+
+  it("associates a Field label with its control", () => {
+    const { getByText, getByRole } = render(
+      <Field label="Threshold">
+        <Input placeholder="80" />
+      </Field>,
+    );
+    const label = getByText("Threshold");
+    const input = getByRole("textbox");
+    expect(label.getAttribute("for")).toBeTruthy();
+    expect(label.getAttribute("for")).toBe(input.id);
+  });
+
+  it("renders DataTable rows and an empty state", () => {
+    const columns = [
+      { key: "name", header: "name" },
+      { key: "value", header: "value", align: "right" as const, render: (row: { value: number }) => `${row.value}%` },
+    ];
+    const { getByText, rerender } = render(
+      <DataTable columns={columns} rows={[{ name: "cpu", value: 72 }]} />,
+    );
+    expect(getByText("cpu")).toBeTruthy();
+    expect(getByText("72%")).toBeTruthy();
+
+    rerender(<DataTable columns={columns} rows={[]} empty="nothing here" />);
+    expect(getByText("nothing here")).toBeTruthy();
+  });
+
+  it("clamps Progress value into the indicator width", () => {
+    const { container } = render(<Progress value={140} />);
+    const indicator = container.querySelector("[data-slot='progress-indicator']") as HTMLElement;
+    expect(indicator.style.width).toBe("100%");
+  });
+
+  it("draws a sparkline path for a data series", () => {
+    const { container } = render(<Sparkline data={[1, 4, 2, 8, 5]} />);
+    const path = container.querySelector("path");
+    expect(path?.getAttribute("d")).toMatch(/^M0/);
+  });
+
+  it("renders a skeleton placeholder", () => {
+    const { container } = render(<Skeleton className="h-4 w-10" />);
+    expect(container.querySelector("[data-slot='skeleton']")?.className).toContain("animate-pulse");
+  });
+});

--- a/tests/ui-export-contract.test.ts
+++ b/tests/ui-export-contract.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import * as ui from "../src/ui";
+import { UI_EXPORT_NAMES } from "../src/shared/ui-exports";
+
+// The @babymenu/ui surface is a stability contract: the barrel, the contract
+// list, and the host re-export shim must agree, or packaged widgets that import
+// a name will silently get `undefined`. This test fails the moment they drift.
+describe("@babymenu/ui public surface contract", () => {
+  it("keeps the barrel exports exactly in sync with UI_EXPORT_NAMES", () => {
+    const exported = Object.keys(ui).sort();
+    const declared = [...UI_EXPORT_NAMES].sort();
+    expect(exported).toEqual(declared);
+  });
+});

--- a/tests/ui-import-rewrite.test.ts
+++ b/tests/ui-import-rewrite.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { rewriteExtensionModuleImports, UI_IMPORT_SPECIFIER } from "../src/main/extension-module-compiler";
+
+const widgetContext = {
+  kind: "widget" as const,
+  extensionId: "demo",
+  extensionDir: "/extensions/demo",
+  filePath: "/extensions/demo/widget.tsx",
+};
+
+describe("@babymenu/ui widget import rewriting", () => {
+  it("rewrites the design-system specifier to the host protocol module", async () => {
+    const rewritten = await rewriteExtensionModuleImports({
+      ...widgetContext,
+      source: `import { Button } from "${UI_IMPORT_SPECIFIER}";\n`,
+    });
+    expect(rewritten).toContain('"baby-menu-host://ui/index.mjs"');
+    expect(rewritten).not.toContain(UI_IMPORT_SPECIFIER);
+  });
+
+  it("still rewrites react to the host shim alongside the design system", async () => {
+    const rewritten = await rewriteExtensionModuleImports({
+      ...widgetContext,
+      source: `import { useState } from "react";\nimport { Card } from "${UI_IMPORT_SPECIFIER}";\n`,
+    });
+    expect(rewritten).toContain('"baby-menu-host://react/index.mjs"');
+    expect(rewritten).toContain('"baby-menu-host://ui/index.mjs"');
+  });
+
+  it("still rejects arbitrary npm imports in widgets", async () => {
+    await expect(
+      rewriteExtensionModuleImports({ ...widgetContext, source: `import thing from "lodash";\n` }),
+    ).rejects.toThrow(/Unsupported widget import/);
+  });
+});

--- a/tests/widget-host-shim.test.ts
+++ b/tests/widget-host-shim.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from "vitest";
 import { installWidgetHostShims } from "../src/renderer/widget-host-shim";
 
 describe("renderer widget host shims", () => {
-  it("exposes the host React and JSX runtime objects for compiled widgets", () => {
+  it("exposes the host React, JSX runtime, and design system for compiled widgets", () => {
     const target = {} as Window;
     const React = { useState: () => undefined };
     const jsxRuntime = { jsx: () => undefined, Fragment: Symbol.for("fragment") };
+    const ui = { Button: () => undefined };
 
-    installWidgetHostShims(target, React, jsxRuntime);
+    installWidgetHostShims(target, React, jsxRuntime, ui);
 
-    expect(target.__BABY_MENU_WIDGET_HOST__).toEqual({ React, jsxRuntime });
+    expect(target.__BABY_MENU_WIDGET_HOST__).toEqual({ React, jsxRuntime, ui });
   });
 });

--- a/tests/widget-pipeline-integration.test.ts
+++ b/tests/widget-pipeline-integration.test.ts
@@ -1,0 +1,63 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { discoverWidgetModules } from "../src/main/widget-module-registry";
+
+// End-to-end proof of the packaged pipeline: an agent-authored widget that
+// imports @babymenu/ui and uses token Tailwind utilities must compile to a
+// host-shim import plus a token-restricted stylesheet.
+describe("compiled widget pipeline", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  function cachePath(widgetCacheDir: string, protocolUrl: string): string {
+    return join(widgetCacheDir, protocolUrl.replace("baby-menu-widget://", ""));
+  }
+
+  it("rewrites @babymenu/ui to the host shim and compiles a stylesheet from the packaged workspace", async () => {
+    // The workspace lives under a hidden `.baby-menu` dir, exactly like packaged
+    // mode, to guard the regression where Tailwind's scanner skipped it.
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-pipeline-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    const widgetCacheDir = join(rootDir, "cache", "widgets");
+    await mkdir(join(extensionsDir, "cpu-temp"), { recursive: true });
+    await writeFile(
+      join(extensionsDir, "cpu-temp", "widget.tsx"),
+      [
+        `import { StatusDot } from "@babymenu/ui";`,
+        `export const cpuTempWidget = {`,
+        `  id: "cpu-temp",`,
+        `  title: "CPU TEMP",`,
+        `  render: () => <span className="flex items-center gap-2"><StatusDot /></span>,`,
+        `};`,
+        ``,
+      ].join("\n"),
+    );
+
+    const [descriptor] = await discoverWidgetModules({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir,
+    });
+
+    expect(descriptor?.moduleUrl).toMatch(/^baby-menu-widget:\/\/cpu-temp\/[a-f0-9]{16}\/widget\.mjs$/);
+    expect(descriptor?.cssUrl).toMatch(/^baby-menu-widget:\/\/cpu-temp\/[a-f0-9]{16}\/widget\.css$/);
+
+    const compiledModule = await readFile(cachePath(widgetCacheDir, descriptor!.moduleUrl), "utf8");
+    expect(compiledModule).toContain("baby-menu-host://ui/index.mjs");
+    expect(compiledModule).not.toContain("@babymenu/ui");
+
+    // Tailwind scanned the widget through the hidden ancestor and emitted CSS.
+    // (Token/palette correctness is covered by widget-tailwind-css.test.ts, which
+    // loads the real @theme; vitest returns "" for the registry's `?raw` import.)
+    const compiledCss = await readFile(cachePath(widgetCacheDir, descriptor!.cssUrl!), "utf8");
+    expect(compiledCss).toContain(".flex");
+    expect(compiledCss).toContain(".items-center");
+  });
+});

--- a/tests/widget-pipeline-integration.test.ts
+++ b/tests/widget-pipeline-integration.test.ts
@@ -60,4 +60,44 @@ describe("compiled widget pipeline", () => {
     expect(compiledCss).toContain(".flex");
     expect(compiledCss).toContain(".items-center");
   });
+
+  it("rebuilds a cached stylesheet when its cache key is stale", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-pipeline-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    const widgetCacheDir = join(rootDir, "cache", "widgets");
+    await mkdir(join(extensionsDir, "cpu-temp"), { recursive: true });
+    await writeFile(
+      join(extensionsDir, "cpu-temp", "widget.tsx"),
+      [
+        `export const cpuTempWidget = {`,
+        `  id: "cpu-temp",`,
+        `  title: "CPU TEMP",`,
+        `  render: () => <span className="flex items-center gap-2" />,`,
+        `};`,
+        ``,
+      ].join("\n"),
+    );
+
+    const [descriptor] = await discoverWidgetModules({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir,
+    });
+    const cssPath = cachePath(widgetCacheDir, descriptor!.cssUrl!);
+    await writeFile(cssPath, "stale css", "utf8");
+    await writeFile(join(cssPath, "..", "widget.css.cache-key"), "stale-key", "utf8");
+
+    await discoverWidgetModules({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir,
+    });
+
+    const compiledCss = await readFile(cssPath, "utf8");
+    expect(compiledCss).toContain(".flex");
+    expect(compiledCss).not.toBe("stale css");
+  });
 });

--- a/tests/widget-protocol.test.ts
+++ b/tests/widget-protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { hostProtocolModuleSource, resolveWidgetProtocolFilePath } from "../src/main/widget-protocol";
+import { UI_EXPORT_NAMES } from "../src/shared/ui-exports";
 
 describe("widget protocol", () => {
   it("resolves widget URLs only inside the compiler cache", () => {
@@ -17,6 +18,12 @@ describe("widget protocol", () => {
     );
   });
 
+  it("serves compiled per-widget stylesheets through the widget protocol", () => {
+    expect(resolveWidgetProtocolFilePath("/cache/widgets", "baby-menu-widget://cpu-temp/abc123/widget.css")).toBe(
+      "/cache/widgets/cpu-temp/abc123/widget.css",
+    );
+  });
+
   it("serves host React shim modules from the renderer host object", () => {
     expect(hostProtocolModuleSource("baby-menu-host://react/index.mjs")).toContain(
       "window.__BABY_MENU_WIDGET_HOST__.React",
@@ -25,5 +32,13 @@ describe("widget protocol", () => {
       "window.__BABY_MENU_WIDGET_HOST__.jsxRuntime",
     );
     expect(() => hostProtocolModuleSource("baby-menu-host://unknown/index.mjs")).toThrow("Unknown host module URL");
+  });
+
+  it("serves the design system shim re-exporting every public name from the host object", () => {
+    const source = hostProtocolModuleSource("baby-menu-host://ui/index.mjs");
+    expect(source).toContain("window.__BABY_MENU_WIDGET_HOST__.ui");
+    for (const name of UI_EXPORT_NAMES) {
+      expect(source).toContain(`export const ${name} = ui.${name};`);
+    }
   });
 });

--- a/tests/widget-tailwind-css.test.ts
+++ b/tests/widget-tailwind-css.test.ts
@@ -1,8 +1,13 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { compileWidgetTailwindCss } from "../src/main/widget-tailwind-css";
+import { compileWidgetTailwindCss, widgetTailwindCssCacheKey } from "../src/main/widget-tailwind-css";
+
+const require = createRequire(import.meta.url);
 
 describe("per-widget Tailwind compile", () => {
   const tempDirs: string[] = [];
@@ -41,4 +46,30 @@ describe("per-widget Tailwind compile", () => {
     expect(css).not.toContain(".bg-red-500");
     expect(css).not.toContain(".text-blue-300");
   });
+
+  it("keys cached CSS by resolved compiler package metadata", () => {
+    const compilerPackageMetadata = ["tailwindcss", "@tailwindcss/postcss", "postcss"].map((packageName) =>
+      readFileSync(resolvePackageJson(packageName), "utf8"),
+    );
+    const expectedKey = createHash("sha256")
+      .update("widget-tailwind-css-v1")
+      .update("\0")
+      .update(themeCss)
+      .update("\0")
+      .update(compilerPackageMetadata.join("\0"))
+      .digest("hex")
+      .slice(0, 16);
+
+    expect(widgetTailwindCssCacheKey(themeCss)).toBe(expectedKey);
+  });
 });
+
+function resolvePackageJson(packageName: string): string {
+  let currentDir = dirname(require.resolve(packageName));
+  while (currentDir !== dirname(currentDir)) {
+    const packageJsonPath = join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) return packageJsonPath;
+    currentDir = dirname(currentDir);
+  }
+  throw new Error(`Could not resolve package.json for ${packageName}`);
+}

--- a/tests/widget-tailwind-css.test.ts
+++ b/tests/widget-tailwind-css.test.ts
@@ -1,0 +1,44 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { compileWidgetTailwindCss } from "../src/main/widget-tailwind-css";
+
+describe("per-widget Tailwind compile", () => {
+  const tempDirs: string[] = [];
+  let themeCss = "";
+
+  beforeAll(async () => {
+    // Use the real single source of truth so the test breaks if the theme drifts.
+    themeCss = await readFile(resolve(__dirname, "../src/ui/theme.css"), "utf8");
+  });
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  async function compileFromSource(source: string): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "baby-menu-widget-css-"));
+    tempDirs.push(dir);
+    await writeFile(join(dir, "widget.tsx"), source, "utf8");
+    return compileWidgetTailwindCss({ sourceDir: dir, themeCss });
+  }
+
+  it("generates utility CSS for classes authored in widget source", async () => {
+    const css = await compileFromSource(`<div className="flex gap-2 text-ink-muted bg-surface" />`);
+    expect(css).toContain(".flex");
+    expect(css).toContain(".text-ink-muted");
+    expect(css).toContain(".bg-surface");
+  });
+
+  it("maps token utilities to Baby Menu token values", async () => {
+    const css = await compileFromSource(`<span className="text-signal-live" />`);
+    expect(css.toLowerCase()).toContain("#6ae3b6");
+  });
+
+  it("does not generate off-palette utilities (Monochrome Lab is framework-enforced)", async () => {
+    const css = await compileFromSource(`<div className="bg-red-500 text-blue-300" />`);
+    expect(css).not.toContain(".bg-red-500");
+    expect(css).not.toContain(".text-blue-300");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,10 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "paths": {
+      "@babymenu/ui": ["./src/ui/index.ts"]
+    }
   },
   "include": ["electron.vite.config.ts", "vitest.config.ts", "src", "extensions", "tests"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,14 @@
+import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    // Mirror the renderer alias so tests resolve the design system the same way
+    // dev/source mode does (packaged mode rewrites it to the host protocol).
+    alias: {
+      "@babymenu/ui": resolve(__dirname, "src/ui/index.ts"),
+    },
+  },
   test: {
     exclude: ["**/node_modules/**", "**/.git/**", "**/.cache/**"],
   },


### PR DESCRIPTION
## Intent

The developer wanted to evolve Baby Menu from token-only extension styling into a shared, shadcn-inspired Tailwind design system used by both the app shell and agent-authored extensions, while preserving the existing import/security constraints and avoiding hacky architecture. They explicitly chose per-widget Tailwind compilation over browser-runtime Tailwind, accepted some CSS duplication, and wanted the work carried through to completion with clean tests, packaging-aware dependencies, and no flaky spike leftovers. They also wanted the Hello World starter migrated to the new design system, the default dev port changed to avoid conflicts, the global type scale made more readable, and the popover layout fixed so content auto-sizes without internal widget scrolling. Later UI refinements included replacing the prominent “login off” pill with a settings button and settings view, ensuring the settings button has no startup highlight outline, and preventing the popover from shrinking or getting stuck smaller when toggling settings.

## What Changed

- Added a shared `@babymenu/ui` component surface, Tailwind theme tokens, host import rewriting, and packaged per-widget CSS compilation so extension widgets can use the same design system as the app shell.
- Updated the renderer shell with the new design language, a settings view for open-at-login controls, improved popover sizing/scroll behavior, and migrated the starter Hello World widget to shared UI components.
- Refreshed extension authoring docs, recipes, and design-system references to document server-action-based widget contracts, `@babymenu/ui` usage, Tailwind styling caveats, and current user-facing Keep/Undo terminology.

## Risk Assessment

⚠️ Medium: The review found no substantiated material issues, but the change is broad and touches the renderer design system, packaged widget compilation, custom protocols, and build dependencies.

## Testing

Exercised the focused design-system/unit coverage, packaging and dev-port tests, a production build, and live browser screenshots of both the settings surface and migrated Hello World menu surface; all automated checks passed and the captured UI evidence shows the expected settings button/view and shared design-system widget styling.

- Evidence: Rendered Baby Menu settings view (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNV99YE3E2ZJQ7ERFZKZBC4/settings-view.png</code>)
- Evidence: Rendered Baby Menu menu view with migrated Hello World widget (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNV99YE3E2ZJQ7ERFZKZBC4/menu-view.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4)</summary>

**Round 1** - found 1 warning
- ⚠️ `src/main/widget-module-registry.ts:137` - Compiled widget stylesheets are reused solely when `widget.css` already exists in the JS source-hash output directory, but that hash does not include `themeCss` or the Tailwind compiler inputs. After an app update changes `src/ui/theme.css` or Tailwind output semantics, installed packaged widgets with unchanged source will keep serving stale cached CSS from `~/.baby-menu/cache/widgets`, causing design-system tokens/utilities to drift until the cache is manually cleared. Include a theme/compiler hash in the cache key or validate/rewrite the CSS cache when these inputs change.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `src/main/widget-tailwind-css.ts:52` - The packaged widget CSS cache key is based on dependency specifiers from package.json rather than the actual compiler inputs that ship in node_modules. A lockfile-only update to Tailwind, @tailwindcss/postcss, or PostCSS can change generated CSS while leaving these strings unchanged, so installed widgets with unchanged source and theme will keep serving stale cached widget.css after an app update. Hash the resolved package versions/package metadata, the lockfile, or a build-time compiler version constant instead of the semver ranges.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `src/ui/theme.css:15` - The theme wipe removes Tailwind&#39;s named color palette, but it does not prevent arbitrary value utilities such as `bg-[#ff0000]` or `text-[color:...]` from being generated in dev or packaged widget CSS. That means the new design-system promise that only token colors exist is not actually framework-enforced for agent-authored widgets; add validation/rejection for arbitrary color utilities or explicitly downgrade this to guidance.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `src/ui/styles.css:15` - The renderer Tailwind entry unconditionally scans the gitignored `extensions-dev` workspace. Production builds run the same stylesheet, so any local generated dev widgets present on the release machine can be baked into the packaged renderer CSS, making release artifacts depend on untracked workspace state and potentially embedding arbitrary-value utility payloads that were never intended to ship. Keep `extensions-dev` out of production scanning or include it only via a dev-only Tailwind entry/config path.

**Round 5** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm vitest run tests/settings-view.test.tsx tests/renderer-layout.test.ts tests/design-system-styles.test.ts tests/design-type-scale.test.ts tests/ui-components.test.tsx tests/ui-export-contract.test.ts tests/ui-import-rewrite.test.ts tests/widget-tailwind-css.test.ts tests/widget-pipeline-integration.test.ts tests/widget-protocol.test.ts tests/widget-host-shim.test.ts tests/extension-layout.test.ts tests/popover-position.test.ts`
- `pnpm build`
- `pnpm vitest run tests/electron-vite-config.test.ts tests/package-config.test.ts tests/widget-module-registry.test.ts`
- <code>`chrome-devtools-axi snapshot` on the rendered Baby Menu page to verify the settings view and menu widget surface</code>
- `chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNV99YE3E2ZJQ7ERFZKZBC4/settings-view.png`
- <code>`chrome-devtools-axi click @g510:16_5` to return from settings to the menu</code>
- `chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNV99YE3E2ZJQ7ERFZKZBC4/menu-view.png`

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed (26)</summary>

**Round 1** - found 5 issues (3 warnings, 2 infos)
- ⚠️ `README.md:42` - The Quick Start still tells users to use a `login on/off` toggle in the popover header, but the change removed that pill and moved the open-at-login control behind the new settings button and settings view. Update this user-facing instruction to describe opening settings and toggling `open at login` there.
- ℹ️ `README.md:114` - The Layout section still summarizes `src/renderer/` as `AgentChat` + `WidgetHost` and has no entry for the new shared `src/ui/` design-system layer. Since this change adds a public shared `@babymenu/ui` surface and a renderer settings view, the README layout table should mention the design-system directory and the settings surface so contributors can find the new public UI layer.
- ⚠️ `.agents/skills/baby-menu-design/README.md:198` - The design-system layout rules say the widget host scrolls internally once it exceeds 360px, but the change removed the widget-host max-height/internal scrolling and moved scrolling to `.pop-body` while the popover auto-sizes up to 720px. Update this guidance to match the new popover/body scrolling behavior.
- ⚠️ `.agents/skills/baby-menu-design/README.md:222` - The iconography section says Lucide is not bundled with the live codebase, but this change adds `lucide-react` as a runtime dependency and uses Lucide icons in the renderer. Remove or revise the stale flagged substitution note.
- ℹ️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md:34` - The UI kit compatibility table says `App.tsx` has no mode toggle and the composer is always rendered. The changed app now has a settings button/view and does not render `AgentChat` while settings are open, so this compatibility note should document the settings-view exception or update the mapping.

**Round 2** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ⚠️ `.agents/skills/baby-menu-design/README.md:11` - The design-system brief still says the agent composer sits permanently at the bottom and is always one slim prompt away, but this change adds a settings view that hides `AgentChat`/the composer while settings are open. Update the brief to document the settings-view exception so designers and agents do not assume the composer is always visible in every popover state.
- ⚠️ `.agents/skills/baby-menu-design/SKILL.md:28` - The skill&#39;s hard rules still state that the composer is always visible. The changed live app now switches to a settings view where only `SettingsView` is rendered in the body and `AgentChat` is omitted, so the hard rule should mention that the composer is always visible only in the main menu/agent surface, not in settings.
- ℹ️ `.agents/skills/baby-menu-design/README.md:142` - The typography section still documents the old smaller scale as body 12-13px, caption 11px, and key 10px. This change raises the global scale in `colors_and_type.css`/`src/ui/theme.css` to `--fs-xxs`/`text-xxs` 11px, `xs` 12px, `sm` 13px, `base` 14px, and `md` 16px, so the design-system type guidance should be updated to match the new readable scale.

**Round 3** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ℹ️ `AGENTS.md:35` - The architecture overview still summarizes the renderer as `AgentChat` + `WidgetHost`, but this change adds a first-class `SettingsView` route in `src/renderer/App.tsx` that replaces both the menu body and `AgentChat` while settings are open. Update the renderer-process description so contributors can find and reason about the new settings surface.
- ⚠️ `.agents/skills/baby-menu-design/README.md:199` - The layout rules still state that the composer is always pinned to the bottom. The live app now has a settings view that renders only `SettingsView` inside `.pop-body` and omits `AgentChat`, so this layout rule should include the settings-view exception rather than presenting the composer as present in every popover state.
- ⚠️ `.agents/skills/baby-menu-design/colors_and_type.css:91` - The design-skill token source still defines the old smaller type scale (`--fs-xxs` 10px, `--fs-xs` 11px, `--fs-sm` 12px, `--fs-base` 13px, `--fs-md` 15px). The live renderer tokens and the updated design README now use the more readable scale (`--fs-xxs` 11px, `xs` 12px, `sm` 13px, `base` 14px, `md` 16px), so this source-of-truth design asset is stale and should be updated to match.

**Round 4** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `README.md:39` - The Quick Start still describes user-facing turn controls as &#34;Save / Rollback&#34; and says to use &#34;Save&#34; or &#34;Rollback&#34;, while the current SessionBar UI presents the actions as &#34;Keep&#34; and &#34;Undo&#34; (`src/renderer/agent/AgentChat.tsx`) and the updated design-system guidance explicitly says not to expose Save/Rollback to users. Update this user-facing README section to use Keep/Undo; the nearby How It Works diagram and runtime bullet should also distinguish the internal save/rollback mechanism from the visible button labels if they remain.
- ℹ️ `.agents/skills/baby-menu-design/README.md:25` - The design-system README&#39;s &#34;Key files referenced&#34; list still points designers at the old renderer styling files and does not mention the new live `src/ui/` design-system layer, `src/ui/theme.css` Tailwind `@theme`, or `src/shared/ui-exports.ts` public export contract added by this change. Add these files so the design skill points agents at the current shared `@babymenu/ui` implementation rather than only the prototype/token assets.

**Round 5** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-buttons.html:48` - The design-system button preview still demonstrates the turn-decision buttons as `Save` and `Rollback`, while the live SessionBar now labels those actions `Keep` and `Undo` and the updated design guidance explicitly says not to expose Save/Rollback to users. Update this preview so agents and designers do not copy stale user-facing labels.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-mode-toggle.html:75` - The persistent-composer preview note says the composer is pinned to the bottom of the popover at all times. The changed live app hides `AgentChat`/the composer while the settings view is open, so this preview documentation should qualify the rule as applying to the main menu/agent surface and mention the settings-view exception.
- ℹ️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx:7` - The UI kit&#39;s top-level doc comment still says `the composer is always there`. The live app now has a settings view where `AgentChat` is omitted, and the surrounding design docs have been updated with that exception. Update this comment to avoid reintroducing the old always-visible composer assumption when agents use the UI kit source as reference.

**Round 6** (auto-fix) - found 1 info
- ℹ️ `extensions/AGENTS.md:60` - The change exposes `@babymenu/ui` as a public extension-widget API (`src/shared/ui-exports.ts`) with many exported components and typed props, but the extension authoring docs only list component names and one `Progress`/`StatusDot` example. Add API-oriented usage documentation for the public components or representative examples covering required props and composition patterns such as `DataTable` columns/rows, `Badge`/`StatusDot` tones, `Sparkline` data/area options, and Radix-style `Select`/`Dialog` composition so embedded agents can use the new public surface without inspecting implementation files.

**Round 7** (auto-fix) - found 9 issues (7 warnings, 2 infos)
- ℹ️ `.agents/skills/baby-menu-design/preview/type-sans-scale.html:29` - The type-scale preview still documents the old compact scale as `10 to 18 px` and shows rows for 15px subhead, 13px body/title, and 10px tracked-caps labels, while the updated design tokens and README now define `--fs-xxs` 11px, `xs` 12px, `sm` 13px, `base` 14px, `md` 16px, and hero values 28-36px. Update this preview so the visual design reference matches the current readable scale.
- ℹ️ `.agents/skills/baby-menu-design/preview/type-eyebrow.html:22` - The tracked-caps preview label still says `tracked-caps · 10px`, but the updated design-system type scale now uses 11px for `--fs-xxs` / tracked-caps labels. Update the preview copy and sample sizing so it does not reintroduce the old 10px label guidance.
- ⚠️ `.agents/skills/baby-menu-design/preview/type-eyebrow.html:30` - The tracked-caps preview still uses `git change session`, `b8d3a2c`, and `3 files in extensions/cpu-temp/` as sample user-visible text. The changed SessionBar/design guidance now explicitly hides git, file counts, and commits behind plain-language Keep/Undo summaries, so this preview should use product-facing examples instead.
- ⚠️ `.agents/skills/baby-menu-design/preview/type-display.html:39` - The display-type preview still uses a commit hash (`b8d3a2c`) as a prominent value sample. Since the updated UI and design guidance say commits are infrastructure and should not be exposed to users, replace this sample with a user-facing value.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-pills.html:52` - The status-chip preview still shows `saved · b8d3a2c` and `pending · 3 files`. The current live labels and design guidance use plain-language Keep/Undo states and explicitly avoid commit hashes and file counts, so these chip examples are stale.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-runstrip.html:49` - The RunStrip preview still shows the current step as `editing src/main/ipc.ts`, exposing an implementation file path. The updated design guidance says file paths and git details should stay infrastructure-only; update the preview to a human-readable agent step such as writing or testing the requested widget.
- ⚠️ `.agents/skills/baby-menu-design/preview/color-accent.html:38` - The accent-color preview still demonstrates `editing src/main/ipc.ts`, `git change session`, and `saved · b8d3a2c` as visible status text. This conflicts with the updated user-facing SessionBar/design rules that hide file paths, git, and commit hashes; replace these samples with plain product-facing status copy.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-composer.html:71` - The composer preview hint says `git change session begins on send`, exposing implementation terminology in the UI kit documentation. The live design now keeps git/change-session language out of user-facing surfaces, so this hint should describe the user-visible behavior instead.
- ⚠️ `.agents/skills/baby-menu-design/preview/color-status.html:35` - The status-color preview still shows `saved · b8d3a2c`, `git change session committed`, `3 files modified`, and `save or rollback before next request`. The current UI uses Keep/Undo for visible decisions and hides git, commits, file counts, and Save/Rollback wording, so these samples are stale.

**Round 8** (auto-fix) - found 6 issues (1 warning, 5 infos)
- ℹ️ `.agents/skills/baby-menu-design/README.md:70` - The design-system README still gives `last sync 12:04` as a 10px example and the widget anatomy later calls the foot row `10px ink-faint meta`, but the updated type tokens now define `--fs-xxs` / `text-xxs` as 11px and document 11px as the minimum readable tracked-caps/meta size. Update these residual 10px references to the new 11px/token-based scale.
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css:164` - The canonical popup-menu UI kit still hardcodes several live popover text styles at 10px, including widget keys, foot rows, empty-state examples, run timers, and SessionBar hints. Since the live renderer/design tokens were raised to an 11px minimum (`--fs-xxs`) and the design docs now describe that readable scale, this UI kit reference is stale and should be updated to use the current token sizes.
- ℹ️ `.agents/skills/baby-menu-design/preview/comp-widget-card.html:16` - The widget-card preview still sets the widget key to `font-size: 10px`, while the current design tokens and documentation use 11px `--fs-xxs` / `text-xxs` for tracked-caps keys. Update this preview so agents do not copy the old compact key sizing.
- ℹ️ `.agents/skills/baby-menu-design/preview/comp-sessionbar.html:39` - The SessionBar preview still renders hint copy at `font-size: 10px`, but the updated design-system scale uses 11px as the smallest supported readable meta size. Update the hint sizing to the new token scale.
- ℹ️ `.agents/skills/baby-menu-design/preview/comp-mode-toggle.html:43` - The persistent-composer preview still uses 10px for the `send` label and its state index labels, while the updated design tokens define 11px as the smallest label/meta size. Update these sample sizes to match the current type scale.
- ℹ️ `.agents/skills/baby-menu-design/preview/brand-popover.html:40` - The popover-frame preview still sizes the tray glyph at 10px. The design-system type scale was raised to 11px minimum for tiny UI text, so this preview should be brought in line with the current token guidance or explicitly justify this as a non-text icon exception.

**Round 9** (auto-fix) - found 3 issues (1 warning, 2 infos)
- ⚠️ `README.md:33` - The Quick Start still calls the prompt surface a `popover chat`, but this change intentionally replaces chat/transcript framing with a composer plus RunStrip/SessionBar workflow. Update the user-facing wording to refer to the composer or prompt field instead of chat.
- ℹ️ `.agents/skills/baby-menu-design/README.md:149` - The spacing guidance still presents the design system as a single 2px base scale, while the new shared Tailwind path keeps standard Tailwind spacing utilities for widgets and only the legacy `colors_and_type.css` app-shell/prototype tokens use the 2px `--space-*` scale. Clarify the distinction so agents do not apply the prototype spacing scale as the Tailwind widget API.
- ℹ️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md:18` - The UI kit interaction documentation still only covers tray toggle, composer, RunStrip, and SessionBar flows. The live app change adds a settings button/view with an `open at login` switch and hides the composer while settings are open; document this interaction in the kit README or explicitly state that the prototype omits the settings flow.

**Round 10** (auto-fix) - found 2 warnings
- ⚠️ `extensions/recipes/claude-code-quota.html:156` - The recipe&#39;s implementation contract still tells the embedded agent to add main-process files, new IPC/preload API (`window.babyMenu.quota.claude()`), a renderer widget under `src/renderer/widgets`, and a `WidgetHost` registration. The current extension architecture expects this quota widget to be implemented as a self-contained extension under `&lt;extension-id&gt;/widget.tsx` plus `&lt;extension-id&gt;/server.ts`, using `window.babyMenu.capabilities.invoke(...)`, automatic widget discovery, and the shared `@babymenu/ui` surface rather than new core IPC/preload/widget registration.
- ⚠️ `extensions/recipes/codex-quota.html:157` - The recipe&#39;s implementation contract still directs the agent to create core `src/main`, `src/preload`, `src/renderer/widgets`, and `WidgetHost` registration changes for the Codex quota widget. That is stale against the current extension contract: privileged work belongs in the extension&#39;s `server.ts`, the renderer surface belongs in the extension&#39;s `widget.tsx`, calls should go through `window.babyMenu.capabilities.invoke(...)`, widgets are auto-discovered, and widget UI should use the shared `@babymenu/ui` design system instead of adding per-widget core APIs.

**Round 11** (auto-fix) - found 2 warnings
- ⚠️ `.agents/skills/baby-menu-design/README.md:46` - The design-system index still calls `colors_and_type.css` the token source of truth and says to import it. This change adds `src/ui/theme.css` as the live Tailwind `@theme` source consumed by the renderer and per-widget compiler, while `colors_and_type.css` is now a prototype/app-shell token file. Update this entry to distinguish the prototype CSS tokens from the live shared `@babymenu/ui` theme source so agents do not edit or import the wrong source when changing production widget tokens.
- ⚠️ `.agents/skills/baby-menu-design/SKILL.md:16` - The skill manifest still says `colors_and_type.css` is the token source of truth and instructs agents to always import it. The live design-system path introduced by this change uses `src/ui/theme.css` plus `@babymenu/ui`/compiled Tailwind for production widgets, so the manifest should qualify `colors_and_type.css` as the skill/prototype token asset and point production work at the live `src/ui/theme.css` contract.

**Round 12** (auto-fix) - found 2 warnings
- ⚠️ `extensions/recipes/claude-code-quota.html:73` - The recipe still tells the embedded agent to check credentials from the &#34;main process only&#34; and to run privileged CLI work in the &#34;Electron main process&#34;. This is stale against the current extension architecture: credential, network, and CLI work for this recipe should live in `claude-code-quota/server.ts` as extension server actions invoked through `window.babyMenu.capabilities.invoke(...)`, not in Baby Menu core main-process code.
- ⚠️ `extensions/recipes/codex-quota.html:73` - The recipe still tells the embedded agent to check credentials from the &#34;main process only&#34; and to run privileged CLI work in the &#34;Electron main process&#34;. This is stale against the current extension architecture: credential and CLI RPC work for this recipe should live in `codex-quota/server.ts` as extension server actions invoked through `window.babyMenu.capabilities.invoke(...)`, not in Baby Menu core main-process code.

**Round 13** (auto-fix) - found 1 warning
- ⚠️ `AGENTS.md:125` - The recipe authoring guidance still says normalized TypeScript shapes should define what data &#34;the main process should return to the renderer.&#34; This is stale against the current extension architecture documented elsewhere in the same file and recipes: recipe-backed privileged work should live in extension-owned `server.ts` actions invoked through `window.babyMenu.capabilities.invoke(...)`, with normalized data returned from those server actions to the widget rather than from Baby Menu core main-process code.

**Round 14** (auto-fix) - found 4 issues (2 warnings, 2 infos)
- ⚠️ `extensions/AGENTS.md:108` - The newly added `@babymenu/ui` examples export a standalone `function render()`, but the runtime only discovers exported widget objects whose exports include `id`, `title`, and `render` (`widgetsFromModule` filters for `RefreshableBabyMenuWidget` shape). Update the examples at lines 108 and 187 to wrap the render body in an exported `BabyMenuWidget`/`RefreshableBabyMenuWidget` object so embedded agents do not create widgets that compile but never load.
- ⚠️ `.agents/skills/baby-menu-design/README.md:204` - The layout rules still say the composer stays pinned when the popover reaches max height and that RunStrip is pinned just above the composer during an in-flight run. In the changed live code, `AgentChat` returns only `RunStrip` while `run` is active, so the composer is temporarily replaced rather than pinned underneath it. Update the layout guidance to match the actual RunStrip/composer replacement behavior.
- ℹ️ `extensions/recipes/claude-code-quota.html:156` - The implementation contract says to create or edit only &#34;extension files&#34; but then lists `tests/claude-quota.test.ts`, which lives in the repo-level test suite rather than inside the extension. Clarify this section by separating extension files (`claude-code-quota/server.ts`, `widget.tsx`) from repo-level tests so embedded agents do not place tests inside the extension workspace by mistake.
- ℹ️ `extensions/recipes/codex-quota.html:157` - The implementation contract says to create or edit only &#34;extension files&#34; but then lists `tests/codex-quota.test.ts`, which lives in the repo-level test suite rather than inside the extension. Clarify this section by separating extension files (`codex-quota/server.ts`, `widget.tsx`) from repo-level tests so embedded agents do not place tests inside the extension workspace by mistake.

**Round 15** (auto-fix) - found 1 warning
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/App.jsx:92` - The canonical popup-menu UI kit still renders `RunStrip`, `SessionBar`, and `Composer` together, with the composer merely disabled while `running` is true. The changed live `AgentChat` returns only `RunStrip` during an active run, so the composer is temporarily replaced rather than pinned underneath it. Update the UI kit source to match the live RunStrip/composer replacement behavior so agents do not copy the stale in-flight layout.

**Round 16** (auto-fix) - found 5 issues (2 warnings, 3 infos)
- ℹ️ `.agents/skills/baby-menu-design/README.md:28` - The design-system source-material list still describes `src/renderer/styles.css` as `the original warm-paper palette`, but the changed live renderer stylesheet now imports the Monochrome Lab tokens and implements the near-black popover shell. Update this entry so agents do not treat the current renderer stylesheet as a superseded warm-paper reference.
- ⚠️ `.agents/skills/baby-menu-design/README.md:203` - The layout rules say the popover is fixed at 360px with a 400px max and never less than 320px, implying a responsive width range. The current popover code fixes width to `DEFAULT_POPOVER_SIZE.width` 360px in both initial options and `responsivePopoverSize`, with only height changing dynamically. Update the width guidance to describe the actual fixed 360px runtime behavior.
- ℹ️ `.agents/skills/baby-menu-design/README.md:67` - The voice/iconography rule says status is a 5px glowing mint dot, but the current shared `@babymenu/ui` `StatusDot` uses Tailwind `size-1.5` (6px) and the live RunStrip/SessionBar dots are 8px. Update this guidance to allow the current 6-8px production dot sizes or distinguish prototype-only 5px usage from live UI components.
- ℹ️ `.agents/skills/baby-menu-design/SKILL.md:22` - The skill manifest repeats that status is a 5px glowing dot, while the current live design-system components use 6px `StatusDot` and 8px RunStrip/SessionBar dots. Keep the manifest in sync with the README and live component sizes so agents using only the skill summary do not copy the stale 5px-only rule.
- ⚠️ `.agents/skills/baby-menu-design/README.md:228` - The Lucide fallback rule mandates 16x16 icons with stroke width 1.5, but this change uses Lucide icons in compact controls at 14px (`size-3.5`) with the default Lucide stroke in places such as widget refresh and select affordances. Update the iconography guidance to document the compact-control exception or the actual live Lucide sizing/stroke conventions.

**Round 17** (auto-fix) - found 1 warning
- ⚠️ `.agents/skills/baby-menu-design/preview/color-status.html:45` - The status-color preview still uses `working tree dirty` and `commit or stash before asking` as visible refused-state copy. The current SessionBar/runtime design filters infrastructure terms such as `working tree`, `commit`, and `stash` out of user-facing summaries and uses plain-language blocked copy like `Finish this change first` / `keep or undo before asking again`, so this preview should be updated to match the non-git user-facing language.

**Round 18** (auto-fix) - found 3 issues (1 warning, 2 infos)
- ⚠️ `README.md:22` - The public feature summary still says every agent turn can be &#34;kept or rolled back,&#34; but the changed UI and design guidance expose the turn actions as Keep and Undo and intentionally avoid rollback terminology in user-facing copy. Update this bullet to use &#34;undone&#34; or the Keep/Undo wording.
- ℹ️ `README.md:75` - The How It Works diagram still summarizes the renderer popover as `+ AgentChat`, but the changed renderer now has a menu surface with widgets, a separate agent-control surface, and a settings view that replaces both while open. Update the diagram label so contributors do not miss the new `MenuSurface`/`SettingsView` split.
- ℹ️ `.agents/skills/baby-menu-design/README.md:145` - The typography guidance now states the design scale starts at 11px, but the live app-shell stylesheet still hardcodes several 10px text styles such as widget keys, foot rows, run timers, and SessionBar hints in `src/renderer/styles.css`. Either document these as app-shell exceptions or adjust the guidance so the design reference does not overstate the current live minimum size.

**Round 19** (auto-fix) - found 2 warnings
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md:13` - The popup-menu UI kit file table still describes `Composer.jsx` as &#34;Always pinned to bottom.&#34; In both the changed live app (`AgentChat` returns only `RunStrip` while a run is active and hides the composer in settings) and the updated prototype flow, the composer is only pinned on the main idle surface and is replaced during an agent run or settings. Update this description to include those exceptions.
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/Composer.jsx:5` - The `Composer.jsx` doc comment still says the composer is a persistent slim bar pinned to the bottom of the popover. The changed live behavior and the current `App.jsx` prototype render `RunStrip` instead of `Composer` while a run is active, and settings hide the composer entirely. Update the comment so agents using the UI kit source do not copy the stale always-persistent composer model.

**Round 20** (auto-fix) - found 2 warnings
- ⚠️ `.agents/skills/baby-menu-design/SKILL.md:28` - The skill hard rules still say the composer is always visible on the main menu and only mention the settings-view exception. The live `AgentChat` now returns only `RunStrip` while a run is active, so the composer is also replaced during agent execution. Update the hard rule to include the in-flight RunStrip exception so agents using only the skill summary do not design a composer pinned underneath active runs.
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md:41` - The compatibility note says `GitSessionSnapshot` maps to the SessionBar&#39;s internal `session.kind` and that the agent should pass a separate plain-language `summary` alongside the snapshot. The current contract returns `AgentChatResult.assistantText` plus `session`, and `useAgentRuntime` derives `AgentSessionNotice`/summary from `assistantText` and `GitSessionSnapshot.canSave/canRollback`; there is no separate summary field and `GitSessionSnapshot` has no `kind`. Update this note to match the actual renderer mapping.

**Round 21** (auto-fix) - found 5 issues (2 warnings, 3 infos)
- ⚠️ `.agents/skills/baby-menu-design/README.md:165` - The design-system button guidance still says buttons are full pill-shaped, but the new shared production `@babymenu/ui` `Button` component uses `rounded-sm` in `src/ui/Button.tsx`. Update this rule to describe the current shared component shape or explicitly distinguish prototype/app-shell pill buttons from production `@babymenu/ui` buttons.
- ⚠️ `.agents/skills/baby-menu-design/SKILL.md:34` - The skill hard rules repeat that buttons are pill-shaped, which is stale for production code after this change because the exported shared `Button` component is `rounded-sm`. Keep the skill summary in sync with the live design-system component so agents using only the manifest do not generate the wrong button shape.
- ℹ️ `.agents/skills/baby-menu-design/preview/comp-buttons.html:46` - The button preview still documents `pill is the only roundness` and renders all sample buttons with `border-radius: 999px`, while the new shared `@babymenu/ui` `Button` component uses compact `rounded-sm` corners. Update the preview or label it as prototype-only so designers do not copy stale production button guidance.
- ℹ️ `extensions/recipes/claude-code-quota.html:156` - The recipe requires automatic 5-minute refresh and a manual refresh action, but its implementation contract only says to create `server.ts` and `widget.tsx`. Since the current widget contract centralizes refresh in `WidgetHost` via exported `RefreshableBabyMenuWidget.refresh` and optional `refreshIntervalMs`, add recipe instructions to export a refreshable widget and put the quota reload logic behind `refresh` rather than widget-owned polling.
- ℹ️ `extensions/recipes/codex-quota.html:157` - The recipe requires automatic 5-minute refresh and a manual refresh action, but its implementation contract does not tell agents to use the current `RefreshableBabyMenuWidget` contract. Add instructions to export a refreshable widget with `refresh` and optional `refreshIntervalMs`, letting `WidgetHost` own timer/manual refresh instead of adding widget-owned polling.

**Round 22** (auto-fix) - found 1 info
- ℹ️ `extensions/AGENTS.md:64` - The extension authoring docs list the newly public `@babymenu/ui` input and disclosure components (`Button`, `Field`, `Input`, `Textarea`, `Switch`, `Tabs`, `DropdownMenu`, `Tooltip`) but the API guidance and examples only cover data components plus `Select`/`Dialog`. Since these components are now exported through the public design-system contract, add usage notes for important props and composition patterns such as `Button` variants/sizes, `Field` child wiring, `Switch` checked handlers, `Tabs` root/list/trigger/content, `DropdownMenu` trigger/content/item, and `Tooltip` content/side so embedded agents can use the public API without inspecting `src/ui` implementation files.

**Round 23** (auto-fix) - found 4 issues (2 warnings, 2 infos)
- ⚠️ `.agents/skills/baby-menu-design/README.md:11` - The design-system brief still says the composer sits at the bottom of the main surface permanently and only names settings as the exception. The live `AgentChat` returns only `RunStrip` while an agent run is active, and later guidance in this same file says the RunStrip replaces the composer during a run. Update the opening brief so it lists both exceptions: settings and in-flight RunStrip replacement.
- ℹ️ `.agents/skills/baby-menu-design/preview/spacing-radius.html:27` - The radius preview still labels the pill radius as `pill · buttons` and the note says `Buttons = pill`, but the new shared production `@babymenu/ui` `Button` component uses compact `rounded-sm` corners and the updated design README says pill controls are only prototype/app-shell exceptions. Update this preview to show production buttons as `--radius-sm`/4px or explicitly mark the pill example as prototype-only.
- ℹ️ `.agents/skills/baby-menu-design/preview/brand-iconography.html:51` - The iconography preview still says Lucide fallback icons should be 16px with stroke 1.5. The live app now uses bundled Lucide icons at 14px in compact controls and 16px in roomier controls, and the updated README documents that split. Update the preview note and SVG samples to match the 14px compact-control exception or label the current 16px examples as roomier-control examples only.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-mode-toggle.html:75` - The persistent-composer preview note says the composer is pinned to the bottom of the main menu and agent surface and only mentions the settings exception. The live `AgentChat` also replaces the composer with `RunStrip` during an active run, so this preview should mention the in-flight replacement behavior to avoid agents designing a composer under the RunStrip.

**Round 24** (auto-fix) - found 8 issues (6 warnings, 2 infos)
- ⚠️ `.agents/skills/baby-menu-design/README.md:68` - The design-system iconography guidance still documents `⟳` as the refresh affordance and says ASCII glyphs cover refresh, but the changed live `WidgetHost` now renders the widget refresh control with Lucide `RefreshCw` at compact icon size. Update the README iconography and widget-head guidance so refresh is documented as a Lucide compact-control exception rather than an ASCII glyph.
- ⚠️ `.agents/skills/baby-menu-design/SKILL.md:31` - The skill hard-rule summary still includes `⟳` in the core ASCII glyph set. Since the live widget refresh action was changed to use a bundled Lucide `RefreshCw` icon, this summary should match the production rule and identify refresh as a Lucide fallback/compact-control use case.
- ℹ️ `.agents/skills/baby-menu-design/preview/brand-iconography.html:33` - The iconography preview still shows `⟳` as one of the primary ASCII glyphs and says `› ⟳ + · ↵ ⌘ ●` cover almost every popover affordance. The current production refresh control uses Lucide `RefreshCw`, so this preview should move refresh into the Lucide examples or otherwise label the ASCII glyph as prototype-only.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-widget-card.html:55` - The widget-card preview still renders the widget refresh button as the ASCII `⟳` glyph, while the live `WidgetHost` now uses the Lucide `RefreshCw` icon inside the shared `Button` component. Update the preview so agents copying the widget shell reproduce the live refresh affordance.
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/WidgetHost.jsx:14` - The canonical popup-menu UI kit still renders refresh buttons with the ASCII `⟳` glyph. The changed live widget shell uses Lucide `RefreshCw`, so this reference implementation should be updated or explicitly marked as prototype-only for refresh iconography.
- ⚠️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/WidgetHost.jsx:117` - The UI kit empty state still says `switch to build, ask the agent to add one`, but the redesigned app has no build-mode toggle and keeps the composer on the main idle surface. Replace this stale build-mode instruction with the current user-facing empty-state copy, such as asking the agent to add a widget.
- ⚠️ `.agents/skills/baby-menu-design/preview/comp-empty.html:30` - The empty-state preview still tells users to `switch to build`, which conflicts with the changed no-build-mode interaction model. Update the preview copy to match the live empty state and current design guidance that the agent composer is already available on the main surface.
- ℹ️ `.agents/skills/baby-menu-design/README.md:137` - The color guidance names amber and coral tokens only as `--signal-pending` and `--signal-error` after pointing readers at the live `src/ui/theme.css`. The new production Tailwind theme exposes these as `--color-signal-warn` / `text-signal-warn` and `--color-signal-danger` / `text-signal-danger`, while `--signal-pending` and `--signal-error` are app-shell/prototype CSS names. Document both names or qualify the existing names so production widget authors do not use unavailable Tailwind utilities.

**Round 25** (auto-fix) - found 4 issues (2 warnings, 2 infos)
- ⚠️ `README.md:130` - The environment flag table documents `BABY_MENU_EXTENSIONS_DIR=&lt;dir&gt;` as a general source/dev extension-workspace override, but the new dev Tailwind path only scans `extensions/` and `extensions-dev/` via `src/ui/styles.css` / `src/ui/styles.dev.css`, and source-mode widget descriptors do not get a compiled `cssUrl`. A custom override outside those scanned directories can load widget modules without their Tailwind utility CSS, so the docs should warn about the supported override locations or the dev CSS limitation.
- ⚠️ `AGENTS.md:94` - The agent-runtime docs say source mode honors `BABY_MENU_EXTENSIONS_DIR` without noting that dev/source Tailwind utility generation is only wired for the statically scanned `extensions/` and `extensions-dev/` paths. Update this contributor guidance to document the same limitation or require adding an `@source` path when using an override outside those directories.
- ℹ️ `extensions/AGENTS.md:159` - The extension authoring docs say widget Tailwind styles are compiled automatically, but the new packaged compiler relies on Tailwind scanning the extension source with `@source`, so dynamically assembled class-name fragments may be omitted from packaged CSS. Add guidance to keep Tailwind class names statically discoverable or explicitly safelisted/documented through supported patterns.
- ℹ️ `.agents/skills/baby-menu-design/colors_and_type.css:136` - The design token comment still describes `--radius-pill` as `the *only* rounded affordance`, while the updated production `@babymenu/ui` button and design guidance use `--radius-sm` / `rounded-sm` for shared buttons and reserve pills for prototype/app-shell exceptions. Update this source-material comment so the token reference does not contradict the current button-radius contract.

**Round 26** (auto-fix) - found 2 infos
- ℹ️ `.agents/skills/baby-menu-design/preview/comp-sessionbar.html:46` - The SessionBar preview still styles its Keep/Undo/Dismiss buttons with `border-radius: 999px`, while this change moved production controls to the shared `@babymenu/ui` `Button` component using compact `rounded-sm` corners and the updated button preview says production buttons use compact corners. Update the SessionBar preview so it does not continue documenting pill-shaped production action buttons.
- ℹ️ `.agents/skills/baby-menu-design/ui_kits/popup-menu/popup.css:349` - The popup-menu UI kit&#39;s shared `.btn` rule still uses a pill radius (`999px`). The live SessionBar now renders `@babymenu/ui` buttons from `src/ui/Button.tsx`, which use compact `rounded-sm` corners, and the design docs now distinguish pill controls as prototype/app-shell exceptions. Update the kit CSS or explicitly mark this button radius as prototype-only so agents do not copy stale production button styling.

**Round 27** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
