### PR TITLE
feat: add selectable embedded agents

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -15,6 +15,8 @@ When the user sends a request, the composer momentarily becomes a `RunStrip`: a 
 The popover surface is dynamic-height.
 On the main menu, the composer is pinned to the bottom; everything above it stacks and grows.
 The header keeps compact settings and quit controls together; quit stays neutral at rest and shifts to danger coral only on hover.
+Settings replaces the menu body and composer, and includes both the `open at login` preference and the embedded-agent picker.
+Agent options are radio-like rows: available inactive agents can be selected, unavailable agents are disabled with install hints, and switching agents requires confirmation because it resets the current conversation.
 
 ---
 

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -21,8 +21,9 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 2. **Type a request** in the composer and press Enter (or click `send`). The composer flips into a `RunStrip` with a pulsing mint dot, a current-step subtitle that fades up each time the agent advances, and a live timer. No checklist, no log.
 3. **When the agent finishes**, a `SessionBar` slides in with a plain-language summary (e.g. `Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. Click **Keep** to add the new widget to the surface; click **Undo** to discard. Either way, the bar auto-dismisses after a moment.
 4. **Send a second request while a session is still pending** — the SessionBar flips to an amber-dot `Finish this change first` state. Click **Dismiss** and try again.
-5. **Open settings from the header** in the live app to change `launch at system start`, or use the adjacent quit control to fully quit Baby Menu.
+5. **Open settings from the header** in the live app to change `launch at system start`, choose the embedded agent, or use the adjacent quit control to fully quit Baby Menu.
    The settings view replaces the menu body and hides the composer until you return to the main surface; this prototype documents that flow but does not implement the settings screen.
+   The live settings screen shows unavailable agents disabled with install hints and confirms before switching agents because switching resets the current conversation.
 
 ## What this kit *does not* try to do
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ Use `pnpm` (declared `packageManager: pnpm@11.1.1`). Renderer dev server is pinn
 ## Dev mode helpers
 
 - `BABY_MENU_KEEP_POPOVER_OPEN=1` disables the blur-to-hide behavior so the popover stays open while devtools / external windows have focus.
-- `BABY_MENU_AGENT=<agent-name>` selects the ACP agent. E2E tests pass `acpx-mock` via `registryOverrides`.
+- `BABY_MENU_AGENT=<agent-name>` overrides agent auto-detection when no saved Settings choice exists. E2E tests pass `acpx-mock` via `registryOverrides`.
+- `BABY_MENU_AGENT_TIMEOUT_MS=<ms>` overrides the embedded-agent request timeout.
 - `process.env.VITEST` is checked in `src/main/app.ts` so importing the main entry from tests does not auto-start the Electron app.
 
 ## Architecture
@@ -42,11 +43,12 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 
 `src/main/` module index:
 
-- `app.ts` - Electron lifecycle, popover window creation, packaged path setup, extension seeding, preferences, protocols, tray, and IPC. `package.json#main` points here via `out/main/index.js`.
+- `app.ts` - Electron lifecycle, popover window creation, packaged path setup, extension seeding, preferences, selectable-agent catalog wiring, protocols, tray, and IPC. `package.json#main` points here via `out/main/index.js`.
 - `app-paths.ts` - resolves source paths versus packaged `~/.baby-menu` paths.
 - `tray.ts` - macOS tray icon and click handling (`createBabyMenuTray`).
 - `popover.ts` - popover `BrowserWindow` options (`createPopoverOptions`), bounds math (`calculatePopoverBounds`), and renderer URL/file loading (`loadPopoverRenderer`).
 - `ipc.ts` - registers all `ipcMain` handlers exposed via the preload bridge; the single place new generic IPC routes are added.
+- `agent-catalog.ts` - defines built-in agents, merges custom `agents.json`, computes Settings availability, and builds `acpx` registry overrides.
 - `agent-runtime.ts` - `BabyMenuAgentRuntime` wrapping `acpx/runtime`; gates every `send()` through a change session.
 - `agent-turn-log.ts` - structured per-turn transcript log used by the renderer and tests.
 - `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
@@ -56,7 +58,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `widget-tailwind-css.ts` - compiles a widget's authored Tailwind utilities against the `@babymenu/ui` `@theme` (single source of truth, `src/ui/theme.css`) for packaged loading.
 - `widget-module-registry.ts` - discovers widget modules, returning a renderer `/@fs` URL in dev and, in packaged mode, a compiled `baby-menu-widget://` module URL plus a sibling compiled `cssUrl`.
 - `widget-protocol.ts` - registers custom protocols for compiled widget modules, the per-widget `.css`, and the renderer host shims (`react`, `react/jsx-runtime`, and `@babymenu/ui` re-exported from the host global).
-- `preferences.ts` - stores app preferences under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
+- `preferences.ts` - stores app preferences, including the selected agent, under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
 - `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `recipe-loader.ts` - discovers and parses `recipes/*.html` from the active extension workspace.
 - `server-action-registry.ts` - dynamically loads extension server actions and background task declarations from the active extension workspace.
@@ -92,7 +94,8 @@ Keep credential and token work in extension server actions.
 
 ### Agent runtime + change sessions
 
-`BabyMenuAgentRuntime` (`src/main/agent-runtime.ts`) wraps `acpx/runtime`. It allows only one active `send()` call at a time; overlapping sends return an "already running" assistant response before any change session begins. Every accepted `send()` call:
+`BabyMenuAgentRuntime` (`src/main/agent-runtime.ts`) wraps `acpx/runtime`. It allows only one active `send()` call at a time; overlapping sends return an "already running" assistant response before any change session begins. The active agent comes from the persisted Settings choice, then `BABY_MENU_AGENT`, then catalog auto-detection. The catalog defaults to Claude Code, Pi, and Codex, and may be extended by `agents.json` under the active app data root (`~/.baby-menu/agents.json` when packaged, repo-root `agents.json` in source mode). Switching agents through Settings is blocked while an agent turn is running or while a change session can still be saved or rolled back; a successful switch closes the current persistent session with `discardPersistentState` so the next turn starts a fresh conversation.
+Every accepted `send()` call:
 
 1. Resolves the active extension workspace from runtime paths. Source mode honors `BABY_MENU_EXTENSIONS_DIR` or defaults to `extensions/`; packaged mode uses `~/.baby-menu/extensions` after seeding bundled templates. Dev/source Tailwind utility generation scans only `extensions/` and `extensions-dev/` unless `src/ui/styles.css` or `src/ui/styles.dev.css` is given an additional `@source` path, so custom overrides outside those directories may load widget modules without their utility CSS.
 2. Uses `DevExtensionChangeSession` for snapshot workspaces such as `extensions-dev/` and packaged `~/.baby-menu/extensions`, so Save keeps generated files and Rollback restores the pre-turn contents.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,35 @@ Use Keep to keep it, or Undo to throw it away.
 Extensions can keep local state in Baby Menu's shared SQLite store and can register background tasks for work that must continue while the popover is closed.
 The packaged app opens at login by default.
 Use the popover header to open settings or fully quit the app.
-Settings lets you turn `launch at system start` off or back on.
+Settings lets you turn `launch at system start` off or back on, choose the embedded agent, and see unavailable agents with install hints.
+Switching agents resets the current conversation after confirmation.
 
 ## Install Details
 
-The packaged app stores mutable extensions, the local extension database, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets and extension state.
-Set `BABY_MENU_AGENT=<name>` in the launch environment to choose an agent explicitly.
+The packaged app stores mutable extensions, the local extension database, caches, agent sessions, custom agent catalog, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets and extension state.
+Baby Menu detects supported agents from the catalog in order: Claude Code (`claude`), Pi (`npx`), then Codex (`codex`).
+Use Settings to persist an agent choice across launches.
+Set `BABY_MENU_AGENT=<name>` in the launch environment to override auto-detection before a preference is saved.
+Add `~/.baby-menu/agents.json` to override or append catalog entries; source mode reads `agents.json` from the repo root.
+Each entry is an object with `name`, optional `label`, optional `command`, optional `installHint`, and optional `launchCommand`.
+Agents with `launchCommand` are registered as custom `acpx` overrides and are shown as available.
+
+```json
+[
+  {
+    "name": "gemini",
+    "label": "Gemini",
+    "command": "gemini",
+    "installHint": "Install the Gemini CLI, then restart Baby Menu."
+  },
+  {
+    "name": "local-mock",
+    "label": "Local Mock",
+    "command": "node",
+    "launchCommand": "node ./agents/local-mock.js"
+  }
+]
+```
 
 Update with Homebrew:
 
@@ -132,7 +155,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | Var                              | Effect                                                       |
 | -------------------------------- | ------------------------------------------------------------ |
 | `BABY_MENU_KEEP_POPOVER_OPEN=1`  | Disables blur-to-hide so devtools / external windows stay up |
-| `BABY_MENU_AGENT=<name>`         | Selects the ACP agent (e2e tests use `acpx-mock`)            |
+| `BABY_MENU_AGENT=<name>`         | Overrides agent auto-detection when no saved Settings choice exists |
+| `BABY_MENU_AGENT_TIMEOUT_MS=<ms>` | Overrides the embedded-agent request timeout                 |
 | `BABY_MENU_EXTENSIONS_DIR=<dir>` | Overrides the active extension workspace in source/dev runs. Dev Tailwind scans only `extensions/` and `extensions-dev/`, so overrides outside those paths need matching `@source` coverage for widget utilities. |
 
 ## Development

--- a/src/main/agent-catalog.ts
+++ b/src/main/agent-catalog.ts
@@ -1,0 +1,112 @@
+import { readFile } from "node:fs/promises";
+
+export type AgentDefinition = {
+  /** acpx agent name and registry key. */
+  name: string;
+  /** Display name shown in settings. */
+  label: string;
+  /** CLI command probed with commandExists to decide availability. */
+  command: string;
+  /** Shown in settings when the agent is unavailable. */
+  installHint?: string;
+  /** When set, registered as an acpx registry override so a custom command launches this agent. */
+  launchCommand?: string;
+};
+
+export type AgentOption = {
+  name: string;
+  label: string;
+  available: boolean;
+  installHint?: string;
+};
+
+export const DEFAULT_AGENTS: readonly AgentDefinition[] = [
+  {
+    name: "claude",
+    label: "Claude Code",
+    command: "claude",
+    installHint: "Install the Claude Code CLI, then restart Baby Menu.",
+  },
+  {
+    name: "pi",
+    label: "Pi",
+    command: "npx",
+    installHint: "Install Node.js (provides npx), then restart Baby Menu.",
+  },
+  {
+    name: "codex",
+    label: "Codex",
+    command: "codex",
+    installHint: "Install the Codex CLI, then restart Baby Menu.",
+  },
+];
+
+type ResolveAgentCatalogOptions = {
+  /** Parsed contents of agents.json (an array of agent definitions). */
+  config?: unknown;
+  /** Built-in defaults; overridable for tests. */
+  defaults?: readonly AgentDefinition[];
+};
+
+function parseAgentDefinitions(config: unknown): AgentDefinition[] {
+  if (!Array.isArray(config)) return [];
+  const definitions: AgentDefinition[] = [];
+  for (const entry of config) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const candidate = entry as Record<string, unknown>;
+    const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+    if (!name) continue;
+    const command = typeof candidate.command === "string" ? candidate.command.trim() : "";
+    const launchCommand = typeof candidate.launchCommand === "string" ? candidate.launchCommand.trim() : "";
+    definitions.push({
+      name,
+      label: typeof candidate.label === "string" && candidate.label.trim() ? candidate.label.trim() : name,
+      command: command || name,
+      installHint: typeof candidate.installHint === "string" ? candidate.installHint : undefined,
+      launchCommand: launchCommand || undefined,
+    });
+  }
+  return definitions;
+}
+
+export function resolveAgentCatalog(options: ResolveAgentCatalogOptions = {}): AgentDefinition[] {
+  const defaults = options.defaults ?? DEFAULT_AGENTS;
+  const order = defaults.map((agent) => agent.name);
+  const byName = new Map<string, AgentDefinition>(defaults.map((agent) => [agent.name, { ...agent }]));
+
+  for (const definition of parseAgentDefinitions(options.config)) {
+    const existing = byName.get(definition.name);
+    if (!existing) order.push(definition.name);
+    byName.set(definition.name, existing ? { ...existing, ...definition } : definition);
+  }
+
+  return order.map((name) => byName.get(name)!);
+}
+
+export function toAgentOptions(
+  catalog: readonly AgentDefinition[],
+  commandExists: (command: string) => boolean,
+): AgentOption[] {
+  return catalog.map((agent) => ({
+    name: agent.name,
+    label: agent.label,
+    available: agent.launchCommand ? true : commandExists(agent.command),
+    installHint: agent.installHint,
+  }));
+}
+
+export function agentRegistryOverrides(catalog: readonly AgentDefinition[]): Record<string, string> {
+  const overrides: Record<string, string> = {};
+  for (const agent of catalog) {
+    if (agent.launchCommand) overrides[agent.name] = agent.launchCommand;
+  }
+  return overrides;
+}
+
+export async function loadAgentConfigFile(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/main/agent-runtime.ts
+++ b/src/main/agent-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "acpx/runtime";
 import type { AgentChatResult, GitActionResult, GitSessionSnapshot } from "../shared/contracts";
 import type { AgentRuntimeStatus } from "../shared/contracts";
+import { type AgentDefinition, resolveAgentCatalog } from "./agent-catalog";
 import { getAgentStateDir, getDevExtensionSnapshotDir, getExtensionsDir } from "../shared/paths";
 import { AgentTurnLogRecorder } from "./agent-turn-log";
 import { DevExtensionChangeSession } from "./dev-extension-change-session";
@@ -40,13 +41,9 @@ type ResolveDefaultAgentNameOptions = {
   env?: Partial<Pick<NodeJS.ProcessEnv, "BABY_MENU_AGENT" | "PATH">>;
   commandExists?: (command: string) => boolean;
   allowFallbackWhenMissing?: boolean;
+  catalog?: readonly AgentDefinition[];
 };
 
-const PREFERRED_AGENTS = [
-  { name: "claude", command: "claude" },
-  { name: "pi", command: "npx" },
-  { name: "codex", command: "codex" },
-] as const;
 const DEFAULT_AGENT_TIMEOUT_MS = 300_000;
 
 type AgentChangeSession = {
@@ -68,7 +65,7 @@ export class AgentTimeoutError extends Error {
   }
 }
 
-function commandExists(command: string): boolean {
+export function commandExists(command: string): boolean {
   const lookupCommand = process.platform === "win32" ? "where" : "sh";
   const lookupArgs = process.platform === "win32" ? [command] : ["-c", "command -v \"$1\"", "sh", command];
   return spawnSync(lookupCommand, lookupArgs, { stdio: "ignore" }).status === 0;
@@ -78,10 +75,12 @@ export function resolveDefaultAgentName(options: ResolveDefaultAgentNameOptions 
   const configuredAgent = options.env?.BABY_MENU_AGENT ?? process.env.BABY_MENU_AGENT;
   if (configuredAgent?.trim()) return configuredAgent.trim();
 
+  const catalog = options.catalog ?? resolveAgentCatalog();
+  if (catalog.length === 0) return null;
   const hasCommand = options.commandExists ?? commandExists;
-  const detected = PREFERRED_AGENTS.find((agent) => hasCommand(agent.command))?.name;
+  const detected = catalog.find((agent) => (agent.launchCommand ? true : hasCommand(agent.command)))?.name;
   if (detected) return detected;
-  return options.allowFallbackWhenMissing === false ? null : PREFERRED_AGENTS[0].name;
+  return options.allowFallbackWhenMissing === false ? null : catalog[0].name;
 }
 
 export function resolveAgentTimeoutMs(env: Partial<Pick<NodeJS.ProcessEnv, "BABY_MENU_AGENT_TIMEOUT_MS">> = process.env) {
@@ -257,7 +256,7 @@ export class BabyMenuAgentRuntime {
   private handle: AcpRuntimeHandle | null = null;
   private activeSession: AgentChangeSession | null = null;
   private activeTurn = false;
-  private readonly agentName: string;
+  private agentName: string;
   private readonly registryOverrides: Record<string, string> | undefined;
   private readonly requestTimeoutMs: number;
   private readonly paths: BabyMenuAgentRuntimePaths | undefined;
@@ -269,7 +268,7 @@ export class BabyMenuAgentRuntime {
     this.agentName =
       typeof options === "string"
         ? options
-        : options.agentName ?? resolveDefaultAgentName() ?? PREFERRED_AGENTS[0].name;
+        : options.agentName ?? resolveDefaultAgentName() ?? resolveAgentCatalog()[0].name;
     this.registryOverrides = typeof options === "string" ? undefined : options.registryOverrides;
     this.requestTimeoutMs = typeof options === "string" ? resolveAgentTimeoutMs() : options.requestTimeoutMs ?? resolveAgentTimeoutMs();
     this.paths = typeof options === "string" ? undefined : options.paths;
@@ -277,6 +276,32 @@ export class BabyMenuAgentRuntime {
 
   get session(): AgentChangeSession | null {
     return this.activeSession;
+  }
+
+  get currentAgent(): string {
+    return this.agentName;
+  }
+
+  /**
+   * Switches the embedded agent and resets the live conversation. Closing the
+   * runtime with discardPersistentState drops the persisted "baby-menu-agent-chat"
+   * session so the next send() starts the new agent with a fresh conversation.
+   */
+  async setAgent(name: string): Promise<void> {
+    const next = name.trim();
+    if (!next || next === this.agentName) return;
+
+    if (this.runtime && this.handle) {
+      const runtime = this.runtime;
+      const handle = this.handle;
+      await runtime
+        .close({ handle, reason: "agent-switch", discardPersistentState: true })
+        .catch(() => undefined);
+    }
+    this.runtime = null;
+    this.handle = null;
+    this.activeSession = null;
+    this.agentName = next;
   }
 
   async send(prompt: string, options: BabyMenuAgentRuntimeSendOptions = {}): Promise<AgentChatResult> {

--- a/src/main/agent-runtime.ts
+++ b/src/main/agent-runtime.ts
@@ -282,6 +282,14 @@ export class BabyMenuAgentRuntime {
     return this.agentName;
   }
 
+  get agentSwitchDisabledReason(): string | undefined {
+    if (this.activeTurn) return "Agent is running. Wait for it to finish before switching agents.";
+    if (this.activeSession?.canSave || this.activeSession?.canRollback) {
+      return "Save or Rollback the current agent changes before switching agents.";
+    }
+    return undefined;
+  }
+
   /**
    * Switches the embedded agent and resets the live conversation. Closing the
    * runtime with discardPersistentState drops the persisted "baby-menu-agent-chat"
@@ -290,6 +298,9 @@ export class BabyMenuAgentRuntime {
   async setAgent(name: string): Promise<void> {
     const next = name.trim();
     if (!next || next === this.agentName) return;
+
+    const disabledReason = this.agentSwitchDisabledReason;
+    if (disabledReason) throw new Error(disabledReason);
 
     if (this.runtime && this.handle) {
       const runtime = this.runtime;
@@ -399,12 +410,16 @@ export class BabyMenuAgentRuntime {
 
   async save(message?: string) {
     if (!this.activeSession) return { ok: false, reason: "No active agent change session" };
-    return this.activeSession.save(message);
+    const result = await this.activeSession.save(message);
+    if (result.ok) this.activeSession = null;
+    return result;
   }
 
   async rollback() {
     if (!this.activeSession) return { ok: false, reason: "No active agent change session" };
-    return this.activeSession.rollback();
+    const result = await this.activeSession.rollback();
+    if (result.ok) this.activeSession = null;
+    return result;
   }
 
   async close() {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -168,6 +168,7 @@ export async function startBabyMenuApp(): Promise<void> {
     return {
       openAtLogin: current.openAtLogin,
       agentName: agentRuntime.currentAgent,
+      agentSwitchDisabledReason: agentRuntime.agentSwitchDisabledReason,
       agents: toAgentOptions(agentCatalog, commandExists),
     };
   }
@@ -179,8 +180,8 @@ export async function startBabyMenuApp(): Promise<void> {
       return buildSettings();
     },
     async setAgent(agentName: string) {
-      await preferences.setAgent(agentName);
       await agentRuntime.setAgent(agentName);
+      await preferences.setAgent(agentName);
       return buildSettings();
     },
   };

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -1,8 +1,15 @@
 import { app, BrowserWindow, screen, type Rectangle } from "electron";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { BabyMenuSettings } from "../shared/contracts";
 import { getRepoRoot } from "../shared/paths";
-import { BabyMenuAgentRuntime } from "./agent-runtime";
+import {
+  agentRegistryOverrides,
+  loadAgentConfigFile,
+  resolveAgentCatalog,
+  toAgentOptions,
+} from "./agent-catalog";
+import { BabyMenuAgentRuntime, commandExists } from "./agent-runtime";
 import { resolveBabyMenuRuntimePaths } from "./app-paths";
 import { seedExtensionWorkspace } from "./extension-seeder";
 import { registerIpcHandlers } from "./ipc";
@@ -137,9 +144,15 @@ export async function startBabyMenuApp(): Promise<void> {
     defaultOpenAtLogin: paths.isPackaged,
     allowOpenAtLogin: paths.isPackaged,
   });
-  await preferences.apply();
+  const persistedPreferences = await preferences.apply();
+
+  const agentConfig = await loadAgentConfigFile(join(paths.appDataRoot, "agents.json"));
+  const agentCatalog = resolveAgentCatalog({ config: agentConfig });
+  const registryOverrides = agentRegistryOverrides(agentCatalog);
 
   const agentRuntime = new BabyMenuAgentRuntime(paths.appDataRoot, {
+    agentName: persistedPreferences.agentName,
+    registryOverrides: Object.keys(registryOverrides).length > 0 ? registryOverrides : undefined,
     paths: {
       extensionsDir: paths.extensionsDir,
       agentStateDir: paths.agentStateDir,
@@ -149,6 +162,29 @@ export async function startBabyMenuApp(): Promise<void> {
   });
   const database = createExtensionDatabase(paths.databasePath);
   const notify = createNotifier();
+
+  async function buildSettings(): Promise<BabyMenuSettings> {
+    const current = await preferences.get();
+    return {
+      openAtLogin: current.openAtLogin,
+      agentName: agentRuntime.currentAgent,
+      agents: toAgentOptions(agentCatalog, commandExists),
+    };
+  }
+
+  const settingsController = {
+    get: buildSettings,
+    async setOpenAtLogin(openAtLogin: boolean) {
+      await preferences.setOpenAtLogin(openAtLogin);
+      return buildSettings();
+    },
+    async setAgent(agentName: string) {
+      await preferences.setAgent(agentName);
+      await agentRuntime.setAgent(agentName);
+      return buildSettings();
+    },
+  };
+
   const serverActions = createServerActionRegistry({
     rootDir: paths.appDataRoot,
     actionRoots: [paths.extensionsDir],
@@ -169,7 +205,7 @@ export async function startBabyMenuApp(): Promise<void> {
     serverActions,
     widgetModules,
     { setContentHeight: setPopoverContentHeight, getVisibility: () => ({ visible: popoverWindow?.isVisible() ?? false }) },
-    preferences,
+    settingsController,
     undefined,
     { recipesDir: paths.recipesDir, database },
   );

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -27,6 +27,7 @@ type PopoverController = {
 type SettingsController = {
   get: () => Promise<BabyMenuSettings> | BabyMenuSettings;
   setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuSettings> | BabyMenuSettings;
+  setAgent: (agentName: string) => Promise<BabyMenuSettings> | BabyMenuSettings;
 };
 
 type AppController = {
@@ -45,8 +46,9 @@ export function registerIpcHandlers(
   widgetModules: WidgetModuleRegistry = createWidgetModuleRegistry(rootDir),
   popover: PopoverController = { setContentHeight: () => undefined, getVisibility: () => ({ visible: false }) },
   settings: SettingsController = {
-    get: () => ({ openAtLogin: false }),
-    setOpenAtLogin: (openAtLogin) => ({ openAtLogin }),
+    get: () => ({ openAtLogin: false, agentName: "", agents: [] }),
+    setOpenAtLogin: (openAtLogin) => ({ openAtLogin, agentName: "", agents: [] }),
+    setAgent: (agentName) => ({ openAtLogin: false, agentName, agents: [] }),
   },
   appController: AppController = { quit: () => electronApp.quit() },
   runtimeOptions: IpcRuntimeOptions = {},
@@ -115,6 +117,10 @@ export function registerIpcHandlers(
 
   ipcMain.handle("baby-menu:settings:set-open-at-login", async (_event, openAtLogin: boolean) => {
     return settings.setOpenAtLogin(openAtLogin);
+  });
+
+  ipcMain.handle("baby-menu:settings:set-agent", async (_event, agentName: string) => {
+    return settings.setAgent(agentName);
   });
 
   ipcMain.handle("baby-menu:app:quit", async () => {

--- a/src/main/preferences.ts
+++ b/src/main/preferences.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 
 export type BabyMenuPreferences = {
   openAtLogin: boolean;
+  /** Persisted embedded-agent choice; absent until the user picks one. */
+  agentName?: string;
 };
 
 type LoginItemApp = {
@@ -12,6 +14,7 @@ type LoginItemApp = {
 export type PreferencesService = {
   get: () => Promise<BabyMenuPreferences>;
   setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuPreferences>;
+  setAgent: (agentName: string) => Promise<BabyMenuPreferences>;
   apply: () => Promise<BabyMenuPreferences>;
 };
 
@@ -31,7 +34,11 @@ export function createPreferencesService({
   const filePath = join(userDataDir, "preferences.json");
 
   function normalizePreferences(preferences: BabyMenuPreferences): BabyMenuPreferences {
-    return { openAtLogin: allowOpenAtLogin && preferences.openAtLogin };
+    const agentName = preferences.agentName?.trim();
+    return {
+      openAtLogin: allowOpenAtLogin && preferences.openAtLogin,
+      ...(agentName ? { agentName } : {}),
+    };
   }
 
   function applyLoginItemSettings(preferences: BabyMenuPreferences): void {
@@ -42,7 +49,7 @@ export function createPreferencesService({
   async function readPreferences(): Promise<BabyMenuPreferences> {
     try {
       const parsed = JSON.parse(await readFile(filePath, "utf8")) as Partial<BabyMenuPreferences>;
-      return normalizePreferences({ openAtLogin: parsed.openAtLogin ?? defaultOpenAtLogin });
+      return normalizePreferences({ openAtLogin: parsed.openAtLogin ?? defaultOpenAtLogin, agentName: parsed.agentName });
     } catch {
       return normalizePreferences({ openAtLogin: defaultOpenAtLogin });
     }
@@ -57,9 +64,14 @@ export function createPreferencesService({
   return {
     get: readPreferences,
     async setOpenAtLogin(openAtLogin) {
-      const preferences = await writePreferences(normalizePreferences({ openAtLogin }));
+      const current = await readPreferences();
+      const preferences = await writePreferences(normalizePreferences({ ...current, openAtLogin }));
       applyLoginItemSettings(preferences);
       return preferences;
+    },
+    async setAgent(agentName) {
+      const current = await readPreferences();
+      return writePreferences(normalizePreferences({ ...current, agentName }));
     },
     async apply() {
       const preferences = await readPreferences();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -56,6 +56,7 @@ const api: BabyMenuApi = {
   settings: {
     get: () => ipcRenderer.invoke("baby-menu:settings:get"),
     setOpenAtLogin: (openAtLogin: boolean) => ipcRenderer.invoke("baby-menu:settings:set-open-at-login", openAtLogin),
+    setAgent: (agentName: string) => ipcRenderer.invoke("baby-menu:settings:set-agent", agentName),
   },
   app: {
     quit: () => ipcRenderer.invoke("baby-menu:app:quit"),

--- a/src/renderer/settings/SettingsView.tsx
+++ b/src/renderer/settings/SettingsView.tsx
@@ -1,13 +1,30 @@
 import { useEffect, useState } from "react";
-import { Switch } from "../../ui";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  StatusDot,
+  Switch,
+  cn,
+} from "../../ui";
+import type { BabyMenuAgentOption } from "../../shared/contracts";
 
 export function SettingsView() {
   const [openAtLogin, setOpenAtLogin] = useState(false);
+  const [agents, setAgents] = useState<BabyMenuAgentOption[]>([]);
+  const [agentName, setAgentName] = useState("");
+  const [pendingAgent, setPendingAgent] = useState<BabyMenuAgentOption | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void window.babyMenu?.settings?.get().then((settings) => {
-      if (!cancelled) setOpenAtLogin(settings.openAtLogin);
+      if (cancelled) return;
+      setOpenAtLogin(settings.openAtLogin);
+      setAgents(settings.agents);
+      setAgentName(settings.agentName);
     });
     return () => {
       cancelled = true;
@@ -20,16 +37,74 @@ export function SettingsView() {
     setOpenAtLogin(result.openAtLogin);
   }
 
+  async function confirmSwitch() {
+    if (!window.babyMenu?.settings || !pendingAgent) return;
+    const result = await window.babyMenu.settings.setAgent(pendingAgent.name);
+    setAgentName(result.agentName);
+    setAgents(result.agents);
+    setPendingAgent(null);
+  }
+
   return (
-    <div className="flex flex-col gap-3">
-      <span className="text-xxs uppercase tracking-caps text-ink-label">preferences</span>
-      <div className="flex items-center justify-between gap-4">
-        <span className="flex flex-col gap-0.5">
-          <span className="text-sm text-ink">launch at system start</span>
-          <span className="text-xs text-ink-soft">Automatically start baby menu along with your system</span>
-        </span>
-        <Switch checked={openAtLogin} onCheckedChange={(next) => void toggle(next)} aria-label="launch at system start" />
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-3">
+        <span className="text-xxs uppercase tracking-caps text-ink-label">preferences</span>
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex flex-col gap-0.5">
+            <span className="text-sm text-ink">launch at system start</span>
+            <span className="text-xs text-ink-soft">Automatically start baby menu along with your system</span>
+          </span>
+          <Switch checked={openAtLogin} onCheckedChange={(next) => void toggle(next)} aria-label="launch at system start" />
+        </div>
       </div>
+
+      <div className="flex flex-col gap-2" role="radiogroup" aria-label="agent">
+        <span className="text-xxs uppercase tracking-caps text-ink-label">agent</span>
+        {agents.map((agent) => {
+          const active = agent.name === agentName;
+          return (
+            <button
+              key={agent.name}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              disabled={!agent.available || active}
+              onClick={() => setPendingAgent(agent)}
+              className={cn(
+                "flex items-center justify-between gap-3 rounded-sm border px-3 py-2 text-left outline-none transition-colors",
+                active ? "border-signal-live bg-elevated" : "border-line hover:bg-pressed",
+                !agent.available && "cursor-not-allowed opacity-50 hover:bg-transparent",
+              )}
+            >
+              <span className="flex flex-col gap-0.5">
+                <span className="text-sm text-ink">{agent.label}</span>
+                {!agent.available && agent.installHint ? (
+                  <span className="text-xs text-ink-soft">{agent.installHint}</span>
+                ) : null}
+              </span>
+              {active ? <StatusDot tone="live" /> : null}
+            </button>
+          );
+        })}
+      </div>
+
+      <Dialog open={pendingAgent !== null} onOpenChange={(open) => !open && setPendingAgent(null)}>
+        <DialogContent className="max-w-sm">
+          <DialogTitle>switch agent?</DialogTitle>
+          <DialogDescription>
+            Switching to {pendingAgent?.label} will reset the current conversation. The new agent starts fresh with no
+            memory of this chat.
+          </DialogDescription>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setPendingAgent(null)}>
+              cancel
+            </Button>
+            <Button variant="primary" onClick={() => void confirmSwitch()}>
+              switch and reset
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/renderer/settings/SettingsView.tsx
+++ b/src/renderer/settings/SettingsView.tsx
@@ -16,6 +16,7 @@ export function SettingsView() {
   const [openAtLogin, setOpenAtLogin] = useState(false);
   const [agents, setAgents] = useState<BabyMenuAgentOption[]>([]);
   const [agentName, setAgentName] = useState("");
+  const [agentSwitchDisabledReason, setAgentSwitchDisabledReason] = useState<string | undefined>();
   const [pendingAgent, setPendingAgent] = useState<BabyMenuAgentOption | null>(null);
 
   useEffect(() => {
@@ -25,6 +26,7 @@ export function SettingsView() {
       setOpenAtLogin(settings.openAtLogin);
       setAgents(settings.agents);
       setAgentName(settings.agentName);
+      setAgentSwitchDisabledReason(settings.agentSwitchDisabledReason);
     });
     return () => {
       cancelled = true;
@@ -42,6 +44,7 @@ export function SettingsView() {
     const result = await window.babyMenu.settings.setAgent(pendingAgent.name);
     setAgentName(result.agentName);
     setAgents(result.agents);
+    setAgentSwitchDisabledReason(result.agentSwitchDisabledReason);
     setPendingAgent(null);
   }
 
@@ -62,13 +65,14 @@ export function SettingsView() {
         <span className="text-xxs uppercase tracking-caps text-ink-label">agent</span>
         {agents.map((agent) => {
           const active = agent.name === agentName;
+          const switchBlocked = Boolean(agentSwitchDisabledReason && !active);
           return (
             <button
               key={agent.name}
               type="button"
               role="radio"
               aria-checked={active}
-              disabled={!agent.available || active}
+              disabled={!agent.available || active || switchBlocked}
               onClick={() => setPendingAgent(agent)}
               className={cn(
                 "flex items-center justify-between gap-3 rounded-sm border px-3 py-2 text-left outline-none transition-colors",
@@ -81,6 +85,7 @@ export function SettingsView() {
                 {!agent.available && agent.installHint ? (
                   <span className="text-xs text-ink-soft">{agent.installHint}</span>
                 ) : null}
+                {agent.available && switchBlocked ? <span className="text-xs text-ink-soft">{agentSwitchDisabledReason}</span> : null}
               </span>
               {active ? <StatusDot tone="live" /> : null}
             </button>

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -48,6 +48,7 @@ export type BabyMenuSettings = {
   openAtLogin: boolean;
   /** Name of the active embedded agent. */
   agentName: string;
+  agentSwitchDisabledReason?: string;
   /** Selectable agents; unavailable ones are shown disabled with an install hint. */
   agents: BabyMenuAgentOption[];
 };

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -48,6 +48,7 @@ export type BabyMenuSettings = {
   openAtLogin: boolean;
   /** Name of the active embedded agent. */
   agentName: string;
+  /** Present when the current runtime state prevents switching agents. */
   agentSwitchDisabledReason?: string;
   /** Selectable agents; unavailable ones are shown disabled with an install hint. */
   agents: BabyMenuAgentOption[];
@@ -184,6 +185,7 @@ export type BabyMenuApi = {
   settings: {
     get: () => Promise<BabyMenuSettings>;
     setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuSettings>;
+    /** Switches the embedded agent; callers should confirm because this resets the current conversation. */
     setAgent: (agentName: string) => Promise<BabyMenuSettings>;
   };
   app: {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -37,8 +37,19 @@ export type AgentRuntimeStatus = {
   eventType: "text_delta";
 };
 
+export type BabyMenuAgentOption = {
+  name: string;
+  label: string;
+  available: boolean;
+  installHint?: string;
+};
+
 export type BabyMenuSettings = {
   openAtLogin: boolean;
+  /** Name of the active embedded agent. */
+  agentName: string;
+  /** Selectable agents; unavailable ones are shown disabled with an install hint. */
+  agents: BabyMenuAgentOption[];
 };
 
 // SQL bind parameters: positional (an array) or named (an object keyed by the
@@ -172,6 +183,7 @@ export type BabyMenuApi = {
   settings: {
     get: () => Promise<BabyMenuSettings>;
     setOpenAtLogin: (openAtLogin: boolean) => Promise<BabyMenuSettings>;
+    setAgent: (agentName: string) => Promise<BabyMenuSettings>;
   };
   app: {
     /** Fully quits the Electron app from the popover shell. */

--- a/tests/agent-catalog.test.ts
+++ b/tests/agent-catalog.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_AGENTS,
+  agentRegistryOverrides,
+  loadAgentConfigFile,
+  resolveAgentCatalog,
+  toAgentOptions,
+} from "../src/main/agent-catalog";
+
+function available(commands: string[]) {
+  const commandSet = new Set(commands);
+  return (command: string) => commandSet.has(command);
+}
+
+describe("agent catalog", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("returns the built-in agents when no config is provided", () => {
+    expect(resolveAgentCatalog().map((agent) => agent.name)).toEqual(
+      DEFAULT_AGENTS.map((agent) => agent.name),
+    );
+  });
+
+  it("overrides a built-in agent by name while keeping order", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ name: "claude", label: "My Claude", command: "claude-custom" }],
+    });
+
+    expect(catalog.map((agent) => agent.name)).toEqual(DEFAULT_AGENTS.map((agent) => agent.name));
+    const claude = catalog.find((agent) => agent.name === "claude");
+    expect(claude).toMatchObject({ label: "My Claude", command: "claude-custom" });
+  });
+
+  it("appends new agents from config after the built-ins", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ name: "gemini", label: "Gemini", command: "gemini" }],
+    });
+
+    expect(catalog.map((agent) => agent.name)).toEqual([
+      ...DEFAULT_AGENTS.map((agent) => agent.name),
+      "gemini",
+    ]);
+  });
+
+  it("ignores malformed config entries", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ label: "no name" }, 42, null, { name: "ok", label: "Ok", command: "ok" }],
+    });
+
+    expect(catalog.map((agent) => agent.name)).toEqual([
+      ...DEFAULT_AGENTS.map((agent) => agent.name),
+      "ok",
+    ]);
+  });
+
+  it("builds registry overrides only for agents with a launch command", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ name: "mock", label: "Mock", command: "mock", launchCommand: "node ./mock.js" }],
+    });
+
+    expect(agentRegistryOverrides(catalog)).toEqual({ mock: "node ./mock.js" });
+  });
+
+  it("marks agents available when their command is on PATH", () => {
+    const options = toAgentOptions(resolveAgentCatalog(), available(["claude"]));
+    const byName = Object.fromEntries(options.map((option) => [option.name, option.available]));
+
+    expect(byName.claude).toBe(true);
+    expect(byName.codex).toBe(false);
+  });
+
+  it("treats agents with an explicit launch command as available", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ name: "mock", label: "Mock", command: "definitely-missing", launchCommand: "node ./mock.js" }],
+    });
+    const options = toAgentOptions(catalog, available([]));
+
+    expect(options.find((option) => option.name === "mock")?.available).toBe(true);
+  });
+
+  it("exposes the install hint on options", () => {
+    const catalog = resolveAgentCatalog({
+      config: [{ name: "gemini", label: "Gemini", command: "gemini", installHint: "brew install gemini" }],
+    });
+    const options = toAgentOptions(catalog, available([]));
+
+    expect(options.find((option) => option.name === "gemini")?.installHint).toBe("brew install gemini");
+  });
+
+  it("reads agents.json from disk and returns undefined when missing or invalid", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "baby-menu-agents-"));
+    tempDirs.push(dir);
+
+    await expect(loadAgentConfigFile(join(dir, "agents.json"))).resolves.toBeUndefined();
+
+    await writeFile(join(dir, "agents.json"), "{ not json");
+    await expect(loadAgentConfigFile(join(dir, "agents.json"))).resolves.toBeUndefined();
+
+    await writeFile(join(dir, "agents.json"), JSON.stringify([{ name: "gemini", label: "Gemini", command: "gemini" }]));
+    const config = await loadAgentConfigFile(join(dir, "agents.json"));
+    expect(resolveAgentCatalog({ config }).some((agent) => agent.name === "gemini")).toBe(true);
+  });
+});

--- a/tests/agent-chat.test.tsx
+++ b/tests/agent-chat.test.tsx
@@ -44,8 +44,9 @@ function installBabyMenuAgentMock() {
       onVisibility: vi.fn(() => () => undefined),
     },
     settings: {
-      get: vi.fn(async () => ({ openAtLogin: false })),
-      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+      get: vi.fn(async () => ({ openAtLogin: false, agentName: "claude", agents: [] })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin, agentName: "claude", agents: [] })),
+      setAgent: vi.fn(async (agentName: string) => ({ openAtLogin: false, agentName, agents: [] })),
     },
     app: {
       quit: vi.fn(async () => ({ ok: true })),

--- a/tests/agent-runtime.test.ts
+++ b/tests/agent-runtime.test.ts
@@ -300,3 +300,59 @@ describe("agent runtime defaults", () => {
     expect(runtimeInternals.collectTurnOutput).toHaveBeenCalledOnce();
   });
 });
+
+describe("agent runtime switching", () => {
+  function buildRuntime() {
+    const runtime = new BabyMenuAgentRuntime("/repo", { agentName: "claude" });
+    const internals = runtime as unknown as {
+      runtime: { close: ReturnType<typeof vi.fn> } | null;
+      handle: object | null;
+      activeSession: object | null;
+    };
+    return { runtime, internals };
+  }
+
+  it("reports the configured agent as the current agent", () => {
+    const { runtime } = buildRuntime();
+    expect(runtime.currentAgent).toBe("claude");
+  });
+
+  it("ignores a switch to the same or empty agent", async () => {
+    const { runtime, internals } = buildRuntime();
+    const close = vi.fn(async () => undefined);
+    internals.runtime = { close };
+    internals.handle = {};
+
+    await runtime.setAgent("claude");
+    await runtime.setAgent("   ");
+
+    expect(close).not.toHaveBeenCalled();
+    expect(runtime.currentAgent).toBe("claude");
+  });
+
+  it("switches agent and resets the live session with discarded state", async () => {
+    const { runtime, internals } = buildRuntime();
+    const close = vi.fn(async () => undefined);
+    internals.runtime = { close };
+    internals.handle = { sessionKey: "baby-menu-agent-chat" };
+    internals.activeSession = { startedClean: true };
+
+    await runtime.setAgent("codex");
+
+    expect(close).toHaveBeenCalledWith({
+      handle: { sessionKey: "baby-menu-agent-chat" },
+      reason: "agent-switch",
+      discardPersistentState: true,
+    });
+    expect(runtime.currentAgent).toBe("codex");
+    expect(internals.runtime).toBeNull();
+    expect(internals.handle).toBeNull();
+    expect(internals.activeSession).toBeNull();
+  });
+
+  it("switches agent even when no runtime is active yet", async () => {
+    const { runtime } = buildRuntime();
+    await runtime.setAgent("codex");
+    expect(runtime.currentAgent).toBe("codex");
+  });
+});

--- a/tests/e2e-acp-runtime.test.ts
+++ b/tests/e2e-acp-runtime.test.ts
@@ -156,6 +156,60 @@ describe("BabyMenuAgentRuntime ACP e2e", () => {
   );
 
   it.skipIf(process.platform === "win32")(
+    "blocks agent switching while generated changes are pending review",
+    async () => {
+      const repo = await createRepo();
+      tempDirs.push(repo);
+      const logDir = await mkdtemp(join(tmpdir(), "baby-menu-acp-logs-"));
+      tempDirs.push(logDir);
+      const mockLogPath = join(logDir, "mock-acp.jsonl");
+
+      const runtime = new BabyMenuAgentRuntime(repo, {
+        agentName: "mock-target",
+        registryOverrides: {
+          "mock-target": buildMockCommand(mockLogPath),
+          "next-agent": buildMockCommand(mockLogPath),
+        },
+      });
+
+      await runtime.send("Add a line before switching");
+
+      await expect(runtime.setAgent("next-agent")).rejects.toThrow("Save or Rollback the current agent changes before switching agents.");
+      expect(runtime.currentAgent).toBe("mock-target");
+      expect(await runtime.rollback()).toMatchObject({ ok: true });
+      expect(await readFile(join(repo, "README.md"), "utf8")).toBe("# fixture\n");
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "blocks agent switching while a turn is running",
+    async () => {
+      const repo = await createRepo();
+      tempDirs.push(repo);
+      const logDir = await mkdtemp(join(tmpdir(), "baby-menu-acp-logs-"));
+      tempDirs.push(logDir);
+      const mockLogPath = join(logDir, "mock-acp.jsonl");
+
+      const runtime = new BabyMenuAgentRuntime(repo, {
+        agentName: "mock-target",
+        registryOverrides: {
+          "mock-target": buildSlowMockCommand(mockLogPath),
+          "next-agent": buildMockCommand(mockLogPath),
+        },
+      });
+
+      const turn = runtime.send("Keep the agent busy");
+
+      await expect(runtime.setAgent("next-agent")).rejects.toThrow("Agent is running. Wait for it to finish before switching agents.");
+      expect(runtime.currentAgent).toBe("mock-target");
+      await turn;
+      expect(await runtime.rollback()).toMatchObject({ ok: true });
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
     "blocks ACP startup when the repo is dirty so rollback remains safe",
     async () => {
       const repo = await createRepo();

--- a/tests/ipc-capabilities.test.ts
+++ b/tests/ipc-capabilities.test.ts
@@ -204,14 +204,17 @@ describe("capabilities IPC", () => {
       rollback: vi.fn(),
     };
     const settings = {
-      get: vi.fn(async () => ({ openAtLogin: false })),
-      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+      get: vi.fn(async () => ({ openAtLogin: false, agentName: "claude", agents: [] })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin, agentName: "claude", agents: [] })),
+      setAgent: vi.fn(async (agentName: string) => ({ openAtLogin: false, agentName, agents: [] })),
     };
 
     registerIpcHandlers("/repo", agentRuntime, undefined, undefined, undefined, settings);
 
-    await expect(handlers.get("baby-menu:settings:get")?.({})).resolves.toEqual({ openAtLogin: false });
-    await expect(handlers.get("baby-menu:settings:set-open-at-login")?.({}, true)).resolves.toEqual({ openAtLogin: true });
+    await expect(handlers.get("baby-menu:settings:get")?.({})).resolves.toEqual({ openAtLogin: false, agentName: "claude", agents: [] });
+    await expect(handlers.get("baby-menu:settings:set-open-at-login")?.({}, true)).resolves.toEqual({ openAtLogin: true, agentName: "claude", agents: [] });
     expect(settings.setOpenAtLogin).toHaveBeenCalledWith(true);
+    await expect(handlers.get("baby-menu:settings:set-agent")?.({}, "codex")).resolves.toEqual({ openAtLogin: false, agentName: "codex", agents: [] });
+    expect(settings.setAgent).toHaveBeenCalledWith("codex");
   });
 });

--- a/tests/preferences.test.ts
+++ b/tests/preferences.test.ts
@@ -73,4 +73,22 @@ describe("preferences service", () => {
     expect(appFacade.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
     await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"openAtLogin": false');
   });
+
+  it("has no agent preference until the user picks one", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const service = createPreferencesService({ userDataDir, app: { setLoginItemSettings: vi.fn() } });
+
+    await expect(service.get()).resolves.not.toHaveProperty("agentName");
+  });
+
+  it("persists the chosen agent without disturbing the login preference", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "baby-menu-prefs-"));
+    tempDirs.push(userDataDir);
+    const service = createPreferencesService({ userDataDir, app: { setLoginItemSettings: vi.fn() }, defaultOpenAtLogin: false });
+
+    await expect(service.setAgent("codex")).resolves.toEqual({ openAtLogin: false, agentName: "codex" });
+    await expect(service.get()).resolves.toEqual({ openAtLogin: false, agentName: "codex" });
+    await expect(readFile(join(userDataDir, "preferences.json"), "utf8")).resolves.toContain('"agentName": "codex"');
+  });
 });

