### PR TITLE
fix(renderer): clarify system start setting label

### DIFF
--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -21,7 +21,7 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 2. **Type a request** in the composer and press Enter (or click `send`). The composer flips into a `RunStrip` with a pulsing mint dot, a current-step subtitle that fades up each time the agent advances, and a live timer. No checklist, no log.
 3. **When the agent finishes**, a `SessionBar` slides in with a plain-language summary (e.g. `Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. Click **Keep** to add the new widget to the surface; click **Undo** to discard. Either way, the bar auto-dismisses after a moment.
 4. **Send a second request while a session is still pending** — the SessionBar flips to an amber-dot `Finish this change first` state. Click **Dismiss** and try again.
-5. **Open settings from the header** in the live app to change `open at login`, or use the adjacent quit control to fully quit Baby Menu.
+5. **Open settings from the header** in the live app to change `launch at system start`, or use the adjacent quit control to fully quit Baby Menu.
    The settings view replaces the menu body and hides the composer until you return to the main surface; this prototype documents that flow but does not implement the settings screen.
 
 ## What this kit *does not* try to do

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Baby Menu writes the extension under `~/.baby-menu/extensions`, mounts the widge
 Use Keep to keep it, or Undo to throw it away.
 The packaged app opens at login by default.
 Use the popover header to open settings or fully quit the app.
-Settings lets you turn `open at login` off or back on.
+Settings lets you turn `launch at system start` off or back on.
 
 ## Install Details
 

--- a/src/renderer/settings/SettingsView.tsx
+++ b/src/renderer/settings/SettingsView.tsx
@@ -25,10 +25,10 @@ export function SettingsView() {
       <span className="text-xxs uppercase tracking-caps text-ink-label">preferences</span>
       <div className="flex items-center justify-between gap-4">
         <span className="flex flex-col gap-0.5">
-          <span className="text-sm text-ink">open at login</span>
-          <span className="text-xs text-ink-soft">launch baby_menu when you sign in</span>
+          <span className="text-sm text-ink">launch at system start</span>
+          <span className="text-xs text-ink-soft">Automatically start baby menu along with your system</span>
         </span>
-        <Switch checked={openAtLogin} onCheckedChange={(next) => void toggle(next)} aria-label="open at login" />
+        <Switch checked={openAtLogin} onCheckedChange={(next) => void toggle(next)} aria-label="launch at system start" />
       </div>
     </div>
   );

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -34,12 +34,12 @@ describe("settings view", () => {
 
     // Menu view: composer present, no settings controls.
     expect(screen.getByPlaceholderText("ask the agent")).toBeTruthy();
-    expect(screen.queryByText("open at login")).toBeNull();
+    expect(screen.queryByText("launch at system start")).toBeNull();
 
     // Open settings.
     fireEvent.click(screen.getByRole("button", { name: "open settings" }));
-    expect(await screen.findByText("open at login")).toBeTruthy();
-    const toggle = screen.getByRole("switch", { name: "open at login" });
+    expect(await screen.findByText("launch at system start")).toBeTruthy();
+    const toggle = screen.getByRole("switch", { name: "launch at system start" });
     expect(toggle).toBeTruthy();
     // The agent composer is hidden in the settings context.
     expect(screen.queryByPlaceholderText("ask the agent")).toBeNull();
@@ -51,6 +51,6 @@ describe("settings view", () => {
     // Return to the menu.
     fireEvent.click(screen.getByRole("button", { name: "close settings" }));
     expect(await screen.findByPlaceholderText("ask the agent")).toBeTruthy();
-    expect(screen.queryByText("open at login")).toBeNull();
+    expect(screen.queryByText("launch at system start")).toBeNull();
   });
 });


### PR DESCRIPTION
## Intent

The developer wanted to update the text in a settings section for the app’s login/startup behavior. They specifically requested the title be changed to "launch at system start" and the subtitle to "Automatically start baby menu along with your system".

## What Changed

- Updated the settings launch preference label, subtitle, and switch aria label to use `launch at system start` language.
- Aligned settings view tests, README copy, and the popup-menu design kit docs with the new launch preference wording.

## Risk Assessment

✅ Low: The change is limited to settings UI copy and matching test selectors, with no behavioral or integration changes.

## Testing

Inspected the target diff, ran the focused settings view Vitest test, discarded an initially stale browser session, started the current checkout with `pnpm dev`, opened Settings in the rendered app, and captured a screenshot showing the requested title and subtitle with no issues found.

<details>
<summary>Evidence: Rendered settings copy showing launch at system start</summary>

Source: Rendered settings copy showing launch at system start (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSQSH3P3XWHH4SQMTMGR7T77/settings-launch-at-system-start.png</code>)

```text
The screenshot shows the Settings preferences row with title `launch at system start` and subtitle `Automatically start baby menu along with your system`.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 5a364d35f8a123ab81b1e11a4e7977bd119f3a73..32fd20800b9c367eb1b60e1ee3f6dc3965e46722 && git diff --name-only 5a364d35f8a123ab81b1e11a4e7977bd119f3a73..32fd20800b9c367eb1b60e1ee3f6dc3965e46722`
- `pnpm vitest run tests/settings-view.test.tsx`
- `BABY_MENU_KEEP_POPOVER_OPEN=1 pnpm dev`
- `chrome-devtools-axi open http://localhost:5273/`
- <code>`chrome-devtools-axi snapshot` and `chrome-devtools-axi click @g592:51_5` to open Settings in the current checkout&#39;s rendered app</code>
- `chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSQSH3P3XWHH4SQMTMGR7T77/settings-launch-at-system-start.png`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
