### PR TITLE
fix(main): preserve server action module state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `preferences.ts` - stores app preferences, including the selected agent, under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
 - `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `recipe-loader.ts` - discovers and parses `recipes/*.html` from the active extension workspace.
-- `server-action-registry.ts` - dynamically loads extension server actions and background task declarations from the active extension workspace.
+- `server-action-registry.ts` - discovers extension server actions and background task declarations from the active extension workspace, caches unchanged compiled server modules, and reloads them when the entry or local helper source changes.
 - `background-task-scheduler.ts` - runs discovered extension background tasks on host-owned timers, hot-reloads changed tasks, and enforces the 60-second minimum interval.
 - `extension-database.ts` - owns the shared local SQLite database exposed to extension server actions, background tasks, and widgets through the bridge.
 - `notifier.ts` - backs `context.notify` for server actions and background tasks with native notifications.
@@ -117,11 +117,13 @@ Do not write generated extension files, the local extension database, compiled m
 
 - Recipes are HTML files in `recipes/` inside the active extension workspace. `recipe-loader.ts` discovers `*.html`, sorts them, and extracts the title from `<title>` or first `<h1>`. They are intentionally HTML so the embedded agent can read them from its cwd and use embedded interactive demos.
 - Extensions live in the active extension workspace under `<extension-id>/` and may include `widget.tsx`, `server.ts`, and local helper files.
-- Packaged widgets, settings sections, and server actions are compiled into `~/.baby-menu/cache` and loaded through custom protocols or cached modules; dev mode keeps Vite `/@fs` loading.
+- Packaged widgets, settings sections, and server actions are compiled into `~/.baby-menu/cache` and loaded through custom protocols or cached modules; dev mode keeps Vite `/@fs` loading for renderer modules.
 - Widgets conform to `BabyMenuWidget` / `RefreshableBabyMenuWidget`. The `WidgetHost` owns visible-widget refresh timing via `useViewRefresh`, using the main-process popover visibility signal - widgets should not start their own polling.
 - Settings sections conform to `BabyMenuSettingsSection`, are exported from `widget.tsx`, and own only the section body; `SettingsView` owns the frame and rediscovers sections when settings refresh or the popover reopens.
 - New widgets and capabilities should be built as self-contained extensions behind the stable `window.babyMenu` bridge.
 - Extension server actions and background tasks are discovered dynamically from the active extension workspace, so new or changed capabilities can be picked up without changing preload.
+- Server action modules keep one module instance while `server.ts` and its local imports are unchanged, so module-scope state can survive repeated `invoke` calls and background ticks.
+- That state is reset on code edits and app restarts; durable extension state belongs in the shared SQLite store, not module scope.
 - Use `viewRefreshIntervalMs` / `refreshView` for live data that only matters while the popover is visible, and use background tasks only for work that must keep running while the popover is closed.
 - Extension data that should persist locally belongs in the shared SQLite store, exposed as `context.db` server-side and `window.babyMenu.db` renderer-side; keep heavy queries out of widgets.
 - The embedded agent should be steered toward editing its active extension workspace. The Electron core in `src/main/`, `src/preload/`, and shared IPC wiring is meant to be boring infrastructure.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 - **Extension settings sections** - extensions may export `BabyMenuSettingsSection` from `widget.tsx`; the Settings page discovers those renderer-only sections through the same module pipeline as widgets and renders the host-owned frame around each body.
 - **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets and settings sections via `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
   No per-widget IPC channels.
+  Baby Menu keeps an unchanged `server.ts` module instance alive across invokes and background ticks, so module-scope values are only an ephemeral cache and reset after code edits or app restarts.
 - **Local extension storage** - extensions share a local SQLite store exposed as `context.db` in server actions and background tasks, and as `window.babyMenu.db` in widgets and settings sections.
+  Use this store for settings, history, rate baselines, and anything else that must survive reloads.
 - **Background tasks vs view refresh** - `refreshView` / `viewRefreshIntervalMs` keeps a visible widget current and pauses while the popover is hidden; `export const background` in `server.ts` runs on a host-owned timer, clamped to a 60-second minimum, for work that must continue while the popover is closed.
 - **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with internal snapshot save/rollback.
   Tracked `extensions/` remain the source templates for dev and packaged extension workspaces.

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -274,8 +274,8 @@ The `context` is `{ rootDir, db, notify }`:
 
 ### Module-scope state in server.ts is not durable
 
-The host keeps one `server.ts` module instance alive across calls, so a module-scope variable does carry its value between `invoke`s and between background ticks - a `let previous = ...` at the top of `server.ts` will hold the last run's value while the code is unchanged.
-But that instance is replaced with fresh, reset state whenever you edit the extension's code (a hot reload) and whenever the app restarts.
+The host keeps one `server.ts` module instance alive across calls, so a module-scope variable does carry its value between `invoke`s and between background ticks - a `let previous = ...` at the top of `server.ts` will hold the last run's value while `server.ts` and its local helper imports are unchanged.
+But that instance is replaced with fresh, reset state whenever you edit the extension's code, including local helper files, and whenever the app restarts.
 So module scope is fine for a cheap in-memory cache that is safe to lose, but anything that must survive a reload or restart - settings, accumulated history, a baseline you cannot recompute - has to live in `db` (see "Storage").
 When in doubt, persist to `db`: it is the only place state is guaranteed to outlive a code edit or restart.
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -272,6 +272,13 @@ The `context` is `{ rootDir, db, notify }`:
 - `db` is the shared SQL store (see "Storage").
 - `notify({ title, body })` shows a native system notification.
 
+### Module-scope state in server.ts is not durable
+
+The host keeps one `server.ts` module instance alive across calls, so a module-scope variable does carry its value between `invoke`s and between background ticks - a `let previous = ...` at the top of `server.ts` will hold the last run's value while the code is unchanged.
+But that instance is replaced with fresh, reset state whenever you edit the extension's code (a hot reload) and whenever the app restarts.
+So module scope is fine for a cheap in-memory cache that is safe to lose, but anything that must survive a reload or restart - settings, accumulated history, a baseline you cannot recompute - has to live in `db` (see "Storage").
+When in doubt, persist to `db`: it is the only place state is guaranteed to outlive a code edit or restart.
+
 ## Storage
 
 Extensions share one local SQLite database, exposed as a small SQL interface.
@@ -333,8 +340,10 @@ Choosing the right mechanism is the main performance decision:
   It runs in the main process on a single owned timer, clamped to a 60s floor; pick the slowest cadence that meets the need, since each run wakes the machine.
 - Never start your own `setInterval`, `setTimeout` loops, or recursive polling inside a widget or server action - the host owns all timing.
 - Keep both server actions and background `run` functions cheap and non-blocking.
-  An action should read and return quickly; never `await` a fixed delay to build a measurement window.
-  For rate-derived metrics such as CPU percent, store the previous reading (in a table or module scope) and diff against it on the next run, instead of opening a fresh sampling window each call.
+  An action should read and return quickly; do not `await` a fixed delay inside an action to build a measurement window.
+- For rate-derived metrics such as CPU percent, persist the previous cumulative reading in `db` and diff the new reading against it on the next view refresh or background run; the gap between refreshes is your sampling window.
+  Prefer `db` over a module-scope variable here: module state is dropped on every code edit and restart (see "Module-scope state in server.ts is not durable"), and a baseline lost mid-session makes the next reading collapse to a meaningless 0 or 100 until it warms back up.
+  Whenever there is no stored baseline yet - the first call, or just after a reset - write the baseline and report a warming-up state rather than a misleading 0 or 100.
 - Guard long work with an in-flight flag and keep stored history bounded.
 
 ## Tests

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -1,6 +1,6 @@
 import { builtinModules } from "node:module";
 import { createHash } from "node:crypto";
-import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
@@ -23,11 +23,13 @@ export type CompiledExtensionModule = {
   // Absolute paths of every source file in the compiled module graph (entry plus local
   // imports). Callers use these to detect edits cheaply via mtime/size before recompiling.
   sourceFiles: string[];
+  sourceSignature: string;
 };
 
 type SourceModule = {
   filePath: string;
   source: string;
+  signature: string;
 };
 
 type ResolvedLocalImport = {
@@ -59,6 +61,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
   const outputDir = join(options.cacheRoot, options.extensionId, hash);
   const outputPath = compiledOutputPath(outputDir, extensionDir, entryFile);
   const sourceFiles = graph.map((module) => module.filePath);
+  const sourceSignature = graph.map((module) => module.signature).join("|");
 
   if (await pathExists(outputPath)) {
     return {
@@ -67,6 +70,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
       outputPath,
       moduleUrl: pathToFileURL(outputPath).href,
       sourceFiles,
+      sourceSignature,
     };
   }
 
@@ -91,6 +95,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
     outputPath,
     moduleUrl: pathToFileURL(outputPath).href,
     sourceFiles,
+    sourceSignature,
   };
 }
 
@@ -144,8 +149,8 @@ async function collectModuleGraph(options: {
     if (modules.has(normalizedPath)) return;
     assertInsideExtension(options.extensionDir, normalizedPath, options.extensionId);
 
-    const source = await readFile(normalizedPath, "utf8");
-    modules.set(normalizedPath, { filePath: normalizedPath, source });
+    const { source, signature } = await readStableSource(normalizedPath);
+    modules.set(normalizedPath, { filePath: normalizedPath, source, signature });
 
     const dependencies = await Promise.all(
       importSpecifierMatches(source, { includeTypeOnly: false }).map(async (match) => {
@@ -161,6 +166,18 @@ async function collectModuleGraph(options: {
 
   await visit(options.entryFile);
   return [...modules.values()].sort((left, right) => left.filePath.localeCompare(right.filePath));
+}
+
+async function readStableSource(filePath: string): Promise<{ source: string; signature: string }> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const before = await stat(filePath);
+    const source = await readFile(filePath, "utf8");
+    const after = await stat(filePath);
+    if (before.size === after.size && before.mtimeMs === after.mtimeMs) {
+      return { source, signature: `${filePath}:${after.size}:${after.mtimeMs}` };
+    }
+  }
+  throw new Error(`Source changed while reading ${filePath}`);
 }
 
 async function transpileAndRewriteModule(options: {

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -20,6 +20,9 @@ export type CompiledExtensionModule = {
   outputDir: string;
   outputPath: string;
   moduleUrl: string;
+  // Absolute paths of every source file in the compiled module graph (entry plus local
+  // imports). Callers use these to detect edits cheaply via mtime/size before recompiling.
+  sourceFiles: string[];
 };
 
 type SourceModule = {
@@ -55,6 +58,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
   const hash = contentHash(graph, extensionDir, options.kind);
   const outputDir = join(options.cacheRoot, options.extensionId, hash);
   const outputPath = compiledOutputPath(outputDir, extensionDir, entryFile);
+  const sourceFiles = graph.map((module) => module.filePath);
 
   if (await pathExists(outputPath)) {
     return {
@@ -62,6 +66,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
       outputDir,
       outputPath,
       moduleUrl: pathToFileURL(outputPath).href,
+      sourceFiles,
     };
   }
 
@@ -85,6 +90,7 @@ export async function compileExtensionModule(options: CompileExtensionModuleOpti
     outputDir,
     outputPath,
     moduleUrl: pathToFileURL(outputPath).href,
+    sourceFiles,
   };
 }
 

--- a/src/main/server-action-registry.ts
+++ b/src/main/server-action-registry.ts
@@ -187,6 +187,7 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
   const compile = options.compile ?? compileExtensionModule;
   const importModule = options.importModule ?? ((moduleUrl: string) => import(moduleUrl));
   const cache = new Map<string, ServerModuleCacheEntry>();
+  const inFlight = new Map<string, Promise<ServerModuleLoad>>();
   let reloadGeneration = 0;
 
   return {
@@ -197,24 +198,19 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
         return cached.result;
       }
 
-      const inferredId = inferExtensionId(normalizedPath);
-      const compiled = await compile({
-        kind: "server",
-        extensionId: inferredId,
-        extensionDir: dirname(normalizedPath),
-        entryFile: normalizedPath,
-        cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
-      });
-      const module = (await importModule(withReloadGeneration(compiled.moduleUrl, ++reloadGeneration))) as ServerActionModule;
-      const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
-      const result: ServerModuleLoad = { extensionId, module };
+      const pending = inFlight.get(normalizedPath);
+      if (pending) return pending;
 
-      cache.set(normalizedPath, {
-        signature: await sourceSignature(compiled.sourceFiles),
-        sourceFiles: compiled.sourceFiles,
-        result,
-      });
-      return result;
+      const load = loadFreshServerModule(normalizedPath, rootDir)
+        .then((entry) => {
+          cache.set(normalizedPath, entry);
+          return entry.result;
+        })
+        .finally(() => {
+          inFlight.delete(normalizedPath);
+        });
+      inFlight.set(normalizedPath, load);
+      return load;
     },
     prune(activePaths) {
       const active = new Set([...activePaths].map((filePath) => resolve(filePath)));
@@ -223,6 +219,26 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
       }
     },
   };
+
+  async function loadFreshServerModule(normalizedPath: string, rootDir: string): Promise<ServerModuleCacheEntry> {
+    const inferredId = inferExtensionId(normalizedPath);
+    const compiled = await compile({
+      kind: "server",
+      extensionId: inferredId,
+      extensionDir: dirname(normalizedPath),
+      entryFile: normalizedPath,
+      cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
+    });
+    const module = (await importModule(withReloadGeneration(compiled.moduleUrl, ++reloadGeneration))) as ServerActionModule;
+    const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
+    const result: ServerModuleLoad = { extensionId, module };
+
+    return {
+      signature: await sourceSignature(compiled.sourceFiles),
+      sourceFiles: compiled.sourceFiles,
+      result,
+    };
+  }
 }
 
 function withReloadGeneration(moduleUrl: string, generation: number): string {

--- a/src/main/server-action-registry.ts
+++ b/src/main/server-action-registry.ts
@@ -187,6 +187,7 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
   const compile = options.compile ?? compileExtensionModule;
   const importModule = options.importModule ?? ((moduleUrl: string) => import(moduleUrl));
   const cache = new Map<string, ServerModuleCacheEntry>();
+  let reloadGeneration = 0;
 
   return {
     async load(filePath, rootDir) {
@@ -204,7 +205,7 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
         entryFile: normalizedPath,
         cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
       });
-      const module = (await importModule(compiled.moduleUrl)) as ServerActionModule;
+      const module = (await importModule(withReloadGeneration(compiled.moduleUrl, ++reloadGeneration))) as ServerActionModule;
       const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
       const result: ServerModuleLoad = { extensionId, module };
 
@@ -222,6 +223,12 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
       }
     },
   };
+}
+
+function withReloadGeneration(moduleUrl: string, generation: number): string {
+  const url = new URL(moduleUrl);
+  url.searchParams.set("babyMenuServerActionReload", String(generation));
+  return url.href;
 }
 
 // A cheap fingerprint of a module graph: the size and mtime of every source file. A real

--- a/src/main/server-action-registry.ts
+++ b/src/main/server-action-registry.ts
@@ -1,7 +1,6 @@
 import type { Dirent } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import type { BabyMenuBackgroundTask, BabyMenuCapabilityDescriptor, BabyMenuServerContext } from "../shared/contracts";
 import { createExtensionDatabase, type ExtensionDatabase } from "./extension-database";
 import { compileExtensionModule, rewriteExtensionModuleImports } from "./extension-module-compiler";
@@ -59,8 +58,8 @@ const DEFAULT_ACTION_ROOTS = ["extensions"];
 const SERVER_ACTION_FILE_PATTERN = /(^server|\.server)\.(mjs|js|ts)$/;
 
 export function createServerActionRegistry(options: CreateServerActionRegistryOptions): ServerActionRegistry {
-  let importVersion = 0;
   const actionRoots = options.actionRoots ?? DEFAULT_ACTION_ROOTS;
+  const loader = createServerModuleLoader({ cacheDir: options.cacheDir });
   // Share the host database with actions. Default to an in-memory store so a registry
   // can be exercised in isolation (e.g. tests) without a backing file.
   let database = options.db ?? null;
@@ -71,7 +70,8 @@ export function createServerActionRegistry(options: CreateServerActionRegistryOp
       await Promise.all(actionRoots.map((root) => discoverServerActionFiles(resolveActionRoot(options.rootDir, root))))
     ).flat();
 
-    const loaded = await Promise.all(files.map(async (filePath) => loadServerActionFile(filePath, options.rootDir, ++importVersion, options.cacheDir)));
+    loader.prune(files);
+    const loaded = await Promise.all(files.map((filePath) => loadServerActionFile(loader, filePath, options.rootDir)));
     return loaded.flat();
   };
 
@@ -98,8 +98,8 @@ export function createServerActionRegistry(options: CreateServerActionRegistryOp
 // same file discovery and compilation as the action registry, so background and actions
 // always come from one compiled module per file.
 export function createBackgroundTaskSource(options: CreateBackgroundTaskSourceOptions): BackgroundTaskSource {
-  let importVersion = 0;
   const actionRoots = options.actionRoots ?? DEFAULT_ACTION_ROOTS;
+  const loader = createServerModuleLoader({ cacheDir: options.cacheDir });
 
   return {
     async list() {
@@ -107,10 +107,11 @@ export function createBackgroundTaskSource(options: CreateBackgroundTaskSourceOp
         await Promise.all(actionRoots.map((root) => discoverServerActionFiles(resolveActionRoot(options.rootDir, root))))
       ).flat();
 
+      loader.prune(files);
       const loaded = await Promise.all(
         files.map(async (filePath) => {
           try {
-            return await loadBackgroundTaskFile(filePath, options.rootDir, ++importVersion, options.cacheDir);
+            return await loadBackgroundTaskFile(loader, filePath, options.rootDir);
           } catch (error) {
             (options.onError ?? defaultBackgroundTaskDiscoveryError)(inferExtensionId(filePath), error);
             return null;
@@ -149,22 +150,99 @@ async function discoverServerActionFiles(rootDir: string): Promise<string[]> {
   return files.flat().sort();
 }
 
-async function importServerModule(
-  filePath: string,
-  rootDir: string,
-  importVersion: number,
-  cacheDir?: string,
-): Promise<{ extensionId: string; module: ServerActionModule }> {
-  const importPath = await prepareServerActionModule(filePath, rootDir, cacheDir);
-  const moduleUrl = pathToFileURL(importPath);
-  moduleUrl.searchParams.set("babyMenuServerActionVersion", String(importVersion));
-  const module = (await import(moduleUrl.href)) as ServerActionModule;
-  const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferExtensionId(filePath);
-  return { extensionId, module };
+export type ServerModuleLoad = { extensionId: string; module: ServerActionModule };
+
+export type ServerModuleLoader = {
+  load: (filePath: string, rootDir: string) => Promise<ServerModuleLoad>;
+  // Drop cache entries for files that are no longer present, so deleting an extension
+  // does not leak its cached module forever.
+  prune: (activePaths: Iterable<string>) => void;
+};
+
+type CreateServerModuleLoaderOptions = {
+  cacheDir?: string;
+  // Overridable for tests so the compile/import steps can be observed.
+  compile?: typeof compileExtensionModule;
+  importModule?: (moduleUrl: string) => Promise<unknown>;
+};
+
+type ServerModuleCacheEntry = {
+  signature: string;
+  sourceFiles: string[];
+  result: ServerModuleLoad;
+};
+
+// Compiles, imports, and caches an extension server module per source file.
+//
+// The compiler is content-addressed: identical source compiles to the same module URL, and
+// edited source compiles to a new one. Importing that URL therefore reuses a single module
+// instance while the code is unchanged - module-scope state survives across calls - and
+// loads a fresh module (with reset state) only after a real edit. This is why server actions
+// must not rely on a fresh module per call, and why durable state belongs in the database.
+//
+// On top of that, an mtime/size signature over the module graph lets a repeated load skip
+// recompiling entirely while nothing on disk has changed, so a hot path like a 1-2s view
+// refresh does not re-read and re-hash every extension source on every invoke.
+export function createServerModuleLoader(options: CreateServerModuleLoaderOptions = {}): ServerModuleLoader {
+  const compile = options.compile ?? compileExtensionModule;
+  const importModule = options.importModule ?? ((moduleUrl: string) => import(moduleUrl));
+  const cache = new Map<string, ServerModuleCacheEntry>();
+
+  return {
+    async load(filePath, rootDir) {
+      const normalizedPath = resolve(filePath);
+      const cached = cache.get(normalizedPath);
+      if (cached && (await sourceSignature(cached.sourceFiles)) === cached.signature) {
+        return cached.result;
+      }
+
+      const inferredId = inferExtensionId(normalizedPath);
+      const compiled = await compile({
+        kind: "server",
+        extensionId: inferredId,
+        extensionDir: dirname(normalizedPath),
+        entryFile: normalizedPath,
+        cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
+      });
+      const module = (await importModule(compiled.moduleUrl)) as ServerActionModule;
+      const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
+      const result: ServerModuleLoad = { extensionId, module };
+
+      cache.set(normalizedPath, {
+        signature: await sourceSignature(compiled.sourceFiles),
+        sourceFiles: compiled.sourceFiles,
+        result,
+      });
+      return result;
+    },
+    prune(activePaths) {
+      const active = new Set([...activePaths].map((filePath) => resolve(filePath)));
+      for (const key of [...cache.keys()]) {
+        if (!active.has(key)) cache.delete(key);
+      }
+    },
+  };
 }
 
-async function loadServerActionFile(filePath: string, rootDir: string, importVersion: number, cacheDir?: string): Promise<LoadedServerAction[]> {
-  const { extensionId, module } = await importServerModule(filePath, rootDir, importVersion, cacheDir);
+// A cheap fingerprint of a module graph: the size and mtime of every source file. A real
+// edit always changes at least one of these, so this detects changes without reading or
+// hashing file contents on every load.
+async function sourceSignature(files: string[]): Promise<string> {
+  const parts = await Promise.all(
+    files.map(async (filePath) => {
+      try {
+        const stats = await stat(filePath);
+        return `${filePath}:${stats.size}:${stats.mtimeMs}`;
+      } catch {
+        return `${filePath}:missing`;
+      }
+    }),
+  );
+  return parts.join("|");
+}
+
+async function loadServerActionFile(loader: ServerModuleLoader, filePath: string, rootDir: string): Promise<LoadedServerAction[]> {
+  const { extensionId, module } = await loader.load(filePath, rootDir);
   const actions = normalizeActions(module.actions);
 
   return Object.entries(actions).map(([action, handler]) => ({
@@ -176,12 +254,11 @@ async function loadServerActionFile(filePath: string, rootDir: string, importVer
 }
 
 async function loadBackgroundTaskFile(
+  loader: ServerModuleLoader,
   filePath: string,
   rootDir: string,
-  importVersion: number,
-  cacheDir?: string,
 ): Promise<DiscoveredBackgroundTask | null> {
-  const { extensionId, module } = await importServerModule(filePath, rootDir, importVersion, cacheDir);
+  const { extensionId, module } = await loader.load(filePath, rootDir);
   const background = normalizeBackgroundTask(module.background);
   if (!background) return null;
 
@@ -192,19 +269,6 @@ async function loadBackgroundTaskFile(
     runOnStart: background.runOnStart ?? true,
     run: background.run,
   };
-}
-
-async function prepareServerActionModule(filePath: string, rootDir: string, cacheDir?: string): Promise<string> {
-  const normalizedPath = resolve(filePath);
-  const extensionId = inferExtensionId(normalizedPath);
-  const compiled = await compileExtensionModule({
-    kind: "server",
-    extensionId,
-    extensionDir: dirname(normalizedPath),
-    entryFile: normalizedPath,
-    cacheRoot: cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
-  });
-  return compiled.outputPath;
 }
 
 export async function rewriteLocalServerActionImports(source: string, filePath: string): Promise<string> {

--- a/src/main/server-action-registry.ts
+++ b/src/main/server-action-registry.ts
@@ -1,9 +1,9 @@
 import type { Dirent } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import type { BabyMenuBackgroundTask, BabyMenuCapabilityDescriptor, BabyMenuServerContext } from "../shared/contracts";
 import { createExtensionDatabase, type ExtensionDatabase } from "./extension-database";
-import { compileExtensionModule, rewriteExtensionModuleImports } from "./extension-module-compiler";
+import { compileExtensionModule, rewriteExtensionModuleImports, type CompiledExtensionModule } from "./extension-module-compiler";
 
 export type ServerActionContext = BabyMenuServerContext & {
   db: ExtensionDatabase;
@@ -222,22 +222,30 @@ export function createServerModuleLoader(options: CreateServerModuleLoaderOption
 
   async function loadFreshServerModule(normalizedPath: string, rootDir: string): Promise<ServerModuleCacheEntry> {
     const inferredId = inferExtensionId(normalizedPath);
-    const compiled = await compile({
-      kind: "server",
-      extensionId: inferredId,
-      extensionDir: dirname(normalizedPath),
-      entryFile: normalizedPath,
-      cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
-    });
-    const module = (await importModule(withReloadGeneration(compiled.moduleUrl, ++reloadGeneration))) as ServerActionModule;
-    const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
-    const result: ServerModuleLoad = { extensionId, module };
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const generation = ++reloadGeneration;
+      const compiled = await compile({
+        kind: "server",
+        extensionId: inferredId,
+        extensionDir: dirname(normalizedPath),
+        entryFile: normalizedPath,
+        cacheRoot: options.cacheDir ?? join(rootDir, ".cache", "baby-menu", "server-actions"),
+      });
+      await prepareServerModuleGraph(compiled, dirname(normalizedPath), generation);
+      const module = (await importModule(withReloadGeneration(compiled.moduleUrl, generation))) as ServerActionModule;
+      const signature = await sourceSignature(compiled.sourceFiles);
+      if (signature !== compiled.sourceSignature) continue;
+      const extensionId = normalizeExtensionId(module.extensionId ?? module.id) ?? inferredId;
+      const result: ServerModuleLoad = { extensionId, module };
 
-    return {
-      signature: await sourceSignature(compiled.sourceFiles),
-      sourceFiles: compiled.sourceFiles,
-      result,
-    };
+      return {
+        signature,
+        sourceFiles: compiled.sourceFiles,
+        result,
+      };
+    }
+
+    throw new Error(`Server action source changed while loading ${relative(process.cwd(), normalizedPath)}`);
   }
 }
 
@@ -245,6 +253,43 @@ function withReloadGeneration(moduleUrl: string, generation: number): string {
   const url = new URL(moduleUrl);
   url.searchParams.set("babyMenuServerActionReload", String(generation));
   return url.href;
+}
+
+async function prepareServerModuleGraph(compiled: CompiledExtensionModule, extensionDir: string, generation: number): Promise<void> {
+  await Promise.all(
+    compiled.sourceFiles.map(async (sourceFile) => {
+      const outputPath = join(compiled.outputDir, replaceExtension(relative(extensionDir, sourceFile), ".mjs"));
+      const source = await readFile(outputPath, "utf8");
+      const rewritten = rewriteCompiledLocalImports(source, generation);
+      if (rewritten !== source) await writeFile(outputPath, rewritten);
+    }),
+  );
+}
+
+const COMPILED_STATIC_IMPORT_PATTERN = /(\b(?:import|export)\b[\s\S]*?\bfrom\s*["'])([^"']+)(["'])/g;
+const COMPILED_SIDE_EFFECT_IMPORT_PATTERN = /(\bimport\s*["'])([^"']+)(["'])/g;
+
+function rewriteCompiledLocalImports(source: string, generation: number): string {
+  return source
+    .replace(COMPILED_STATIC_IMPORT_PATTERN, (_match, prefix: string, specifier: string, suffix: string) => {
+      return `${prefix}${withLocalReloadGeneration(specifier, generation)}${suffix}`;
+    })
+    .replace(COMPILED_SIDE_EFFECT_IMPORT_PATTERN, (_match, prefix: string, specifier: string, suffix: string) => {
+      return `${prefix}${withLocalReloadGeneration(specifier, generation)}${suffix}`;
+    });
+}
+
+function withLocalReloadGeneration(specifier: string, generation: number): string {
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) return specifier;
+  const [path, fragment = ""] = specifier.split("#", 2);
+  const [pathname, query = ""] = path.split("?", 2);
+  const params = new URLSearchParams(query);
+  params.set("babyMenuServerActionReload", String(generation));
+  return `${pathname}?${params.toString()}${fragment ? `#${fragment}` : ""}`;
+}
+
+function replaceExtension(filePath: string, extension: string): string {
+  return filePath.slice(0, filePath.length - extname(filePath).length) + extension;
 }
 
 // A cheap fingerprint of a module graph: the size and mtime of every source file. A real

--- a/tests/server-action-registry.test.ts
+++ b/tests/server-action-registry.test.ts
@@ -84,6 +84,26 @@ describe("server action registry", () => {
     await expect(registry.invoke("counter", "next")).resolves.toBe(101);
   });
 
+  it("loads a fresh module when changed source reverts to previously imported contents", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "counter", "server.mjs");
+    const firstSource = `let count = 0; export const actions = { next: () => ++count };`;
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, firstSource);
+    const registry = createServerActionRegistry({ rootDir });
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(2);
+
+    await writeFile(actionPath, `let count = 100; export const actions = { next: () => ++count };`);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(101);
+
+    await writeFile(actionPath, firstSource);
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+  });
+
   it("skips recompiling a server module on repeated loads while it is unchanged", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
     tempDirs.push(rootDir);

--- a/tests/server-action-registry.test.ts
+++ b/tests/server-action-registry.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createBackgroundTaskSource, createServerActionRegistry, rewriteLocalServerActionImports } from "../src/main/server-action-registry";
+import {
+  createBackgroundTaskSource,
+  createServerActionRegistry,
+  createServerModuleLoader,
+  rewriteLocalServerActionImports,
+} from "../src/main/server-action-registry";
 
 describe("server action registry", () => {
   const tempDirs: string[] = [];
@@ -48,6 +53,56 @@ describe("server action registry", () => {
     await writeFile(actionPath, `export const actions = { ping: () => "second" };`);
 
     await expect(registry.invoke("demo", "ping")).resolves.toBe("second");
+  });
+
+  it("reuses one module instance across invokes so module-scope state persists while the source is unchanged", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "counter", "server.mjs");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `let count = 0; export const actions = { next: () => ++count };`);
+    const registry = createServerActionRegistry({ rootDir });
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(2);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(3);
+  });
+
+  it("loads a fresh module with reset state after the source changes", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "counter", "server.mjs");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `let count = 0; export const actions = { next: () => ++count };`);
+    const registry = createServerActionRegistry({ rootDir });
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(2);
+
+    await writeFile(actionPath, `let count = 100; export const actions = { next: () => ++count };`);
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(101);
+  });
+
+  it("skips recompiling a server module on repeated loads while it is unchanged", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "demo", "server.ts");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `export const actions = { ping: () => "ok" };`);
+
+    const { compileExtensionModule } = await import("../src/main/extension-module-compiler");
+    const compile = vi.fn(compileExtensionModule);
+    const loader = createServerModuleLoader({ compile });
+
+    await loader.load(actionPath, rootDir);
+    await loader.load(actionPath, rootDir);
+    expect(compile).toHaveBeenCalledTimes(1);
+
+    await writeFile(actionPath, `export const actions = { ping: () => "changed" };`);
+
+    await loader.load(actionPath, rootDir);
+    expect(compile).toHaveBeenCalledTimes(2);
   });
 
   it("loads TypeScript extension server action files that agents are expected to create", async () => {

--- a/tests/server-action-registry.test.ts
+++ b/tests/server-action-registry.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createBackgroundTaskSource,
@@ -123,6 +124,31 @@ describe("server action registry", () => {
 
     await loader.load(actionPath, rootDir);
     expect(compile).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent loads of the same uncached server module", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "demo", "server.ts");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `export const actions = { ping: () => "ok" };`);
+
+    const moduleUrl = pathToFileURL(join(rootDir, "compiled", "server.mjs")).href;
+    const compile = vi.fn(async () => ({
+      hash: "hash",
+      outputDir: dirname(join(rootDir, "compiled", "server.mjs")),
+      outputPath: join(rootDir, "compiled", "server.mjs"),
+      moduleUrl,
+      sourceFiles: [actionPath],
+    }));
+    const importModule = vi.fn(async () => ({ actions: { ping: () => "ok" } }));
+    const loader = createServerModuleLoader({ compile, importModule });
+
+    const [first, second] = await Promise.all([loader.load(actionPath, rootDir), loader.load(actionPath, rootDir)]);
+
+    expect(first.module).toBe(second.module);
+    expect(compile).toHaveBeenCalledTimes(1);
+    expect(importModule).toHaveBeenCalledTimes(1);
   });
 
   it("loads TypeScript extension server action files that agents are expected to create", async () => {

--- a/tests/server-action-registry.test.ts
+++ b/tests/server-action-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -105,6 +105,28 @@ describe("server action registry", () => {
     await expect(registry.invoke("counter", "next")).resolves.toBe(1);
   });
 
+  it("loads fresh local dependency modules when changed helper source reverts to previously imported contents", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "counter", "server.ts");
+    const helperPath = join(rootDir, "extensions", "counter", "helper.ts");
+    const firstHelperSource = `let count = 0; export function next() { return ++count; }`;
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `import { next } from "./helper"; export const actions = { next };`);
+    await writeFile(helperPath, firstHelperSource);
+    const registry = createServerActionRegistry({ rootDir });
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(2);
+
+    await writeFile(helperPath, `let count = 100; export function next() { return ++count; }`);
+    await expect(registry.invoke("counter", "next")).resolves.toBe(101);
+
+    await writeFile(helperPath, firstHelperSource);
+
+    await expect(registry.invoke("counter", "next")).resolves.toBe(1);
+  });
+
   it("skips recompiling a server module on repeated loads while it is unchanged", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
     tempDirs.push(rootDir);
@@ -133,14 +155,20 @@ describe("server action registry", () => {
     await mkdir(dirname(actionPath), { recursive: true });
     await writeFile(actionPath, `export const actions = { ping: () => "ok" };`);
 
-    const moduleUrl = pathToFileURL(join(rootDir, "compiled", "server.mjs")).href;
-    const compile = vi.fn(async () => ({
-      hash: "hash",
-      outputDir: dirname(join(rootDir, "compiled", "server.mjs")),
-      outputPath: join(rootDir, "compiled", "server.mjs"),
-      moduleUrl,
-      sourceFiles: [actionPath],
-    }));
+    const outputPath = join(rootDir, "compiled", "server.mjs");
+    const moduleUrl = pathToFileURL(outputPath).href;
+    const compile = vi.fn(async () => {
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, `export const actions = { ping: () => "compiled" };`);
+      return {
+        hash: "hash",
+        outputDir: dirname(outputPath),
+        outputPath,
+        moduleUrl,
+        sourceFiles: [actionPath],
+        sourceSignature: await testSourceSignature(actionPath),
+      };
+    });
     const importModule = vi.fn(async () => ({ actions: { ping: () => "ok" } }));
     const loader = createServerModuleLoader({ compile, importModule });
 
@@ -150,6 +178,54 @@ describe("server action registry", () => {
     expect(compile).toHaveBeenCalledTimes(1);
     expect(importModule).toHaveBeenCalledTimes(1);
   });
+
+  it("does not cache a compiled server module when source changes before the cache signature is recorded", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));
+    tempDirs.push(rootDir);
+    const actionPath = join(rootDir, "extensions", "demo", "server.ts");
+    await mkdir(dirname(actionPath), { recursive: true });
+    await writeFile(actionPath, `export const actions = { ping: () => "old" };`);
+
+    let compileCount = 0;
+    const outputPath = join(rootDir, "compiled", "server.mjs");
+    const moduleUrl = pathToFileURL(outputPath).href;
+    const compile = vi.fn(async () => {
+      compileCount += 1;
+      const sourceSignature = await testSourceSignature(actionPath);
+      if (compileCount === 1) {
+        await writeFile(actionPath, `export const actions = { ping: () => "new" };`);
+      }
+      await mkdir(dirname(outputPath), { recursive: true });
+      await writeFile(outputPath, `export const actions = { ping: () => "compiled" };`);
+      return {
+        hash: `hash-${compileCount}`,
+        outputDir: dirname(outputPath),
+        outputPath,
+        moduleUrl,
+        sourceFiles: [actionPath],
+        sourceSignature,
+      };
+    });
+    const importModule = vi
+      .fn()
+      .mockResolvedValueOnce({ actions: { ping: () => "old" } })
+      .mockResolvedValueOnce({ actions: { ping: () => "new" } });
+    const loader = createServerModuleLoader({ compile, importModule });
+
+    const first = await loader.load(actionPath, rootDir);
+    const second = await loader.load(actionPath, rootDir);
+    const firstActions = first.module.actions as { ping: (input: unknown, context: { rootDir: string }) => string };
+    const secondActions = second.module.actions as { ping: (input: unknown, context: { rootDir: string }) => string };
+
+    expect(firstActions.ping(undefined, { rootDir })).toBe("new");
+    expect(secondActions.ping(undefined, { rootDir })).toBe("new");
+    expect(compile).toHaveBeenCalledTimes(2);
+  });
+
+  async function testSourceSignature(filePath: string): Promise<string> {
+    const stats = await stat(filePath);
+    return `${filePath}:${stats.size}:${stats.mtimeMs}`;
+  }
 
   it("loads TypeScript extension server action files that agents are expected to create", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-actions-"));


### PR DESCRIPTION
## Intent

{"summary":"The developer wanted to prevent future extension bugs where agents rely on incorrect assumptions about server-action module lifecycle, after observing a system-usage widget reporting CPU as only 0 or 100 percent. They first asked for stronger embedded-agent guidance rather than fixing the current dev extension, then challenged whether re-importing server modules on every invoke was the right architecture. They requested both the root fix, removing redundant per-invoke cache-busting so module-scope state persists for unchanged code, and the secondary performance fix to avoid unnecessary source rereads and rehashing on every invocation. They explicitly required updating AGENTS.md to reflect the corrected behavior and durable-state guidance."}

## What Changed

- Cache unchanged extension server action modules so module-scope state persists across repeated invokes, while still resetting module instances when the entry file or local import graph changes.
- Coalesce concurrent loads for the same server module and use graph-aware signatures/reload generations to avoid stale imports when helper files are edited or reverted.
- Document the server module cache lifecycle and durable-state guidance in the app and extension authoring docs, with expanded registry tests covering cache, reload, and concurrency behavior.

## Risk Assessment

⚠️ Medium: The change is well-scoped to server module loading, but the cache invalidation and hot-reload behavior is subtle enough that regressions would affect runtime extension actions and background tasks.

## Testing

I inspected the changed server-action loader, compiler metadata, tests, and AGENTS.md guidance; ran the targeted server-action registry suite successfully; tried several outside-root evidence harness approaches that failed due Vitest discovery/root scanning and native Node TypeScript resolution; then ran a temporary repo-local Vitest harness that produced JSON evidence showing repeated end-user-style invokes preserve module-scope state, unchanged loads skip recompilation, and a source edit resets state. No UI surface was changed, so no screenshot or rendered visual artifact was applicable.

<details>
<summary>Evidence: Server action cache behavior evidence</summary>

`invokeTranscript: first=25 warming-up, second=50 warm, third=75 warm, after edit=125 fresh-after-edit; cacheReuse.unchangedSecondLoadSkippedCompile=true`

```text
{
  "intent": "Server actions keep one module instance across invokes while source is unchanged, skip redundant recompilation, and load fresh state after source edits.",
  "capabilityList": [
    {
      "id": "system-usage.sampleCpu",
      "extensionId": "system-usage",
      "action": "sampleCpu"
    }
  ],
  "invokeTranscript": [
    {
      "step": "first invoke",
      "response": {
        "cpuPercent": 25,
        "status": "warming-up"
      }
    },
    {
      "step": "second invoke without source edit",
      "response": {
        "cpuPercent": 50,
        "status": "warm"
      }
    },
    {
      "step": "third invoke without source edit",
      "response": {
        "cpuPercent": 75,
        "status": "warm"
      }
    },
    {
      "step": "invoke after editing server.ts",
      "response": {
        "cpuPercent": 125,
        "status": "fresh-after-edit"
      }
    }
  ],
  "cacheReuse": {
    "compileCallsAfterFirstLoad": 1,
    "compileCallsAfterSecondUnchangedLoad": 1,
    "unchangedSecondLoadSkippedCompile": true
  },
  "serverSourceAfterEdit": "let previousCpu = 100;\nexport const actions = {\n  sampleCpu: () => {\n    previousCpu += 25;\n    return { cpuPercent: previousCpu, status: \"fresh-after-edit\" };\n  }\n};"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `src/main/server-action-registry.ts:207` - Using only the content-addressed compiled module URL means a module can regain an old Node import instance when code is edited back to previously seen contents, so module-scope state is not reset after that hot-reload path. For example, load server.ts with count state, edit it to different code, then revert the file text: the hash and URL return to the original value and dynamic import returns the original live module object with its old count. Add a reload generation or signature-based query only when the source graph changes, rather than cache-busting every invoke.

🔧 Fix: Fix server action reload cache busting
1 warning still open:
- ⚠️ `src/main/server-action-registry.ts:193` - Concurrent loads of the same uncached or just-edited server module can import separate module instances because the cache is populated only after compile/import completes and there is no in-flight promise coalescing. Two simultaneous `capabilities.invoke` calls after startup or hot reload can each see a different module-scope state instance, which breaks the new invariant that unchanged server code has one live module instance. Cache the pending load per normalized path so concurrent callers await the same compile/import result.

🔧 Fix: Coalesce concurrent server module loads
2 warnings still open:
- ⚠️ `src/main/server-action-registry.ts:232` - The reload-generation query is applied only to the entry module URL, so static local imports inside the compiled module keep using bare relative URLs from the content-hash cache directory. If a helper module with module-scope state is edited away and then reverted to previously imported contents, Node will reuse the old helper module instance, so hot reload still fails to reset state for local dependencies. Propagate the reload generation into rewritten local import specifiers or otherwise import the whole compiled graph under fresh URLs when the source graph changes.
- ⚠️ `src/main/server-action-registry.ts:237` - The cache signature is recorded after compile/import, so an edit that lands between the compiler reading the source graph and this `sourceSignature` call can cache an old module result with the new on-disk signature. Future loads will then treat the stale module as current and skip recompilation. Capture and validate the signature around compilation, or retry when the post-compile signature differs from the pre-compile signature.

🔧 Fix: Fix server action reload graph caching
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d`
- `git diff --name-only bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d`
- `git diff --unified=80 bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d -- src/main/server-action-registry.ts`
- `git diff --unified=80 bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d -- src/main/extension-module-compiler.ts`
- `git diff --unified=80 bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d -- tests/server-action-registry.test.ts`
- `git diff --unified=60 bb48654aa14b8e731c4a74bf53cf0dfe9014e7d6..b71dbfc0387ae3750feb0861e81628cfa767060d -- extensions/AGENTS.md`
- `pnpm vitest run tests/server-action-registry.test.ts`
- <code>`pnpm vitest run /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSR035C8TCDKEKKE15479D1M/server-action-cache-evidence.test.ts` (did not discover the outside-root temp test)</code>
- <code>`pnpm vitest run --root / var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSR035C8TCDKEKKE15479D1M/server-action-cache-evidence.test.ts` (timed out while scanning from filesystem root)</code>
- <code>`node --experimental-strip-types /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSR035C8TCDKEKKE15479D1M/server-action-cache-evidence.ts` (native Node TS attempt could not resolve project extensionless imports)</code>
- <code>`pnpm vitest run tests/server-action-cache-evidence.test.ts` using a temporary repo-local harness that wrote `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSR035C8TCDKEKKE15479D1M/server-action-cache-evidence.json` and was deleted after the run</code>
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