--- a/tests/renderer-monochrome-lab.test.tsx
+++ b/tests/renderer-monochrome-lab.test.tsx
@@ -46,8 +46,9 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
       onVisibility: vi.fn(() => () => undefined),
     },
     settings: {
-      get: vi.fn(async () => ({ openAtLogin: false })),
-      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+      get: vi.fn(async () => ({ openAtLogin: false, agentName: "claude", agents: [] })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin, agentName: "claude", agents: [] })),
+      setAgent: vi.fn(async (agentName: string) => ({ openAtLogin: false, agentName, agents: [] })),
     },
     app: {
       quit: vi.fn(async () => ({ ok: true })),

--- a/tests/renderer-widget-host.test.tsx
+++ b/tests/renderer-widget-host.test.tsx
@@ -34,8 +34,9 @@ function installBabyMenuApi(widgets: BabyMenuApi["widgets"]) {
       onVisibility: vi.fn(() => () => undefined),
     },
     settings: {
-      get: vi.fn(async () => ({ openAtLogin: false })),
-      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+      get: vi.fn(async () => ({ openAtLogin: false, agentName: "claude", agents: [] })),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin, agentName: "claude", agents: [] })),
+      setAgent: vi.fn(async (agentName: string) => ({ openAtLogin: false, agentName, agents: [] })),
     },
     app: {
       quit: vi.fn(async () => ({ ok: true })),

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -133,4 +133,25 @@ describe("settings view", () => {
     await waitFor(() => expect(screen.queryByText(/will reset/i)).toBeNull());
     expect(api.settings.setAgent).not.toHaveBeenCalled();
   });
+
+  it("disables agent switching with a visible reason when switching is blocked", async () => {
+    const api = installBabyMenuApi({
+      agentName: "claude",
+      agentSwitchDisabledReason: "Save or Rollback the current agent changes before switching agents.",
+      agents: [
+        { name: "claude", label: "Claude Code", available: true },
+        { name: "codex", label: "Codex", available: true },
+      ],
+    });
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: "open settings" }));
+
+    const codex = await screen.findByRole("radio", { name: /Codex/ });
+
+    expect((codex as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("Save or Rollback the current agent changes before switching agents.")).toBeTruthy();
+    fireEvent.click(codex);
+    expect(screen.queryByText(/will reset the current conversation/i)).toBeNull();
+    expect(api.settings.setAgent).not.toHaveBeenCalled();
+  });
 });

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -2,9 +2,16 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "../src/renderer/App";
-import type { BabyMenuApi } from "../src/shared/contracts";
+import type { BabyMenuApi, BabyMenuSettings } from "../src/shared/contracts";
 
-function installBabyMenuApi(): BabyMenuApi {
+function installBabyMenuApi(settings?: Partial<BabyMenuSettings>): BabyMenuApi {
+  const base: BabyMenuSettings = {
+    openAtLogin: false,
+    agentName: "claude",
+    agents: [{ name: "claude", label: "Claude Code", available: true }],
+    ...settings,
+  };
+  let current = base;
   const api: BabyMenuApi = {
     recipes: { list: vi.fn(async () => []) },
     git: { save: vi.fn(async () => ({ ok: true })), rollback: vi.fn(async () => ({ ok: true })) },
@@ -24,8 +31,15 @@ function installBabyMenuApi(): BabyMenuApi {
       onVisibility: vi.fn(() => () => undefined),
     },
     settings: {
-      get: vi.fn(async () => ({ openAtLogin: false })),
-      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => ({ openAtLogin })),
+      get: vi.fn(async () => current),
+      setOpenAtLogin: vi.fn(async (openAtLogin: boolean) => {
+        current = { ...current, openAtLogin };
+        return current;
+      }),
+      setAgent: vi.fn(async (agentName: string) => {
+        current = { ...current, agentName };
+        return current;
+      }),
     },
     app: { quit: vi.fn(async () => ({ ok: true })) },
   };
@@ -63,5 +77,60 @@ describe("settings view", () => {
     fireEvent.click(screen.getByRole("button", { name: "close settings" }));
     expect(await screen.findByPlaceholderText("ask the agent")).toBeTruthy();
     expect(screen.queryByText("launch at system start")).toBeNull();
+  });
+
+  it("shows unavailable agents disabled with an install hint", async () => {
+    installBabyMenuApi({
+      agentName: "claude",
+      agents: [
+        { name: "claude", label: "Claude Code", available: true },
+        { name: "codex", label: "Codex", available: false, installHint: "Install the Codex CLI." },
+      ],
+    });
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: "open settings" }));
+
+    const codex = await screen.findByRole("radio", { name: /Codex/ });
+    expect((codex as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText("Install the Codex CLI.")).toBeTruthy();
+  });
+
+  it("confirms before switching agents and calls setAgent on confirm", async () => {
+    const api = installBabyMenuApi({
+      agentName: "claude",
+      agents: [
+        { name: "claude", label: "Claude Code", available: true },
+        { name: "codex", label: "Codex", available: true },
+      ],
+    });
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: "open settings" }));
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Codex/ }));
+
+    // Confirmation must make the conversation-reset consequence clear.
+    expect(await screen.findByText(/will reset the current conversation/i)).toBeTruthy();
+    expect(api.settings.setAgent).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /switch and reset/i }));
+    await waitFor(() => expect(api.settings.setAgent).toHaveBeenCalledWith("codex"));
+  });
+
+  it("does not switch agents when the confirmation is cancelled", async () => {
+    const api = installBabyMenuApi({
+      agentName: "claude",
+      agents: [
+        { name: "claude", label: "Claude Code", available: true },
+        { name: "codex", label: "Codex", available: true },
+      ],
+    });
+    render(<App />);
+    fireEvent.click(screen.getByRole("button", { name: "open settings" }));
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Codex/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByText(/will reset/i)).toBeNull());
+    expect(api.settings.setAgent).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Intent

The developer wanted to understand and then implement a way for Baby Menu users to choose which agent harness the embedded agent uses when multiple harnesses are available. They wanted the selection to move beyond environment-variable and auto-detection behavior, become user-facing in Settings, persist across launches, show available and unavailable options, and support config-driven custom agents. They also accepted that switching agents should reset the current conversation with a clear confirmation, while catalog changes could require an app restart. After noticing the assistant had left a dev app running, they explicitly required it to be cleaned up.

## What Changed

- Adds an agent catalog with built-in and custom agent definitions, availability detection, persisted agent preferences, and runtime wiring for selecting the embedded agent harness.
- Adds a Settings agent chooser that shows available and unavailable agents, confirms conversation reset before switching, and blocks switching while an agent turn or unsaved change session is active.
- Updates the preload/shared contracts, IPC, README, and coverage for catalog loading, preferences, runtime switching safety, Settings UI behavior, and ACP runtime behavior.

## Risk Assessment

✅ Low: The changes are well-bounded across agent selection, settings IPC, and runtime switching, and the previously identified unsafe-switching path is guarded by runtime checks and visible UI state.

## Testing

Targeted catalog, preference persistence, runtime switching/session-reset, Settings UI, and ACP e2e tests passed; I also rendered the Settings flow in the browser, captured screenshots of the user-facing agent selector, reset confirmation, and switched state, then cleaned up the dev server.

- Evidence: Settings agent selector shows available, unavailable, and custom agents (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSQS8V0B5FV87SNQJBD4GS8R/settings-agent-selector.png</code>)
- Evidence: Switch confirmation warns conversation reset (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSQS8V0B5FV87SNQJBD4GS8R/switch-agent-confirmation.png</code>)
- Evidence: Custom agent selected after confirmation (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSQS8V0B5FV87SNQJBD4GS8R/agent-switched-active.png</code>)
<details>
<summary>Evidence: Dev server log for rendered evidence session</summary>

`Renderer served at http://localhost:5273/ from the current worktree for visual evidence; the process was stopped after capture.`

```text
$ node scripts/dev.mjs
vite v8.0.13 building ssr environment for development...
[2Ktransforming...✓ 111 modules transformed.
rendering chunks...
out/main/index.js  469.59 kB

✓ built in 45ms

electron main process built successfully

-----

vite v8.0.13 building ssr environment for development...
[2Ktransforming...✓ 2 modules transformed.
rendering chunks...
out/preload/index.cjs  1.52 kB

✓ built in 7ms

electron preload scripts built successfully

-----

10:39:46 AM [vite] (client) Re-optimizing dependencies because vite config has changed
dev server running for the electron renderer process at:

  ➜  Local:   http://localhost:5273/
  ➜  Network: use --host to expose

starting electron app...

[ELIFECYCLE] Command failed.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (2) ✅ across 3 runs (13m11s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/main/agent-runtime.ts:303` - Switching agents clears `activeSession` unconditionally, so if the previous agent has a pending or in-flight change session, subsequent Save/Rollback calls return &#34;No active agent change session&#34; while the repo edits remain on disk. Gate switching until the current change is kept/undone, or explicitly rollback/discard the session as part of the switch.

🔧 Fix: Block unsafe agent switching
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `process` - A Baby Menu electron-vite/Electron dev app is still running from a different worktree (01KSQSH3P3XWHH4SQMTMGR7T77). This validation did not start it, and the task scope says to operate only within the current worktree, so I did not kill it.
- `pnpm vitest run tests/agent-catalog.test.ts tests/preferences.test.ts tests/ipc-capabilities.test.ts tests/agent-runtime.test.ts tests/e2e-acp-runtime.test.ts tests/settings-view.test.tsx`
- <code>`pnpm vitest run tests/settings-evidence-temp.test.tsx` to render the Settings agent chooser, open the switch confirmation, and verify `setAgent(&#34;codex&#34;)` fires after confirmation; the temporary in-repo test was deleted afterward</code>
- <code>`pgrep -fl &#34;electron-vite|Baby Menu|Electron&#34;` to check for leftover Baby Menu dev processes</code>

🔧 Fix: Confirm tests pass without changes
1 warning still open:
- ⚠️ `process:47524` - A Baby Menu electron-vite dev server is still listening on the default renderer port 5273 from outside this validation run. I did not kill it because the validation scope says to operate only within the current worktree; I used an alternate temporary port for evidence instead.
- `pnpm vitest run tests/agent-catalog.test.ts tests/preferences.test.ts tests/ipc-capabilities.test.ts tests/settings-view.test.tsx tests/agent-runtime.test.ts tests/e2e-acp-runtime.test.ts`
- <code>`lsof -nP -iTCP:5273 -sTCP:LISTEN` to check the default renderer port before UI evidence</code>
- <code>Temporary renderer server from this worktree on `http://127.0.0.1:5275/` using Vite and the real renderer source</code>
- `chrome-devtools-axi open http://127.0.0.1:5275/`
- <code>Injected a mocked `window.babyMenu.settings` API with Claude active, Codex available, Pi unavailable with install hint, and Local Agent available</code>
- <code>Clicked Settings, captured `settings-agent-options.png`, clicked Codex, captured `settings-agent-switch-confirmation.png`, confirmed switch, captured `settings-agent-switched-codex.png`</code>
- `chrome-devtools-axi eval '() => ({ switchCalls: window.__agentSwitchCalls, checkedAgent: Array.from(document.querySelectorAll("[role=radio]")).map((el) => ({ text: el.textContent?.trim(), checked: el.getAttribute("aria-checked"), disabled: el.disabled })) })'`
- <code>`kill 81344` and `lsof -nP -iTCP:5275 -sTCP:LISTEN` to stop and verify cleanup of the temporary evidence server</code>

🔧 Fix: Confirm test suite passes
✅ Re-checked - no issues remain.
- `pnpm vitest run tests/agent-catalog.test.ts tests/preferences.test.ts tests/agent-runtime.test.ts tests/settings-view.test.tsx tests/e2e-acp-runtime.test.ts`
- <code>`BABY_MENU_KEEP_POPOVER_OPEN=1 pnpm dev` from the current worktree, then opened `http://localhost:5273/` with `chrome-devtools-axi`</code>
- <code>Injected a mock `window.babyMenu.settings` API in the browser to render Claude Code, unavailable Codex with install hint, and a custom Mock agent; opened Settings and captured `settings-agent-selector.png`</code>
- <code>Clicked the custom agent, verified the reset-confirmation dialog, and captured `switch-agent-confirmation.png`</code>
- <code>Clicked `switch and reset`, verified the custom agent became selected, and captured `agent-switched-active.png`</code>
- <code>Stopped the validation dev process and confirmed `lsof -nP -iTCP:5273 -sTCP:LISTEN` returned no listener</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
