### PR TITLE
fix(renderer): restore agent turn state across remounts

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -82,7 +82,7 @@ The personality is "competent log". A calm CLI tool that happens to have a face.
 - `Added a CPU temperature widget`
 - `keep it, or undo`
 - `Finish this change first`
-- `ask the agent`
+- `talk to the baby`
 - `last sync 12:04`
 - `claude · weekly`
 - `designing the widget`
@@ -100,9 +100,9 @@ The personality is "competent log". A calm CLI tool that happens to have a face.
 ### Capitalization & punctuation
 
 - Wordmark: `baby_menu` (lowercase, underscore).
-- Module / widget keys: ALL CAPS, tracked `0.18em`. `CLAUDE · WEEKLY`, `BATTERY`, `NOW PLAYING`.
+- Module / widget keys: ALL CAPS, tracked `0.18em`. `CLAUDE · WEEKLY`, `CPU`, `NOW PLAYING`.
 - Button labels: Sentence case, no period. `Keep`, `Undo`, `Dismiss`. Special-case: tiny labels like `send` stay lowercase as a typographic detail (it reads as a command, not a button).
-- Placeholders: lowercase imperative, no period, no `...` ellipsis. `ask the agent`.
+- Placeholders: lowercase imperative, no period, no `...` ellipsis. `talk to the baby`.
 - Error states: declarative, no exclamation. `Finish this change first.` `Refresh timed out.`
 - The word "agent" stays lowercase except at the start of a sentence.
 
@@ -114,13 +114,13 @@ Until assistant response text is available, the subtitle reads `Working...`.
 Do not surface tool names, usage updates, command names, or synthetic progress labels in the RunStrip subtitle.
 When assistant response text appears there, it should be plain user-facing copy:
 
-- `Built the battery widget`
+- `Built the Claude quota widget`
 - `Added the calendar widget`
 
 When the agent finishes, the SessionBar summarizes the result in one phrase, past-tense:
 
 - `Added a CPU temperature widget`
-- `Added a battery widget`
+- `Added a memory widget`
 - `Updated the now-playing widget`
 
 The user should be able to read this and immediately know whether to **Keep** it or **Undo** it without thinking about engineering at all.
@@ -183,7 +183,7 @@ The macOS popover assumes the OS provides its own under-window blur. Inside the 
 
 Motion is **snappy, short, and ease-out.**
 
-- `--motion-fast` **80ms** — hover, refresh-button color shift, dot pulse start.
+- `--motion-fast` **80ms** — hover, compact-control color shift, dot pulse start.
 - `--motion-base` **160ms** — segmented-control toggle, button press, focus ring fade.
 - `--motion-slow` **280ms** — popover entry/exit (translate + scale), RunStrip appear, progress fill changes.
 - **Caret blink**: 1100ms `steps(2, start)` — the composer caret blinks like a real terminal cursor.
@@ -196,7 +196,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 ### Interaction states
 
 - **Hover** on text-button: background fades to `--bg-elevated`, border to `--ink-600`, text to `--ink-100` over 160ms.
-- **Hover** on refresh icon or text-link affordance: color shifts to `--signal-live`.
+- **Hover** on compact icon controls or text-link affordances: color shifts to `--signal-live`.
 - **Hover** on quit: keep the button neutral at rest, then shift icon/text to `--signal-error` / `text-signal-danger` on hover without using a danger fill.
 - **Press** (`:active`): background drops to `--bg-pressed`. No translate, no shrink — keep the surface still.
 - **Focus** (keyboard): `--focus-ring` 1px solid mint + 4px mint glow. Same rule for everything.
@@ -206,7 +206,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 ### Layout rules
 
-- Width is fixed at **360px** in the live popover. Do not design responsive popover widths unless the runtime sizing code changes.
+- Width is fixed at **504px** in the live popover. Do not design responsive popover widths unless the runtime sizing code changes.
 - **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header and active agent-control surface stay pinned.
 - The **composer** is pinned to the bottom on the main menu and idle agent surface; it is hidden while the settings view is open and replaced by the RunStrip while an agent run is in flight.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
@@ -217,7 +217,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 A widget is a vertical stack inside the popover body, separated from its neighbors by a `1px dashed` divider — *not* a contained card. Top to bottom:
 
-1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left, compact Lucide `RefreshCw` icon on the right when refresh is available.
+1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left. The host does not render a generic manual refresh button.
 2. **Value row** — the big number (weight 300, 28–36px, tabular numerals, tight tracking) with the unit at small. Optional status word on the right.
 3. **Progress** — a 1px line at `--ink-800` with a `--signal-live` fill plus a 3×5px head at the tip, like a tiny scanline. Optional.
 4. **Foot row** - 11px ink-faint meta on the left (timestamp), an uppercase source tag on the right (`OAUTH`, `CLI`, etc).
@@ -231,7 +231,7 @@ Widgets do **not** have backgrounds, borders, shadows, or padding-as-containers.
 Type is the iconography. The system leans on **ASCII glyphs** and **tracked-caps words** instead of a drawn icon set.
 
 1. **ASCII first.** `›` is the prompt and the menu-affordance pointer. `+` is add. `·` is separator. `↵` and `⌘` appear in shortcut hints. `●` is a status dot. These read crisp at any size because they are real characters in the body font (JetBrains Mono).
-2. **Lucide for compact controls.** Use [Lucide](https://lucide.dev) when ASCII won't carry a meaning, including `RefreshCw` for widget refresh, `Settings` for settings, and `Power` for quitting the app. Use **14×14** in compact controls and **16×16** in roomier controls, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
+2. **Lucide for compact controls.** Use [Lucide](https://lucide.dev) when ASCII won't carry a meaning, including `Settings` for settings and `Power` for quitting the app. Use **14×14** in compact controls and **16×16** in roomier controls, color `currentColor`. Lucide is the closest visual match - slightly soft, geometric, monoline - and is bundled with the live codebase.
 3. **No emoji as UI.** No `🟢 / ✅ / ⚠️ / 🚫`. Status is the mint dot + word.
 4. **No custom hand-drawn SVG.** The tray glyph is the wordmark's `b` rendered as a template PNG by `src/main/tray.ts`.
 

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -23,12 +23,12 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 ## Hard rules
 
-1. Baby Menu is a **macOS tray popover**, 360px wide, dynamic-height. Never design for a full browser window.
+1. Baby Menu is a **macOS tray popover**, 504px wide, dynamic-height. Never design for a full browser window.
 2. **The agent's work is not a chat.** No transcript, no bubbles, no history. Use the `RunStrip` pattern: one live affordance (pulsing mint dot + current step + timer), replaced by a `SessionBar` when done.
 3. **No build-mode toggle.** On the main idle surface, the composer is one slim row pinned to the bottom of the popover. It auto-grows to a second line when the user types more. During an active agent run, `RunStrip` replaces the composer; the settings view also replaces it while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.
 5. **No emoji as UI.** No gradients. Status is color + word (rarely needed — usually only on the SessionBar's leading dot).
-6. **Type and ASCII glyphs are the iconography.** `›` `+` `·` `↵` `⌘` `●`. Lucide is used when ASCII won't carry the meaning, including `RefreshCw` for widget refresh and `Power` for quitting the app; use 14px in compact controls and 16px in roomier controls.
+6. **Type and ASCII glyphs are the iconography.** `›` `+` `·` `↵` `⌘` `●`. Lucide is used when ASCII won't carry the meaning, including `Settings` for settings and `Power` for quitting the app; use 14px in compact controls and 16px in roomier controls.
 7. **JetBrains Mono everywhere** inside the popover surface. Inter Tight only for long prose outside the surface.
 8. **Mint is the only signal color** and is used ONLY as a dot, glow, single word, or 1px progress fill — never as a button fill, never as a background of more than 10% alpha.
 9. Production `@babymenu/ui` buttons use compact `rounded-sm` corners. Primary is **inverse white** (`--ink-100` on near-black). Default is transparent with a 1px hairline border. Destructive is coral outline. Reserve pill buttons for prototype/app-shell affordances where the design brief calls for them.

--- a/.agents/skills/baby-menu-design/preview/brand-popover.html
+++ b/.agents/skills/baby-menu-design/preview/brand-popover.html
@@ -40,7 +40,7 @@
     font-size: 11px;
   }
   .popover {
-    width: 360px;
+    width: 504px;
     background: var(--bg-stage);
     border: 1px solid var(--line);
     border-radius: var(--radius-xl);

--- a/.agents/skills/baby-menu-design/preview/color-ink.html
+++ b/.agents/skills/baby-menu-design/preview/color-ink.html
@@ -28,7 +28,7 @@
     <div class="row"><span class="swatch-name">--ink-300</span><span class="alpha">65%</span><span class="alpha">body</span><span class="sample" style="color:rgba(255,255,255,0.65)">Body copy in the popover.</span></div>
     <div class="row"><span class="swatch-name">--ink-400</span><span class="alpha">48%</span><span class="alpha">caption</span><span class="sample" style="color:rgba(255,255,255,0.48)">secondary · caption</span></div>
     <div class="row"><span class="swatch-name">--ink-500</span><span class="alpha">34%</span><span class="alpha">label</span><span class="sample label" style="color:rgba(255,255,255,0.34)">TRACKED CAPS</span></div>
-    <div class="row"><span class="swatch-name">--ink-600</span><span class="alpha">22%</span><span class="alpha">placeholder</span><span class="sample" style="color:rgba(255,255,255,0.22)">ask the agent…</span></div>
+    <div class="row"><span class="swatch-name">--ink-600</span><span class="alpha">22%</span><span class="alpha">placeholder</span><span class="sample" style="color:rgba(255,255,255,0.22)">talk to the baby</span></div>
     <div class="row"><span class="swatch-name">--ink-700</span><span class="alpha">12%</span><span class="alpha">solid line</span><span class="sample" style="border-top:1px solid rgba(255,255,255,0.12);width:120px;height:0;align-self:center"></span></div>
     <div class="row"><span class="swatch-name">--ink-800</span><span class="alpha">7%</span><span class="alpha">dashed line</span><span class="sample" style="border-top:1px dashed rgba(255,255,255,0.07);width:120px;height:0;align-self:center"></span></div>
   </div>

--- a/.agents/skills/baby-menu-design/preview/comp-empty.html
+++ b/.agents/skills/baby-menu-design/preview/comp-empty.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<title>Empty state</title>
+<title>Starter state</title>
 <link rel="stylesheet" href="card.css">
 <style>
   .empty {
@@ -24,11 +24,11 @@
 </head>
 <body>
 <div class="card">
-  <span class="label">empty state · no widgets · no illustration</span>
+  <span class="label">starter state · getting started · no illustration</span>
   <div class="empty">
-    <span class="top">› no widgets</span>
-    <p>ask the agent to add one.</p>
-    <span class="ex">try: <span style="color:var(--ink-strong)">show my battery</span> · <span style="color:var(--ink-strong)">cpu temp</span> · <span style="color:var(--ink-strong)">remind me to drink water</span></span>
+    <span class="top">hello world</span>
+    <p>tell baby menu what you would like it to become</p>
+    <span class="ex">try: <span style="color:var(--ink-strong)">weekly claude code quota</span> · <span style="color:var(--ink-strong)">cpu and memory usage %</span></span>
   </div>
 </div>
 </body>

--- a/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
+++ b/.agents/skills/baby-menu-design/preview/comp-mode-toggle.html
@@ -61,7 +61,7 @@
   <div class="label-row"><span class="ix">resting · empty</span></div>
   <div class="wrap empty">
     <span class="prompt">›</span>
-    <span class="text"><span class="placeholder">ask the agent</span><span class="caret"></span></span>
+    <span class="text"><span class="placeholder">talk to the baby</span><span class="caret"></span></span>
     <span class="send">send</span>
   </div>
 

--- a/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
+++ b/.agents/skills/baby-menu-design/ui_kits/popup-menu/README.md
@@ -13,7 +13,7 @@ A clickable recreation of the redesigned Baby Menu tray popover in the Monochrom
 | `Composer.jsx` | Slim 1-line prompt with `›` prefix, blinking caret, auto-grow on multi-line typing. Pinned on the main idle surface; replaced by `RunStrip` during a run and hidden in settings. |
 | `RunStrip.jsx` | Single live affordance — pulsing mint dot, agent's task + current step, elapsed timer. No log history. |
 | `SessionBar.jsx` | Human-language summary from the agent (`Added a CPU temperature widget`) with **Keep** / **Undo** actions. |
-| `WidgetHost.jsx` | Widget shell + three sample widgets (claude · weekly, battery, now playing). |
+| `WidgetHost.jsx` | Prototype widget shell + three sample widgets (claude · weekly, battery, now playing). The live host no longer renders a generic manual refresh button. |
 
 ## Interactions to try
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Embedded agents launched from baby-menu should work from the active extension wo
 ## Commands
 
 - `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md` and `extensions/recipes/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
-- `pnpm dev:reset` - removes `extensions-dev/`, recreates it with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
+- `pnpm dev:reset` - removes `extensions-dev/` and `.cache/baby-menu/acp-sessions`, recreates the dev workspace with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
 - `pnpm build` - build main, preload, and renderer bundles into `out/`.
 - `pnpm package:mac` - builds the app, packages `release/mac-universal/Baby Menu.app`, and ad-hoc signs it for local testing.
 - `pnpm dist:mac` - runs `package:mac` and creates `release/Baby-Menu-<version>-universal.dmg`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ Do not write generated extension files, the local extension database, compiled m
 - For durable local data, explicitly say whether the widget should read directly from `window.babyMenu.db`, whether a server action should use `context.db`, or whether a background task should persist data for later widget reads.
 - For ongoing work, explicitly distinguish visible-widget refresh from background tasks and require the slowest acceptable interval.
 - Renderer widgets and settings sections should receive normalized data over `window.babyMenu` and should not add new preload methods for each capability.
-- If a real data source may be unavailable, define the mock fallback and require the UI to label it as mock data.
+- If a real data source may be unavailable, require an explicit unavailable or sign-in-required result rather than a mock fallback; recipes should use real data only and must not fabricate or silently substitute mock data. Only specify labeled sample data when the user explicitly asks for examples.
 - Define normalized TypeScript shapes in the recipe so the agent knows what data extension server actions should return to widgets.
 - Include parser guidance for command or API output, including timeout behavior, stale-data behavior, and user-visible errors.
 - Never include or ask for committed secrets, tokens, cookie values, or local credential dumps.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 
 ```
    ┌─────────────────────┐
-   │  macOS tray popover │   (React renderer, 360px wide)
+   │  macOS tray popover │   (React renderer, 504px wide)
    │ + Menu / Settings   │
    │ + Quit              │
    └──────────┬──────────┘
@@ -166,7 +166,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 
 ```sh
 pnpm dev          # run Electron + renderer dev server with a gitignored extensions-dev/ sandbox
-pnpm dev:reset    # wipe extensions-dev/ and start fresh
+pnpm dev:reset    # wipe extensions-dev/ and agent session cache, then start fresh
 pnpm build        # build main + preload + renderer into out/
 pnpm package:mac  # build and create an ad-hoc-signed .app in release/mac-universal/
 pnpm dist:mac     # build the .app and create a universal DMG in release/
@@ -177,6 +177,7 @@ pnpm lint         # tsc --noEmit (same as typecheck)
 ```
 
 Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
+Use `pnpm dev:reset` when recipe or extension guidance changes; it also clears `.cache/baby-menu/acp-sessions` so the embedded agent re-reads the fresh copied specs instead of continuing from prior conversation state.
 Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
 Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu.app`.
 

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -72,14 +72,15 @@ Available components:
 - `cn(...)` merges Tailwind class strings safely.
 
 `@babymenu/ui` is the only extra import a widget module may add beyond `react` and local files.
-Overlays such as `Dialog`, `Select`, and `Tooltip` are already sized to fit the tray popover; do not reposition them.
+Overlays such as `Dialog` and `Select` are already sized to fit the tray popover; do not reposition them.
+`Tooltip` is a small positioned hint rather than a full popover overlay.
 
 Common API patterns:
 
 - `DataTable` takes `columns`, `rows`, optional `getRowKey`, and optional `empty` content.
 - `DataTable` columns use `{ key, header, align?, render? }`; omit `render` only when the row has a value at `row[column.key]`.
 - `Badge` supports `tone="neutral" | "live" | "warn" | "danger"`.
-- `StatusDot` supports `tone="live" | "warn" | "danger" | "muted"` and should sit next to a short status label.
+- `StatusDot` supports `tone="live" | "warn" | "danger" | "muted"` and optional `pulse`; it should sit next to a short status label.
 - `Progress` takes `value={0..100}` and optional `tone="live" | "warn" | "danger"`.
 - `Sparkline` takes `data={number[]}` and optional `width`, `height`, `tone="live" | "ink"`, and `area`.
 - `Select` and `Dialog` follow Radix composition: root, trigger, content, then item/body/footer pieces.
@@ -89,7 +90,7 @@ Common API patterns:
 - `Switch` uses Radix switch props such as `checked`, `defaultChecked`, `onCheckedChange`, and `disabled`.
 - `Tabs` follow Radix composition: `Tabs defaultValue`, `TabsList`, matching `TabsTrigger value`, and `TabsContent value`.
 - `DropdownMenu` follows Radix composition: root, `DropdownMenuTrigger`, `DropdownMenuContent`, then `DropdownMenuItem` rows.
-- `Tooltip` wraps one trigger child and takes `content`, optional `side`, and optional `className`; do not mount a separate provider.
+- `Tooltip` wraps one trigger child and takes `content`, optional `side`, optional `className`, and optional `defaultOpen`; do not mount a separate provider.
 
 ```tsx
 import {

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -21,11 +21,13 @@ Keep imports package-safe: widget modules may import `react`, `react/jsx-runtime
 Server modules may import Node built-ins such as `node:fs` plus local helper files only.
 Do not add arbitrary npm package imports to extension code unless the host compiler is updated to support them.
 
+When you need current details about a dependency, CLI, local credential layout, or an external API a widget talks to - package versions, command flags, endpoints, request headers, or response shapes - use web search to confirm the latest information before relying on it. APIs and tools change; do not guess field names, versions, or endpoints from memory when a quick search can verify them.
+
 ## Recipes
 
-Recipe-backed widget specs live in `recipes/*.html` inside this extension workspace.
-Read the matching recipe before implementing a recipe-backed widget.
-Recipes are self-contained specs for the embedded agent and should be treated as input, not generated extension output.
+Common recipes live in `recipes/*.html` inside this extension workspace.
+Read the matching recipe before implementing a widget that's relevant.
+Recipes are self-contained specs for the embedded agent and should be treated as technical reference.
 
 The `hello-world` extension is only the starter state for a fresh Baby Menu install.
 The host hides `hello-world` automatically once real widgets are discovered.
@@ -40,15 +42,15 @@ Keep the widget renderer-only.
 Do not read files, spawn commands, use credentials, or perform privileged network work from the renderer.
 Do not store tokens or secrets in renderer or browser storage; Baby Menu disables Chromium keychain-backed storage on macOS.
 
-`refreshView` is for re-rendering a *visible* widget; the host pauses it while the popover is hidden and runs it once each time the popover opens.
+`refreshView` is for re-rendering a _visible_ widget; the host pauses it while the popover is hidden and runs it once each time the popover opens.
 It is not a way to keep data fresh in the background - if data must stay current while the popover is closed, use a background task (see "Background tasks").
 A widget may also read data directly with `window.babyMenu.db` and subscribe to `window.babyMenu.background.onUpdate` to re-read when a background task finishes.
 
 ## Widget Design System
 
 Baby Menu uses the Monochrome Lab direction in runtime widgets.
-Design for a 360px macOS tray popover, not a web page, dashboard, or chat transcript.
-The host owns the outer widget wrapper, title row, refresh button, dashed dividers, scrolling, and popover chrome.
+Design for a 504px macOS tray popover, not a web page, dashboard, or chat transcript.
+The host owns the outer widget wrapper, title row, dashed dividers, scrolling, and popover chrome.
 `widget.title` should be a terse tracked-caps key such as `BATTERY`, `CPU TEMP`, or `CLAUDE · WEEKLY`.
 `render()` should return only the body content that belongs below the host title row.
 
@@ -131,26 +133,41 @@ export const serviceWidget = {
             header: "state",
             render: (row) => <Badge tone={row.status}>{row.status}</Badge>,
           },
-          { key: "load", header: "load", align: "right", render: (row) => `${row.load}%` },
+          {
+            key: "load",
+            header: "load",
+            align: "right",
+            render: (row) => `${row.load}%`,
+          },
         ]}
       />
       <div className="flex items-center justify-between text-xs text-ink-muted">
-        <span className="flex items-center gap-1.5"><StatusDot tone="live" /> healthy</span>
+        <span className="flex items-center gap-1.5">
+          <StatusDot tone="live" /> healthy
+        </span>
         <Sparkline data={[12, 18, 14, 31, 29, 41]} area />
       </div>
       <Select defaultValue="hour">
-        <SelectTrigger><SelectValue placeholder="window" /></SelectTrigger>
+        <SelectTrigger>
+          <SelectValue placeholder="window" />
+        </SelectTrigger>
         <SelectContent>
           <SelectItem value="hour">last hour</SelectItem>
           <SelectItem value="day">last day</SelectItem>
         </SelectContent>
       </Select>
       <Dialog>
-        <DialogTrigger asChild><Button>details</Button></DialogTrigger>
+        <DialogTrigger asChild>
+          <Button>details</Button>
+        </DialogTrigger>
         <DialogContent>
           <DialogTitle>service details</DialogTitle>
-          <DialogBody>Keep dialog copy short enough for the tray window.</DialogBody>
-          <DialogFooter><Button>close</Button></DialogFooter>
+          <DialogBody>
+            Keep dialog copy short enough for the tray window.
+          </DialogBody>
+          <DialogFooter>
+            <Button>close</Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>
@@ -193,6 +210,7 @@ Spacing, flex, and grid utilities are standard Tailwind.
 - Do not add gradients, emoji, large icons, card shadows, full-card accent fills, custom palettes, or new typefaces.
 - Do not wrap widget bodies in their own card background, border, or shadow.
 - Keep layouts narrow and resilient; truncate long labels and avoid horizontal scrolling.
+- Keep a value, its label, and any meter on the same axis. If a metric has two complementary readings (used vs remaining, full vs free, on vs off), pick one for a given element and make the label text, the displayed number, and any `Progress`/meter all describe it. A meter or number labeled "left"/"remaining" must show the remaining amount, not the used amount. This is about labeling correctness, not layout - it does not dictate whether you show a meter, a number, or a label.
 
 ### Example data-widget body
 
@@ -240,7 +258,7 @@ import { Button, Field, Input, Switch } from "@babymenu/ui";
 
 export const calendarSettings = {
   extensionId: "calendar", // must match the extension directory id; used as the section key and sort order
-  title: "CALENDAR",        // terse tracked-caps label, like a widget title
+  title: "CALENDAR", // terse tracked-caps label, like a widget title
   render: () => (
     <div className="flex flex-col gap-3">
       <Field label="account">
@@ -264,6 +282,8 @@ Put privileged filesystem, shell, network, credential, and token work in `server
 Export an `actions` object from `server.ts`.
 Renderer widgets call server actions through `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
 Do not add preload methods or per-extension IPC channels.
+
+Prefer real local data. When a real source is unavailable, return a clear unavailable or sign-in-required result so the widget can show that state - do not fabricate or silently fall back to mock data. Only return labeled sample data when the user explicitly asks for it.
 
 Each action receives `(input, context)`.
 The `context` is `{ rootDir, db, notify }`:
@@ -313,12 +333,18 @@ Export `background` from `server.ts` alongside `actions`:
 ```ts
 export const background = {
   intervalMs: 300_000, // 5 minutes; the host enforces a 60s minimum
-  runOnStart: true,    // run once immediately so data is warm (default true)
+  runOnStart: true, // run once immediately so data is warm (default true)
   run: async (context) => {
     const sample = await readSomething();
-    context.db.exec("CREATE TABLE IF NOT EXISTS my_ext_samples (at INTEGER, value REAL)");
-    context.db.run("INSERT INTO my_ext_samples (at, value) VALUES (?, ?)", [Date.now(), sample]);
-    if (sample > THRESHOLD) context.notify({ title: "Heads up", body: `value is ${sample}` });
+    context.db.exec(
+      "CREATE TABLE IF NOT EXISTS my_ext_samples (at INTEGER, value REAL)",
+    );
+    context.db.run("INSERT INTO my_ext_samples (at, value) VALUES (?, ?)", [
+      Date.now(),
+      sample,
+    ]);
+    if (sample > THRESHOLD)
+      context.notify({ title: "Heads up", body: `value is ${sample}` });
   },
 };
 ```
@@ -332,10 +358,10 @@ The widget reads the persisted data with `window.babyMenu.db` on open and subscr
 Baby Menu lives in the tray and stays running for the whole session, and the popover is hidden (not unmounted) on blur.
 Choosing the right mechanism is the main performance decision:
 
-- Use `viewRefreshIntervalMs` / `refreshView` for keeping a *visible* widget current, including live real-time displays.
+- Use `viewRefreshIntervalMs` / `refreshView` for keeping a _visible_ widget current, including live real-time displays.
   It pauses while the popover is hidden, so a 1-2s loop costs nothing when nobody is looking.
   A live monitor that is only interesting while you are watching it - CPU, memory, a clock - belongs here, sampled on demand through a server action, not in a background task.
-  Choose the slowest interval that still feels live, and omit it entirely for data that rarely changes (the host always offers a manual refresh button).
+  Choose the slowest interval that still feels live, and omit it entirely for data that rarely changes - the host re-runs `refreshView` each time the popover opens, so the widget is already current whenever the user looks at it.
 - Use a background task for anything that must keep running while the popover is closed.
   It runs in the main process on a single owned timer, clamped to a 60s floor; pick the slowest cadence that meets the need, since each run wakes the machine.
 - Never start your own `setInterval`, `setTimeout` loops, or recursive polling inside a widget or server action - the host owns all timing.
@@ -349,5 +375,6 @@ Choosing the right mechanism is the main performance decision:
 ## Tests
 
 Use TDD for behavior changes.
-Add tests under the repo-level `tests/` directory unless the project later adopts colocated extension tests.
-Run the smallest relevant `pnpm vitest run tests/<name>.test.ts` command first, then broader checks before finishing.
+Colocate tests inside your extension directory as `<extension-id>/<name>.test.ts` (or `.test.tsx`), next to the `widget.tsx` and `server.ts` they cover, and import the code under test with relative paths (`./server`, `./widget`).
+Do not add tests under the repo-level `tests/` directory. That directory belongs to the host app and is not wiped when this extension workspace is reset, so a test left there that imports your extension will dangle and break the entire repo test run once your extension is regenerated or removed.
+Run only your extension's tests with `pnpm vitest run <extension-id>` first, then broaden if needed before finishing.

--- a/extensions/hello-world/widget.tsx
+++ b/extensions/hello-world/widget.tsx
@@ -1,38 +1,68 @@
+import { useEffect, useRef, useState } from "react";
 import type { RefreshableBabyMenuWidget } from "../../src/shared/contracts";
-import { StatusDot } from "@babymenu/ui";
 
 const examplePrompts = [
-  "add a battery widget that shows current charge and power source",
-  "add a calendar widget that shows my next event and time until it starts",
-  "add a cpu temp widget that shows current temperature and fan status",
+  "add a widget tracking my weekly claude code quota",
+  "add a widget showing current cpu and memory usage %",
 ];
+
+const COPIED_FEEDBACK_MS = 1500;
+
+function ExampleButton({ prompt }: { prompt: string }) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  async function copyPrompt() {
+    try {
+      await navigator.clipboard.writeText(prompt);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void copyPrompt()}
+      title="Copy prompt to clipboard"
+      className="group flex w-full items-start gap-2 rounded-sm border border-line px-3 py-2 text-left text-sm leading-snug text-ink transition-colors hover:border-signal-live/40 hover:bg-elevated"
+    >
+      <span className="shrink-0 text-signal-live">›</span>
+      <span className="flex-1">{prompt}</span>
+      <span
+        className={`shrink-0 self-center text-xxs uppercase tracking-caps ${
+          copied ? "text-signal-live" : "text-ink-faint opacity-0 group-hover:opacity-100"
+        }`}
+      >
+        {copied ? "copied" : "copy"}
+      </span>
+    </button>
+  );
+}
 
 function HelloWorldView() {
   return (
     <div className="flex flex-col gap-7 pb-2 pt-1.5">
       <div className="flex flex-col gap-3">
-        <span className="flex items-center gap-1.5 text-xxs uppercase tracking-caps text-signal-live">
-          <StatusDot /> ready
-        </span>
         <span className="text-3xl font-light tracking-value text-ink-strong">hello world</span>
         <div className="flex flex-col gap-1">
-          <p className="text-md text-ink-strong">tell baby_menu what to build.</p>
-          <p className="text-base text-ink-muted">
-            paste an example into the prompt below, or ask for any widget you want.
-          </p>
+          <p className="text-md text-ink-strong">tell baby menu what you would like it to become</p>
         </div>
       </div>
       <div className="flex flex-col gap-3">
         <span className="text-xxs uppercase tracking-caps text-ink-label">examples</span>
         <div className="flex flex-col gap-2">
           {examplePrompts.map((example) => (
-            <span
-              key={example}
-              className="flex items-start gap-2 rounded-sm border border-line px-3 py-2 text-sm leading-snug text-ink"
-            >
-              <span className="shrink-0 text-signal-live">›</span>
-              <span>{example}</span>
-            </span>
+            <ExampleButton key={example} prompt={example} />
           ))}
         </div>
       </div>
@@ -42,6 +72,6 @@ function HelloWorldView() {
 
 export const helloWorldWidget: RefreshableBabyMenuWidget = {
   id: "hello-world",
-  title: "baby menu",
+  title: "getting started",
   render: () => <HelloWorldView />,
 };

--- a/extensions/recipes/claude-code-quota.html
+++ b/extensions/recipes/claude-code-quota.html
@@ -14,23 +14,10 @@
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Capability</h2>
-        <p>Add a baby-menu widget that shows Claude Code usage limits in the menu popover.</p>
-        <p>The widget should prefer real local Claude credentials and CLI output, then fall back to clearly labeled mock data only when no usable local source is available.</p>
+        <p>Source Claude Code usage limits from the local machine for a baby-menu widget.</p>
+        <p>Use real local Claude credentials and CLI output only. When no usable local source is available, return an unavailable or sign-in-required result - do not fabricate or fall back to mock data.</p>
+        <p><strong>Scope:</strong> this recipe covers only how to obtain and normalize the data. How the widget presents it - layout, states, copy, refresh controls - is left to the implementer and is intentionally not specified here.</p>
         <p>This recipe is self-contained. Do not require external source code, websites, or implementation guides to complete it.</p>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>User-Facing Behavior</h2>
-        <ul>
-          <li>Show current session usage and weekly usage when available.</li>
-          <li>Show model-specific weekly usage for Sonnet and Opus when available.</li>
-          <li>Show reset time text for each available window.</li>
-          <li>Show account email or plan when available.</li>
-          <li>Show last refreshed time.</li>
-          <li>Show loading, success, stale, unavailable, and error states.</li>
-          <li>Refresh automatically every 5 minutes by default.</li>
-          <li>Expose a manual refresh button.</li>
-        </ul>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
@@ -52,44 +39,55 @@
               <td>OAuth is unavailable but the <code>claude</code> CLI is installed and signed in.</td>
               <td>Current session percentage, current week percentage, reset text, account and org lines when present.</td>
             </tr>
-            <tr>
-              <td>3</td>
-              <td>Claude web API with manual cookie</td>
-              <td>The user explicitly provides a Claude <code>sessionKey</code> cookie later.</td>
-              <td>Session, weekly, model-specific usage, extra usage spend, account email.</td>
-            </tr>
-            <tr>
-              <td>4</td>
-              <td>Mock provider</td>
-              <td>No real source is configured or readable.</td>
-              <td>Static sample values labeled <strong>Mock data</strong>.</td>
-            </tr>
           </tbody>
         </table>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>OAuth Usage API Details</h2>
-        <p>Credential locations to check from <code>claude-code-quota/server.ts</code> only:</p>
-        <ul>
-          <li><code>~/.claude/.credentials.json</code></li>
+        <p>Credential locations to check from <code>claude-code-quota/server.ts</code> only, in this fallback order:</p>
+        <ol>
+          <li><code>~/.claude/.credentials.json</code> - present on Linux and any setup where Claude Code wrote a file-based credential.</li>
+          <li><strong>macOS login Keychain</strong> - a generic-password item with service name <code>Claude Code-credentials</code>. This is where the Claude Code CLI stores its OAuth credentials on macOS, so on a typical Mac the file above does not exist and the Keychain is the real source. Do not skip it. Read it from the server action with the <code>security</code> CLI: <code>security find-generic-password -s "Claude Code-credentials" -w</code>, which prints the secret blob to stdout. Always check the file first, then fall back to this Keychain service.</li>
           <li>Future app-local credential cache under Electron user data, not committed to the repo.</li>
-        </ul>
-        <p>Look for an OAuth access token with scope that can call usage APIs. Tokens with only inference scope may fail.</p>
+        </ol>
+        <p>The file and the Keychain blob hold the same JSON shape. Parse <code>claudeAiOauth</code> and read the access token from it:</p>
+        <pre class="mockup-code p-4 overflow-auto"><code>{
+  "claudeAiOauth": {
+    "accessToken": "sk-ant-oat01-...",
+    "refreshToken": "sk-ant-ort01-...",
+    "expiresAt": 1780000000000,          // epoch ms; treat as expired / refresh-needed when in the past
+    "scopes": ["user:inference", "user:profile"],
+    "subscriptionType": "max"            // maps to the plan label: pro, max, ...
+  }
+}</code></pre>
+        <p>Also accept <code>accessToken</code> / <code>access_token</code> at the JSON root as a fallback, since some writers store the token at the top level rather than under <code>claudeAiOauth</code>. Prefer a token whose scopes can call usage APIs; tokens with only inference scope may fail.</p>
+        <p>macOS Keychain notes: the first <code>security find-generic-password</code> read of an item owned by the <code>claude</code> CLI can trigger a one-time macOS permission prompt for Baby Menu; that is expected, and "Always Allow" authorizes future reads. Never log or echo the secret blob, the access token, or the refresh token, and read credentials only inside the server action, never in the renderer.</p>
         <p>Request:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>GET https://api.anthropic.com/api/oauth/usage
 Authorization: Bearer &lt;access_token&gt;
 anthropic-beta: oauth-2025-04-20</code></pre>
-        <p>Map response fields into this normalized shape:</p>
+        <p><strong>Response shape - parse these fields, but treat the live response as canonical.</strong> The body is a flat object keyed by window id, with no <code>usage</code> / <code>data</code> wrapper. Each present window is <code>{ utilization, resets_at }</code> where <code>utilization</code> is the percent <em>used</em> (0-100), so remaining = <code>100 - utilization</code>. A window key may be <code>null</code> (the user has no such window) - skip nulls, do not treat them as 0% used. <code>resets_at</code> is an ISO-8601 timestamp or null.</p>
+        <p><strong>The live API is the source of truth.</strong> This shape was captured from the real endpoint at the time of writing; the remote API can change field names, nesting, units, or window keys without notice. Confirm the fields against the actual response you receive (and via web search for the current API) before depending on them, and parse defensively - tolerate missing, added, renamed, or null fields and never assume a field is present. If the response no longer matches anything you can parse, return an unavailable or sign-in-required result rather than showing a wrong or fabricated number.</p>
+        <pre class="mockup-code p-4 overflow-auto"><code>{
+  "five_hour":         { "utilization": 20.0, "resets_at": "2026-05-28T21:30:00Z" },
+  "seven_day":         { "utilization": 4.0,  "resets_at": "2026-05-30T15:00:00Z" },
+  "seven_day_opus":    null,
+  "seven_day_sonnet":  { "utilization": 0.0,  "resets_at": null },
+  "extra_usage":       { "is_enabled": false, "monthly_limit": null, "used_credits": null,
+                         "utilization": null, "currency": null }
+}</code></pre>
+        <p>So for the example above the weekly window is 4% used (equivalently 96% remaining). Do not default a missing <code>utilization</code> to 0 (that hides the real number); if a window has no numeric <code>utilization</code>, omit that window instead. For <code>extra_usage</code>, map <code>used_credits</code>/<code>monthly_limit</code> to spend/limit and only show it when <code>is_enabled</code> is true.</p>
+        <p><strong>One axis, consistently.</strong> "Used" and "remaining" are the same number from opposite ends (<code>remaining = 100 - used</code>). Whatever you choose to present, the label, the number, and any progress/meter for a given window must all describe the <em>same</em> axis. A meter or number labeled "left"/"remaining" must carry the remaining value, not the used value (a 4%-used week is "96% left", and a "left" meter should read nearly full, not nearly empty). This is a correctness constraint only - it does not require a meter, a number, or any particular label or layout.</p>
+        <p>Map those fields into this normalized shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type ClaudeQuotaSnapshot = {
-  source: "oauth" | "cli" | "web" | "mock";
+  source: "oauth" | "cli";
   accountEmail?: string;
   plan?: string;
   windows: Array&lt;{
     id: "five_hour" | "seven_day" | "seven_day_sonnet" | "seven_day_opus" | "extra_usage";
     label: string;
-    percentUsed?: number;
-    percentRemaining?: number;
+    percentUsed?: number;        // canonical, percent USED (0-100); derive remaining as 100 - percentUsed
     resetText?: string;
     resetAt?: string;
     spentUsd?: number;
@@ -133,91 +131,26 @@ anthropic-beta: oauth-2025-04-20</code></pre>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Manual Cookie Web API Details</h2>
-        <p>This is not required for the first implementation unless OAuth and CLI are insufficient.</p>
-        <p>If implemented, require explicit user-provided cookie text and keep it out of git.</p>
-        <p>Required cookie name: <code>sessionKey</code>, usually with value prefix <code>sk-ant-</code>.</p>
-        <p>API flow:</p>
-        <pre class="mockup-code p-4 overflow-auto"><code>GET https://claude.ai/api/organizations
-Cookie: sessionKey=&lt;value&gt;
-
-GET https://claude.ai/api/organizations/{orgId}/usage
-Cookie: sessionKey=&lt;value&gt;
-
-GET https://claude.ai/api/organizations/{orgId}/overage_spend_limit
-Cookie: sessionKey=&lt;value&gt;
-
-GET https://claude.ai/api/account
-Cookie: sessionKey=&lt;value&gt;</code></pre>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Implementation Contract</h2>
-        <p>Create or edit these extension files:</p>
-        <ul>
-          <li><code>claude-code-quota/server.ts</code> for privileged token, CLI, network, timeout, and parser work.</li>
-          <li><code>claude-code-quota/widget.tsx</code> for a <code>RefreshableBabyMenuWidget</code>, using <code>@babymenu/ui</code>.</li>
-          <li>The widget should call <code>window.babyMenu.capabilities.invoke("claude-code-quota", "getQuota", input)</code>.</li>
-          <li>Put quota reload logic in the widget's exported <code>refreshView</code> method and set <code>viewRefreshIntervalMs</code> to 5 minutes; <code>WidgetHost</code> owns the timer and manual refresh calls, and pauses view refresh while the popover is hidden.</li>
-          <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
-        </ul>
-        <p>Add repo-level tests:</p>
-        <ul>
-          <li><code>tests/claude-quota.test.ts</code> for parser and fallback tests.</li>
-        </ul>
+        <p>All data acquisition lives in <code>claude-code-quota/server.ts</code>: token reads, the CLI probe, network calls, timeouts, and parsing. Expose it as a <code>getQuota</code> server action invoked from the renderer with <code>window.babyMenu.capabilities.invoke("claude-code-quota", "getQuota", input)</code>. Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</p>
+        <p>The data is safe to refresh roughly every 5 minutes; how and when the widget triggers a refresh is the widget's concern, not this recipe's.</p>
+        <p>Colocate parser and fallback tests inside the extension as <code>claude-code-quota/&lt;name&gt;.test.ts</code>.</p>
         <p>Server action response shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type QuotaResult&lt;T&gt; =
   | { ok: true; data: T }
-  | { ok: false; error: string; sourceTried: string[]; mock?: T };</code></pre>
+  | { ok: false; error: string; sourceTried: string[] };</code></pre>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Error Handling</h2>
+        <p>These are data outcomes the server action returns, not UI copy.</p>
         <ul>
-          <li>If no token or CLI is available, show <code>Claude quota unavailable</code> and offer mock data labeled as mock.</li>
-          <li>If a request times out, show <code>Refresh timed out</code> and keep the previous successful value as stale.</li>
-          <li>If credentials are expired, show <code>Claude sign-in required</code>.</li>
-          <li>Never print token or cookie values in renderer errors, logs, or tests.</li>
-        </ul>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Interactive Demo</h2>
-        <div class="card max-w-sm border border-base-300 bg-base-100 shadow">
-          <div class="card-body gap-4">
-          <h3 class="card-title">Claude Code quota</h3>
-          <p><strong id="remaining">68%</strong> weekly capacity remaining</p>
-          <progress id="bar" class="progress progress-primary" value="68" max="100"></progress>
-          <p id="stamp">Last refreshed just now</p>
-          <button id="refresh" class="btn btn-primary" type="button">Manual refresh</button>
-          </div>
-        </div>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Acceptance Criteria</h2>
-        <ul>
-          <li>The widget displays current Claude quota or a clear unavailable state.</li>
-          <li>The widget displays source label: OAuth, CLI, Web, or Mock data.</li>
-          <li>The widget displays when it was last refreshed.</li>
-          <li>The widget refreshes on a timer.</li>
-          <li>The widget exposes a manual refresh action.</li>
-          <li>The widget shows stale previous values if a refresh fails after a prior success.</li>
-          <li>The widget shows a clear error state if quota cannot be read.</li>
-          <li>Tests cover parser success, parser missing data, timeout/error fallback, and mock fallback.</li>
+          <li>If no token or CLI is available, return an unavailable error (<code>Claude quota unavailable</code>). Do not return mock data.</li>
+          <li>If a request times out, return the previous successful snapshot marked <code>stale: true</code> when one exists.</li>
+          <li>If credentials are expired, return an error of <code>Claude sign-in required</code> rather than silently using a stale token.</li>
+          <li>Never log, echo, or return token or cookie values in errors, logs, or tests.</li>
         </ul>
       </section>
     </main>
-    <script>
-      const values = [68, 54, 73, 61];
-      let index = 0;
-      document.getElementById("refresh").addEventListener("click", () => {
-        index = (index + 1) % values.length;
-        const value = values[index];
-        document.getElementById("remaining").textContent = `${value}%`;
-        document.getElementById("bar").value = value;
-        document.getElementById("stamp").textContent = `Last refreshed ${new Date().toLocaleTimeString()}`;
-      });
-    </script>
   </body>
 </html>

--- a/extensions/recipes/codex-quota.html
+++ b/extensions/recipes/codex-quota.html
@@ -14,23 +14,10 @@
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Capability</h2>
-        <p>Add a baby-menu widget that shows Codex usage limits, credits, and reset windows from local Codex credentials or CLI state.</p>
-        <p>The widget should prefer real local data and fall back to clearly labeled mock data only when no usable source is available.</p>
+        <p>Source Codex usage limits, credits, and reset windows from local Codex credentials or CLI state for a baby-menu widget.</p>
+        <p>Use real local data only. When no usable local source is available, return an unavailable or sign-in-required result - do not fabricate or fall back to mock data.</p>
+        <p><strong>Scope:</strong> this recipe covers only how to obtain and normalize the data. How the widget presents it - layout, states, copy, refresh controls - is left to the implementer and is intentionally not specified here.</p>
         <p>This recipe is self-contained. Do not require external source code, websites, or implementation guides to complete it.</p>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>User-Facing Behavior</h2>
-        <ul>
-          <li>Show primary and secondary Codex usage windows when available.</li>
-          <li>Show reset countdown or reset timestamp for each window when available.</li>
-          <li>Show credit balance if available.</li>
-          <li>Show account email and plan type if available.</li>
-          <li>Show last refreshed time.</li>
-          <li>Show loading, success, stale, unavailable, and error states.</li>
-          <li>Refresh automatically every 5 minutes by default.</li>
-          <li>Expose a manual refresh button.</li>
-        </ul>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
@@ -52,18 +39,6 @@
               <td>The <code>codex</code> CLI is installed and signed in.</td>
               <td>Rate limit windows, credits, account identity.</td>
             </tr>
-            <tr>
-              <td>3</td>
-              <td>Manual status parser</td>
-              <td>A developer supplies saved <code>codex /status</code> output for tests or diagnostics.</td>
-              <td>Credits, five-hour limit, weekly limit, reset text.</td>
-            </tr>
-            <tr>
-              <td>4</td>
-              <td>Mock provider</td>
-              <td>No real source is configured or readable.</td>
-              <td>Static sample values labeled <strong>Mock data</strong>.</td>
-            </tr>
           </tbody>
         </table>
       </section>
@@ -75,20 +50,52 @@
           <li><code>$CODEX_HOME/auth.json</code> if <code>CODEX_HOME</code> is set.</li>
           <li><code>~/.codex/auth.json</code> otherwise.</li>
         </ul>
+        <p>Unlike Claude, Codex stores credentials in a plain file, not the macOS Keychain, so a file read is sufficient. Do not read the Keychain for Codex.</p>
+        <p>Parse <code>auth.json</code> with this precedence:</p>
+        <ol>
+          <li>If a non-empty top-level <code>OPENAI_API_KEY</code> string is present, use it directly as the bearer token (API-key auth).</li>
+          <li>Otherwise read the <code>tokens</code> object: <code>access_token</code> (or <code>accessToken</code>), <code>refresh_token</code> (or <code>refreshToken</code>), and optionally <code>id_token</code> / <code>account_id</code>. Accept both snake_case and camelCase keys.</li>
+        </ol>
+        <pre class="mockup-code p-4 overflow-auto"><code>{
+  "OPENAI_API_KEY": null,                 // when set, use as the bearer token directly
+  "tokens": {
+    "access_token": "...",
+    "refresh_token": "...",
+    "id_token": "...",                    // optional
+    "account_id": "..."                   // optional
+  },
+  "last_refresh": "2026-05-22T08:21:00Z"  // used for the staleness check below
+}</code></pre>
+        <p>If <code>tokens</code> is missing or has no <code>access_token</code>, treat it as a sign-in-required error (<code>Run `codex` to log in.</code>) rather than failing silently. Never log or echo the token values, and read credentials only inside the server action, never in the renderer.</p>
         <p>Request:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>GET https://chatgpt.com/backend-api/wham/usage
-Authorization: Bearer &lt;access_token&gt;</code></pre>
+Authorization: Bearer &lt;access_token&gt;
+ChatGPT-Account-Id: &lt;tokens.account_id&gt;</code></pre>
+        <p>Send the <code>ChatGPT-Account-Id</code> header from <code>tokens.account_id</code> (or the account id decoded from the JWT) - the usage call needs it.</p>
+        <p><strong>Response shape - parse these fields, but treat the live response as canonical.</strong> Usage lives under <code>rate_limit</code>, and each window carries <code>used_percent</code> (percent <em>used</em>, 0-100), so remaining = <code>100 - used_percent</code>. <code>primary_window</code> is the short session window (its <code>limit_window_seconds</code> is ~18000 = 5h) and <code>secondary_window</code> is the weekly window (~604800 = 7d). <code>reset_at</code> is epoch <em>seconds</em> (multiply by 1000 for a JS Date); <code>reset_after_seconds</code> is the countdown.</p>
+        <p><strong>The live API is the source of truth.</strong> This shape was captured from the real endpoint at the time of writing; the remote API can change field names, nesting, units, or window keys without notice. Confirm the fields against the actual response you receive (and via web search for the current API) before depending on them, and parse defensively - tolerate missing, added, renamed, or null fields and never assume a field is present. If the response no longer matches anything you can parse, return an unavailable or sign-in-required result rather than showing a wrong or fabricated number.</p>
+        <pre class="mockup-code p-4 overflow-auto"><code>{
+  "email": "you@example.com",
+  "plan_type": "pro",
+  "rate_limit": {
+    "allowed": true, "limit_reached": false,
+    "primary_window":   { "used_percent": 25, "limit_window_seconds": 18000,  "reset_at": 1780007894 },
+    "secondary_window": { "used_percent": 70, "limit_window_seconds": 604800, "reset_at": 1780176266 }
+  },
+  "credits": { "has_credits": false, "unlimited": false, "balance": "0" }
+}</code></pre>
+        <p>So for the example above the session window is 25% used (equivalently 75% remaining) and the weekly window is 70% used (30% remaining). Map <code>primary_window</code> to the session/5-hour window and <code>secondary_window</code> to the weekly window; map <code>email</code> to <code>accountEmail</code>, <code>plan_type</code> to <code>plan</code>, and <code>credits</code> through. Do not default a missing <code>used_percent</code> to 0 (that hides the real number); omit a window that has no numeric <code>used_percent</code> instead.</p>
+        <p><strong>One axis, consistently.</strong> "Used" and "remaining" are the same number from opposite ends (<code>remaining = 100 - used</code>). Whatever you choose to present, the label, the number, and any progress/meter for a given window must all describe the <em>same</em> axis. A meter or number labeled "left"/"remaining" must carry the remaining value, not the used value (a 25%-used window is "75% left", and a "left" meter should read three-quarters full). This is a correctness constraint only - it does not require a meter, a number, or any particular label or layout.</p>
         <p>If the token metadata includes a refresh timestamp and it is older than roughly 8 days, prefer returning a sign-in or refresh-needed error for the first implementation rather than silently using a stale token.</p>
         <p>Normalize response data into this shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type CodexQuotaSnapshot = {
-  source: "oauth" | "cli-rpc" | "status-text" | "mock";
+  source: "oauth" | "cli-rpc";
   accountEmail?: string;
   plan?: string;
   windows: Array&lt;{
     id: "five_hour" | "weekly" | "primary" | "secondary";
     label: string;
-    percentUsed?: number;
-    percentRemaining?: number;
+    percentUsed?: number;        // canonical, percent USED (0-100); derive remaining as 100 - percentUsed
     resetText?: string;
     resetAt?: string;
   }&gt;;
@@ -129,99 +136,27 @@ Authorization: Bearer &lt;access_token&gt;</code></pre>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Status Text Parser Details</h2>
-        <p>Do not launch the interactive Codex TUI in the background for the first implementation.</p>
-        <p>Keep this parser for tests and manual diagnostics using captured <code>/status</code> text.</p>
-        <p>Parser expectations:</p>
-        <ul>
-          <li>Strip ANSI escape sequences.</li>
-          <li>Parse <code>Credits:</code> lines into <code>credits.balance</code> where possible.</li>
-          <li>Parse <code>5h limit</code> lines into a five-hour usage window.</li>
-          <li>Parse <code>Weekly limit</code> lines into a weekly usage window.</li>
-          <li>Extract percent used or remaining and reset text near each line.</li>
-          <li>Surface update prompts as <code>Codex CLI update needed</code>.</li>
-        </ul>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Optional Web Dashboard Extras</h2>
-        <p>Do not implement browser-cookie scraping in the first widget unless the user explicitly asks for richer dashboard extras.</p>
-        <p>If implemented later, it must be opt-in and server-action only.</p>
-        <p>Dashboard URL: <code>https://chatgpt.com/codex/settings/usage</code>.</p>
-        <p>Potential extras include code review remaining, usage breakdown chart data, credits history, and credits purchase URL.</p>
-        <p>Cookie handling must never write secrets to committed files or renderer logs.</p>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Implementation Contract</h2>
-        <p>Create or edit these extension files:</p>
-        <ul>
-          <li><code>codex-quota/server.ts</code> for privileged token, CLI RPC, timeout, and parser work.</li>
-          <li><code>codex-quota/widget.tsx</code> for a <code>RefreshableBabyMenuWidget</code>, using <code>@babymenu/ui</code>.</li>
-          <li>The widget should call <code>window.babyMenu.capabilities.invoke("codex-quota", "getQuota", input)</code>.</li>
-          <li>Put quota reload logic in the widget's exported <code>refreshView</code> method and set <code>viewRefreshIntervalMs</code> to 5 minutes; <code>WidgetHost</code> owns the timer and manual refresh calls, and pauses view refresh while the popover is hidden.</li>
-          <li>Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</li>
-        </ul>
-        <p>Add repo-level tests:</p>
-        <ul>
-          <li><code>tests/codex-quota.test.ts</code> for parser, RPC fallback, timeout, and mock tests.</li>
-        </ul>
+        <p>All data acquisition lives in <code>codex-quota/server.ts</code>: token reads, the CLI RPC, network calls, timeouts, and parsing. Expose it as a <code>getQuota</code> server action invoked from the renderer with <code>window.babyMenu.capabilities.invoke("codex-quota", "getQuota", input)</code>. Do not add preload methods, per-widget IPC channels, core renderer widgets, or <code>WidgetHost</code> registration; Baby Menu discovers extension widgets automatically.</p>
+        <p>The data is safe to refresh roughly every 5 minutes; how and when the widget triggers a refresh is the widget's concern, not this recipe's.</p>
+        <p>Colocate parser, RPC-fallback, and timeout tests inside the extension as <code>codex-quota/&lt;name&gt;.test.ts</code>.</p>
         <p>Server action response shape:</p>
         <pre class="mockup-code p-4 overflow-auto"><code>type QuotaResult&lt;T&gt; =
   | { ok: true; data: T }
-  | { ok: false; error: string; sourceTried: string[]; mock?: T };</code></pre>
+  | { ok: false; error: string; sourceTried: string[] };</code></pre>
       </section>
 
       <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
         <h2>Error Handling</h2>
+        <p>These are data outcomes the server action returns, not UI copy.</p>
         <ul>
-          <li>If no auth file or CLI is available, show <code>Codex quota unavailable</code> and offer mock data labeled as mock.</li>
-          <li>If the CLI app-server times out, show <code>Codex CLI timed out</code> and keep the previous successful value as stale.</li>
-          <li>If credentials are expired, show <code>Codex sign-in required</code>.</li>
-          <li>If macOS blocks the CLI executable, show <code>Codex CLI could not be launched</code>.</li>
-          <li>Never print token or cookie values in renderer errors, logs, or tests.</li>
-        </ul>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Interactive Demo</h2>
-        <div class="card max-w-sm border border-base-300 bg-base-100 shadow">
-          <div class="card-body gap-4">
-          <h3 class="card-title">Codex status</h3>
-          <div class="grid grid-cols-[1fr_auto] items-center gap-3"><progress id="meter" class="progress progress-primary" value="42" max="100"></progress><strong id="value">42%</strong></div>
-          <p id="credits">Credits: 18.50</p>
-          <p id="stamp">Mock data refreshed just now</p>
-          <button id="refresh" class="btn btn-primary" type="button">Manual refresh</button>
-          </div>
-        </div>
-      </section>
-
-      <section class="card border border-base-300 bg-base-100 shadow-sm p-6">
-        <h2>Acceptance Criteria</h2>
-        <ul>
-          <li>The widget displays current Codex quota state or a clear unavailable state.</li>
-          <li>The widget displays source label: OAuth, CLI RPC, Status text, or Mock data.</li>
-          <li>The widget displays when it was last refreshed.</li>
-          <li>The widget refreshes on a timer.</li>
-          <li>The widget exposes a manual refresh action.</li>
-          <li>The widget shows stale previous values if a refresh fails after a prior success.</li>
-          <li>The widget shows a clear error state if quota cannot be read.</li>
-          <li>Tests cover status parser success, parser missing data, CLI timeout/error fallback, and mock fallback.</li>
+          <li>If no auth file or CLI is available, return an unavailable error (<code>Codex quota unavailable</code>). Do not return mock data.</li>
+          <li>If the CLI app-server times out, return the previous successful snapshot marked <code>stale: true</code> when one exists.</li>
+          <li>If credentials are expired, return a <code>Codex sign-in required</code> error rather than silently using a stale token.</li>
+          <li>If macOS blocks the CLI executable, return a <code>Codex CLI could not be launched</code> error.</li>
+          <li>Never log, echo, or return token or cookie values in errors, logs, or tests.</li>
         </ul>
       </section>
     </main>
-    <script>
-      const values = [42, 47, 39, 52];
-      const credits = [18.5, 17.9, 16.4, 20.0];
-      let index = 0;
-      document.getElementById("refresh").addEventListener("click", () => {
-        index = (index + 1) % values.length;
-        const value = values[index];
-        document.getElementById("meter").value = value;
-        document.getElementById("value").textContent = `${value}%`;
-        document.getElementById("credits").textContent = `Credits: ${credits[index].toFixed(2)}`;
-        document.getElementById("stamp").textContent = `Mock data refreshed ${new Date().toLocaleTimeString()}`;
-      });
-    </script>
   </body>
 </html>

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -75,6 +75,11 @@ export function resetDevWorkspace({
   const rootDir = gitRoot(cwd, execFileSyncFn);
   const devExtensionsDir = resolveDevExtensionsDir(rootDir, env);
   rmSyncFn(devExtensionsDir, { recursive: true, force: true });
+  // Also clear the embedded agent's persistent conversation. Otherwise the agent
+  // keeps its prior context across a reset and rebuilds widgets from memory
+  // instead of re-reading updated recipes/AGENTS.md. Mirrors getAgentStateDir in
+  // src/shared/paths.ts (.cache/baby-menu/acp-sessions).
+  rmSyncFn(join(rootDir, ".cache", "baby-menu", "acp-sessions"), { recursive: true, force: true });
 
   return runDev({
     cwd: rootDir,

--- a/src/main/agent-runtime.ts
+++ b/src/main/agent-runtime.ts
@@ -11,7 +11,7 @@ import {
   type AcpRuntimeTurn,
   type AcpxRuntime,
 } from "acpx/runtime";
-import type { AgentChatResult, GitActionResult, GitSessionSnapshot } from "../shared/contracts";
+import type { AgentActiveTurn, AgentChatResult, GitActionResult, GitSessionSnapshot } from "../shared/contracts";
 import type { AgentRuntimeStatus } from "../shared/contracts";
 import { type AgentDefinition, resolveAgentCatalog } from "./agent-catalog";
 import { getAgentStateDir, getDevExtensionSnapshotDir, getExtensionsDir } from "../shared/paths";
@@ -256,6 +256,7 @@ export class BabyMenuAgentRuntime {
   private handle: AcpRuntimeHandle | null = null;
   private activeSession: AgentChangeSession | null = null;
   private activeTurn = false;
+  private activeTurnInfo: AgentActiveTurn | null = null;
   private agentName: string;
   private readonly registryOverrides: Record<string, string> | undefined;
   private readonly requestTimeoutMs: number;
@@ -276,6 +277,30 @@ export class BabyMenuAgentRuntime {
 
   get session(): AgentChangeSession | null {
     return this.activeSession;
+  }
+
+  /**
+   * Snapshot of the outstanding change session for the renderer to re-hydrate a
+   * pending Keep/Rollback prompt after a reload. Returns null when no session is
+   * open OR a turn is still running. The change session is created at the start of
+   * a turn (so it is "saveable" the whole time the build runs); returning null
+   * mid-turn keeps the renderer from showing a Keep/Rollback prompt before the
+   * build has actually finished. Use currentTurn() to restore the run strip then.
+   */
+  currentSessionSnapshot(): GitSessionSnapshot | null {
+    if (this.activeTurn) return null;
+    if (!this.activeSession) return null;
+    if (!this.activeSession.canSave && !this.activeSession.canRollback) return null;
+    return this.activeSession.snapshot("Review the generated changes, then Save or Rollback.");
+  }
+
+  /**
+   * The turn currently running in the main process, or null. Lets the renderer
+   * restore the in-progress run strip after the popover view is remounted (e.g.
+   * returning from Settings) instead of losing it or surfacing a premature prompt.
+   */
+  currentTurn(): AgentActiveTurn | null {
+    return this.activeTurnInfo;
   }
 
   get currentAgent(): string {
@@ -323,11 +348,13 @@ export class BabyMenuAgentRuntime {
     }
 
     this.activeTurn = true;
+    this.activeTurnInfo = { title: prompt.trim(), startedAt: Date.now() };
 
     try {
       return await this.runSend(prompt, options);
     } finally {
       this.activeTurn = false;
+      this.activeTurnInfo = null;
     }
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,9 +1,11 @@
 import { app as electronApp, ipcMain } from "electron";
 import { pathToFileURL } from "node:url";
 import type {
+  AgentActiveTurn,
   AgentChatResult,
   BabyMenuSettings,
   GitActionResult,
+  GitSessionSnapshot,
   PopoverVisibilityState,
   RecipeMetadata,
   SqlParams,
@@ -15,7 +17,10 @@ import { loadRecipes } from "./recipe-loader";
 import { createServerActionRegistry, type ServerActionRegistry } from "./server-action-registry";
 import { createWidgetModuleRegistry, type WidgetModuleRegistry } from "./widget-module-registry";
 
-type AgentRuntimeFacade = Pick<BabyMenuAgentRuntime, "save" | "rollback"> & {
+type AgentRuntimeFacade = Pick<
+  BabyMenuAgentRuntime,
+  "save" | "rollback" | "currentSessionSnapshot" | "currentTurn"
+> & {
   send: (prompt: string, options?: BabyMenuAgentRuntimeSendOptions) => Promise<AgentChatResult>;
 };
 
@@ -66,12 +71,20 @@ export function registerIpcHandlers(
     });
   });
 
+  ipcMain.handle("baby-menu:agent:active-turn", async (): Promise<AgentActiveTurn | null> => {
+    return agentRuntime.currentTurn();
+  });
+
   ipcMain.handle("baby-menu:git:save", async (_event, message?: string): Promise<GitActionResult> => {
     return agentRuntime.save(message);
   });
 
   ipcMain.handle("baby-menu:git:rollback", async (): Promise<GitActionResult> => {
     return agentRuntime.rollback();
+  });
+
+  ipcMain.handle("baby-menu:git:status", async (): Promise<GitSessionSnapshot | null> => {
+    return agentRuntime.currentSessionSnapshot();
   });
 
   ipcMain.handle("baby-menu:capabilities:list", async () => {

--- a/src/main/popover.ts
+++ b/src/main/popover.ts
@@ -12,7 +12,7 @@ export type Size = {
 };
 
 export const DEFAULT_POPOVER_SIZE: Size = {
-  width: 360,
+  width: 504,
   height: 620,
 };
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,6 +14,7 @@ const api: BabyMenuApi = {
   git: {
     save: (message?: string) => ipcRenderer.invoke("baby-menu:git:save", message),
     rollback: () => ipcRenderer.invoke("baby-menu:git:rollback"),
+    status: () => ipcRenderer.invoke("baby-menu:git:status"),
   },
   agent: {
     send: (prompt: string) => ipcRenderer.invoke("baby-menu:agent:send", prompt),
@@ -22,6 +23,7 @@ const api: BabyMenuApi = {
       ipcRenderer.on("baby-menu:agent:status", handler);
       return () => ipcRenderer.removeListener("baby-menu:agent:status", handler);
     },
+    getActiveTurn: () => ipcRenderer.invoke("baby-menu:agent:active-turn"),
   },
   capabilities: {
     list: () => ipcRenderer.invoke("baby-menu:capabilities:list"),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Power, Settings, X } from "lucide-react";
-import { Button } from "../ui";
+import { Button, Tooltip } from "../ui";
 import { AgentChat } from "./agent/AgentChat";
 import { MenuSurface } from "./menu/MenuSurface";
 import { SettingsView } from "./settings/SettingsView";
@@ -46,23 +46,29 @@ export function App() {
           </span>
         )}
         {view === "settings" ? (
-          <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="close settings" onClick={closeSettings}>
-            <X className="size-4" />
-          </Button>
+          <Tooltip content="Close settings">
+            <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="close settings" onClick={closeSettings}>
+              <X className="size-4" />
+            </Button>
+          </Tooltip>
         ) : (
           <div className="flex items-center gap-1">
-            <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="open settings" onClick={openSettings}>
-              <Settings className="size-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="w-7 px-0 hover:text-signal-danger"
-              aria-label="quit baby_menu"
-              onClick={quitApp}
-            >
-              <Power className="size-4" />
-            </Button>
+            <Tooltip content="Open settings">
+              <Button variant="ghost" size="sm" className="w-7 px-0" aria-label="open settings" onClick={openSettings}>
+                <Settings className="size-4" />
+              </Button>
+            </Tooltip>
+            <Tooltip content="Quit baby menu">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="w-7 px-0 hover:text-signal-danger"
+                aria-label="quit baby_menu"
+                onClick={quitApp}
+              >
+                <Power className="size-4" />
+              </Button>
+            </Tooltip>
           </div>
         )}
       </header>

--- a/src/renderer/agent/AgentChat.tsx
+++ b/src/renderer/agent/AgentChat.tsx
@@ -58,7 +58,7 @@ function Composer({ onSend }: { onSend: (prompt: string) => void | Promise<void>
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="ask the agent"
+          placeholder="talk to the baby"
           rows={1}
         />
         <button

--- a/src/renderer/agent/useAgentRuntime.ts
+++ b/src/renderer/agent/useAgentRuntime.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { GitSessionSnapshot } from "../../shared/contracts";
 
 const unavailableText = "open baby_menu from the tray to talk to the agent";
@@ -8,6 +8,10 @@ export type AgentRun = {
   title: string;
   startedAt: number;
   statusText?: string;
+  // True when this run strip was restored from the main process (a turn that is
+  // still running but whose original send() promise lives in an unmounted
+  // instance). Recovered runs are polled until the turn ends.
+  recovered?: boolean;
 };
 
 export type AgentSessionNotice =
@@ -34,6 +38,54 @@ export function useAgentRuntime() {
       setRun((current) => (current ? { ...current, statusText: status.text } : current));
     });
   }, []);
+
+  // Reconcile renderer state from the main process. The run strip and the
+  // Keep/Rollback prompt are otherwise ephemeral renderer state, so remounting the
+  // popover view (returning from Settings, or an HMR/window reload) would drop a
+  // turn that is still running or a change session that is still open. Main is the
+  // source of truth: if a turn is running, restore the run strip; once it finishes,
+  // surface the pending prompt. This is why the prompt no longer appears mid-build.
+  const reconcile = useCallback(async () => {
+    const api = window.babyMenu;
+    if (!api) return;
+
+    const turn = await api.agent.getActiveTurn();
+    if (turn) {
+      // Do not clobber a live run this instance is already driving via send().
+      setRun((current) =>
+        current && !current.recovered
+          ? current
+          : {
+              id: current?.id ?? crypto.randomUUID(),
+              title: turn.title,
+              startedAt: turn.startedAt,
+              statusText: current?.statusText ?? "Working...",
+              recovered: true,
+            },
+      );
+      return;
+    }
+
+    setRun((current) => (current?.recovered ? null : current));
+    const snapshot = await api.git.status();
+    if (snapshot) {
+      const notice = sessionNoticeForSnapshot(snapshot);
+      if (notice) setPendingChange(notice);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reconcile();
+  }, [reconcile]);
+
+  // While a restored run strip is showing (a turn whose send() promise is not in
+  // this instance), poll until the turn ends so the prompt flips in at the right
+  // time. Live sends resolve their own promise and never set `recovered`.
+  useEffect(() => {
+    if (!run?.recovered) return undefined;
+    const timer = window.setInterval(() => void reconcile(), 1000);
+    return () => window.clearInterval(timer);
+  }, [run?.recovered, reconcile]);
 
   async function send(prompt: string) {
     const trimmed = prompt.trim();
@@ -134,6 +186,20 @@ function sessionNoticeForResult(
     kind: "blocked",
     summary: "Finish this change first",
     hint: "keep or undo before asking again",
+  };
+}
+
+// Builds a pending notice from a re-hydrated session snapshot. There is no
+// assistant text after a reload, so the summary falls back to the snapshot
+// message. Returns null when the session can no longer be saved or rolled back.
+function sessionNoticeForSnapshot(snapshot: GitSessionSnapshot): AgentSessionNotice | null {
+  if (!snapshot.canSave && !snapshot.canRollback) return null;
+  return {
+    kind: "pending",
+    summary: snapshot.message?.trim() || "Unsaved agent changes",
+    hint: "keep it, or undo",
+    canKeep: snapshot.canSave,
+    canUndo: snapshot.canRollback,
   };
 }
 

--- a/src/renderer/menu/WidgetHost.tsx
+++ b/src/renderer/menu/WidgetHost.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
-import { RefreshCw } from "lucide-react";
 import type { RefreshableBabyMenuWidget } from "../../shared/contracts";
 import { helloWorldWidget } from "../../../extensions/hello-world/widget";
-import { Button } from "../../ui";
 import { importRuntimeModule, loadExtensionModules, type RuntimeModuleImporter } from "../extension-modules";
 import { useViewRefresh } from "./useViewRefresh";
 
@@ -11,7 +9,9 @@ export type RuntimeWidgetImporter = RuntimeModuleImporter;
 const DEFAULT_RUNTIME_REFRESH_INTERVAL_MS = 1000;
 
 function WidgetCard({ widget }: { widget: RefreshableBabyMenuWidget }) {
-  const { refreshNow } = useViewRefresh({
+  // Drives automatic refresh only: once each time the popover opens, plus the
+  // optional interval while visible. There is no manual refresh control.
+  useViewRefresh({
     id: widget.id,
     viewRefreshIntervalMs: widget.viewRefreshIntervalMs,
     refreshView: widget.refreshView ?? (() => undefined),
@@ -21,15 +21,6 @@ function WidgetCard({ widget }: { widget: RefreshableBabyMenuWidget }) {
     <article className="widget">
       <header className="w-head">
         <h3 className="key">{widget.title}</h3>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="refresh -mr-1 px-1.5"
-          onClick={refreshNow}
-          aria-label={`refresh ${widget.title}`}
-        >
-          <RefreshCw className="size-3.5" />
-        </Button>
       </header>
       <div>{widget.render()}</div>
     </article>
@@ -49,16 +40,6 @@ export function WidgetHost({ widgets, runtimeImporter, runtimeRefreshIntervalMs 
     refreshIntervalMs: runtimeRefreshIntervalMs,
   });
   const visibleWidgets = widgets ?? (runtimeWidgets.length > 0 ? runtimeWidgets : [helloWorldWidget]);
-
-  if (visibleWidgets.length === 0) {
-    return (
-      <div className="empty-state">
-        <span className="top">› no widgets</span>
-        <p>ask the agent to add one.</p>
-        <span className="ex">try: battery · cpu temp · calendar</span>
-      </div>
-    );
-  }
 
   return (
     <div className="widget-host">

--- a/src/renderer/menu/useViewRefresh.ts
+++ b/src/renderer/menu/useViewRefresh.ts
@@ -75,6 +75,4 @@ export function useViewRefresh(options: ViewRefreshOptions) {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.id, options.viewRefreshIntervalMs]);
-
-  return { refreshNow };
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -51,7 +51,7 @@ button:disabled,
 }
 
 .app-shell {
-  width: 360px;
+  width: 504px;
   height: auto;
   /* A fixed cap, not a viewport-relative one: the viewport height equals the
      auto-sized window, so capping to it would ratchet the popover - it could
@@ -154,20 +154,6 @@ button:disabled,
   text-transform: uppercase;
 }
 
-.widget .refresh {
-  border: 0;
-  background: transparent;
-  color: var(--ink-faint);
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  padding: 2px 4px;
-  transition: color var(--motion-fast) var(--ease);
-}
-
-.widget .refresh:hover {
-  color: var(--signal-live);
-}
 
 .quota-widget,
 .widget > div {
@@ -229,30 +215,6 @@ button:disabled,
   color: var(--ink-soft);
   letter-spacing: 0.14em;
   text-transform: uppercase;
-}
-
-.empty-state {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 14px;
-  border: 1px dashed var(--line-faint);
-  border-radius: var(--radius-sm);
-}
-
-.empty-state .top {
-  color: var(--ink-200);
-  font-size: 12px;
-}
-
-.empty-state p {
-  color: var(--ink-soft);
-  font-size: 11px;
-}
-
-.empty-state .ex {
-  color: var(--ink-faint);
-  font-size: 10px;
 }
 
 .runstrip {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -37,6 +37,13 @@ export type AgentRuntimeStatus = {
   eventType: "text_delta";
 };
 
+// The turn currently executing in the main process. `startedAt` is an epoch ms
+// timestamp so the renderer can render the elapsed timer after a remount.
+export type AgentActiveTurn = {
+  title: string;
+  startedAt: number;
+};
+
 export type BabyMenuAgentOption = {
   name: string;
   label: string;
@@ -164,10 +171,20 @@ export type BabyMenuApi = {
   git: {
     save: (message?: string) => Promise<GitActionResult>;
     rollback: () => Promise<GitActionResult>;
+    // Snapshot of the outstanding agent change session, or null when none is open
+    // OR a turn is still running. Lets the renderer re-hydrate a pending
+    // Keep/Rollback prompt after a reload, since that prompt is otherwise ephemeral
+    // renderer state. Returns null mid-turn so the prompt never appears before the
+    // build finishes; pair with agent.getActiveTurn to restore the run strip.
+    status: () => Promise<GitSessionSnapshot | null>;
   };
   agent: {
     send: (prompt: string) => Promise<AgentChatResult>;
     onStatus: (listener: (status: AgentRuntimeStatus) => void) => () => void;
+    // The turn currently running in the main process, or null. Lets the renderer
+    // restore the in-progress run strip after the popover view is remounted (e.g.
+    // returning from Settings) instead of losing it or showing a premature prompt.
+    getActiveTurn: () => Promise<AgentActiveTurn | null>;
   };
   capabilities: {
     list: () => Promise<BabyMenuCapabilityDescriptor[]>;

--- a/src/ui/Badge.tsx
+++ b/src/ui/Badge.tsx
@@ -30,16 +30,20 @@ const dotTone = {
   muted: "bg-ink-soft",
 } as const;
 
-export type StatusDotProps = ComponentProps<"span"> & { tone?: keyof typeof dotTone };
+export type StatusDotProps = ComponentProps<"span"> & {
+  tone?: keyof typeof dotTone;
+  // Slowly fades the dot in and out to signal a live / breathing state.
+  pulse?: boolean;
+};
 
 // The canonical Monochrome Lab signal: a small glowing dot. Pair with a terse
 // uppercase status word next to it.
-export function StatusDot({ className, tone = "live", ...props }: StatusDotProps) {
+export function StatusDot({ className, tone = "live", pulse = false, ...props }: StatusDotProps) {
   return (
     <span
       data-slot="status-dot"
       aria-hidden="true"
-      className={cn("inline-block size-1.5 rounded-full", dotTone[tone], className)}
+      className={cn("inline-block size-1.5 rounded-full", dotTone[tone], pulse && "animate-pulse", className)}
       {...props}
     />
   );

--- a/src/ui/Tooltip.tsx
+++ b/src/ui/Tooltip.tsx
@@ -7,19 +7,21 @@ export type TooltipProps = {
   children: ReactNode;
   className?: string;
   side?: TooltipPrimitive.TooltipContentProps["side"];
+  defaultOpen?: boolean;
 };
 
 // Self-contained tooltip: wraps a trigger and shows quiet help text. Provider is
-// included so widgets do not need to mount one.
-export function Tooltip({ content, children, className, side = "top" }: TooltipProps) {
+// included so widgets do not need to mount one. Unlike Dialog/Select/Dropdown,
+// the content is intentionally NOT marked data-bm-overlay: a tooltip is a small
+// positioned hint and must not make the popover grow to the full overlay height.
+export function Tooltip({ content, children, className, side = "top", defaultOpen }: TooltipProps) {
   return (
     <TooltipPrimitive.Provider delayDuration={200}>
-      <TooltipPrimitive.Root>
+      <TooltipPrimitive.Root defaultOpen={defaultOpen}>
         <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
         <TooltipPrimitive.Portal>
           <TooltipPrimitive.Content
             data-slot="tooltip-content"
-            data-bm-overlay=""
             side={side}
             sideOffset={6}
             className={cn(

--- a/tests/agent-chat.test.tsx
+++ b/tests/agent-chat.test.tsx
@@ -3,9 +3,12 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentChat } from "../src/renderer/agent/AgentChat";
-import type { AgentChatResult, AgentRuntimeStatus } from "../src/shared/contracts";
+import type { AgentActiveTurn, AgentChatResult, AgentRuntimeStatus, GitSessionSnapshot } from "../src/shared/contracts";
 
-function installBabyMenuAgentMock() {
+function installBabyMenuAgentMock({
+  session = null,
+  activeTurn = null,
+}: { session?: GitSessionSnapshot | null; activeTurn?: AgentActiveTurn | null } = {}) {
   let statusListener: ((status: AgentRuntimeStatus) => void) | null = null;
   window.babyMenu = {
     recipes: {
@@ -14,6 +17,7 @@ function installBabyMenuAgentMock() {
     git: {
       save: vi.fn(),
       rollback: vi.fn(),
+      status: vi.fn(async () => session),
     },
     agent: {
       send: vi.fn(() => new Promise<AgentChatResult>(() => undefined)),
@@ -23,6 +27,7 @@ function installBabyMenuAgentMock() {
           statusListener = null;
         };
       }),
+      getActiveTurn: vi.fn(async () => activeTurn),
     },
     capabilities: {
       list: vi.fn(),
@@ -70,14 +75,14 @@ describe("AgentChat", () => {
     installBabyMenuAgentMock();
     render(<AgentChat />);
 
-    const composer = screen.getByPlaceholderText("ask the agent");
+    const composer = screen.getByPlaceholderText("talk to the baby");
     fireEvent.change(composer, { target: { value: "add a CPU temperature widget" } });
     fireEvent.submit(composer.closest("form")!);
 
     expect(await screen.findByText("› add a CPU temperature widget")).toBeTruthy();
     expect(screen.getByText("Working...")).toBeTruthy();
     expect(screen.queryByPlaceholderText("agent working")).toBeNull();
-    expect(screen.queryByPlaceholderText("ask the agent")).toBeNull();
+    expect(screen.queryByPlaceholderText("talk to the baby")).toBeNull();
     expect(screen.queryByRole("button", { name: "send" })).toBeNull();
   });
 
@@ -85,7 +90,7 @@ describe("AgentChat", () => {
     const agent = installBabyMenuAgentMock();
     render(<AgentChat />);
 
-    const composer = screen.getByPlaceholderText("ask the agent");
+    const composer = screen.getByPlaceholderText("talk to the baby");
     fireEvent.change(composer, { target: { value: "summarize my pull requests" } });
     fireEvent.submit(composer.closest("form")!);
 
@@ -98,5 +103,52 @@ describe("AgentChat", () => {
     });
 
     expect(screen.getByText("I found two pull requests")).toBeTruthy();
+  });
+
+  it("restores the in-progress run strip (not a Keep/Undo prompt) when a turn is still running on mount", async () => {
+    // Mid-build, the popover view can remount (returning from Settings). Main is
+    // the source of truth: it reports an active turn, so the run strip comes back
+    // and the Keep/Undo prompt must NOT appear yet.
+    installBabyMenuAgentMock({
+      activeTurn: { title: "add a codex widget", startedAt: Date.now() - 3_000 },
+      // git.status would return null mid-turn, but assert independently of it.
+      session: { startedClean: true, canSave: true, canRollback: true, head: null },
+    });
+    render(<AgentChat />);
+
+    expect(await screen.findByText("› add a codex widget")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Keep" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Undo" })).toBeNull();
+  });
+
+  it("re-hydrates a pending Keep/Undo prompt from an outstanding session on mount", async () => {
+    installBabyMenuAgentMock({
+      session: {
+        startedClean: true,
+        canSave: true,
+        canRollback: true,
+        head: null,
+        message: "Review the generated changes, then Save or Rollback.",
+      },
+    });
+    render(<AgentChat />);
+
+    expect(await screen.findByRole("button", { name: "Keep" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Undo" })).toBeTruthy();
+    expect(screen.getByText("Review the generated changes, then Save or Rollback.")).toBeTruthy();
+  });
+
+  it("does not show a prompt when no change session is open on mount", async () => {
+    const agent = installBabyMenuAgentMock({ session: null });
+    render(<AgentChat />);
+
+    // Let the mount-time git.status() resolve before asserting absence.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByRole("button", { name: "Keep" })).toBeNull();
+    expect(screen.getByPlaceholderText("talk to the baby")).toBeTruthy();
+    void agent;
   });
 });

--- a/tests/agent-runtime.test.ts
+++ b/tests/agent-runtime.test.ts
@@ -356,3 +356,54 @@ describe("agent runtime switching", () => {
     expect(runtime.currentAgent).toBe("codex");
   });
 });
+
+describe("agent runtime change-session snapshot", () => {
+  function buildRuntime() {
+    const runtime = new BabyMenuAgentRuntime("/repo", { agentName: "claude" });
+    const internals = runtime as unknown as {
+      activeSession: unknown;
+      activeTurn: boolean;
+      activeTurnInfo: { title: string; startedAt: number } | null;
+    };
+    return { runtime, internals };
+  }
+
+  it("returns null when no change session is open", () => {
+    const { runtime } = buildRuntime();
+    expect(runtime.currentSessionSnapshot()).toBeNull();
+  });
+
+  it("returns null when the open session can no longer be saved or rolled back", () => {
+    const { runtime, internals } = buildRuntime();
+    const snapshot = vi.fn();
+    internals.activeSession = { canSave: false, canRollback: false, snapshot };
+    expect(runtime.currentSessionSnapshot()).toBeNull();
+    expect(snapshot).not.toHaveBeenCalled();
+  });
+
+  it("returns the active session snapshot so the renderer can re-hydrate the prompt", () => {
+    const { runtime, internals } = buildRuntime();
+    const snap = { startedClean: true, canSave: true, canRollback: true, head: null, message: "m" };
+    internals.activeSession = { canSave: true, canRollback: true, snapshot: vi.fn(() => snap) };
+    expect(runtime.currentSessionSnapshot()).toBe(snap);
+  });
+
+  it("does NOT report a saveable snapshot while a turn is still running", () => {
+    const { runtime, internals } = buildRuntime();
+    // The change session is created at the start of a turn, so it is saveable the
+    // whole time the build runs - but the renderer must not show Keep/Rollback yet.
+    const snapshot = vi.fn();
+    internals.activeSession = { canSave: true, canRollback: true, snapshot };
+    internals.activeTurn = true;
+    expect(runtime.currentSessionSnapshot()).toBeNull();
+    expect(snapshot).not.toHaveBeenCalled();
+  });
+
+  it("exposes the running turn so the renderer can restore the run strip", () => {
+    const { runtime, internals } = buildRuntime();
+    expect(runtime.currentTurn()).toBeNull();
+    const info = { title: "add a codex widget", startedAt: 1_700_000_000_000 };
+    internals.activeTurnInfo = info;
+    expect(runtime.currentTurn()).toBe(info);
+  });
+});

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -186,7 +186,7 @@ describe("startBabyMenuApp", () => {
 
     popoverController.setContentHeight(333);
 
-    expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 360, height: 333 });
+    expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 504, height: 333 });
   });
 
   it("starts the background scheduler and only forwards task-run events to visible renderer", async () => {

--- a/tests/dev-launcher.test.ts
+++ b/tests/dev-launcher.test.ts
@@ -134,6 +134,10 @@ describe("dev launcher", () => {
 
     expect(status).toBe(0);
     expect(harness.removedDirs).toContain(devExtensionsDir);
+    // Reset must also clear the embedded agent's persistent conversation, or the
+    // agent rebuilds widgets from its prior context and never re-reads updated
+    // recipes. The session store lives outside extensions-dev, under .cache.
+    expect(harness.removedDirs).toContain(join("/repo", ".cache", "baby-menu", "acp-sessions"));
     expect(harness.createdDirs).toContain(devExtensionsDir);
     expect(harness.copiedFiles).toContainEqual({
       source: join("/repo", "extensions", "AGENTS.md"),

--- a/tests/extension-layout.test.ts
+++ b/tests/extension-layout.test.ts
@@ -12,13 +12,12 @@ describe("extension layout", () => {
     expect(widget).toContain("helloWorldWidget");
     expect(widget).toContain("RefreshableBabyMenuWidget");
     expect(widget).toContain("hello world");
-    expect(widget).toContain("tell baby_menu what to build");
-    // The starter widget exemplifies the design system: kit component + token utilities.
-    expect(widget).toContain("@babymenu/ui");
-    expect(widget).toContain("StatusDot");
+    expect(widget).toContain("tell baby menu what you would like it to become");
+    // The starter widget exemplifies the design system via token utilities.
     expect(widget).toContain("text-3xl");
+    expect(widget).toContain("text-signal-live");
     expect(widget).toContain("examples");
-    expect(widget).toContain("add a battery widget that shows current charge and power source");
+    expect(widget).toContain("add a widget tracking my weekly claude code quota");
     expect(widget).not.toContain("quick asks");
     expect(widget).not.toContain("className=\"src\"");
     // Migrated off legacy inline token styles.
@@ -39,11 +38,31 @@ describe("extension layout", () => {
     expect(instructions).not.toContain("rootDir` is the active extension workspace root");
   });
 
+  it("steers extension agents to real data and to verify dependencies via web search", async () => {
+    const instructions = await readFile(resolve(import.meta.dirname, "../extensions/AGENTS.md"), "utf8");
+
+    // Real data only - no silent mock fallback (mirrors the quota recipes).
+    expect(instructions).toContain("do not fabricate or silently fall back to mock data");
+    // Encourage confirming current dependency / API details rather than guessing.
+    expect(instructions).toContain("use web search to confirm the latest information");
+  });
+
+  it("tells extension agents to colocate tests inside the extension directory", async () => {
+    const instructions = await readFile(resolve(import.meta.dirname, "../extensions/AGENTS.md"), "utf8");
+
+    expect(instructions).toContain("Colocate tests inside your extension directory");
+    expect(instructions).toContain("<extension-id>/<name>.test.ts");
+    // The old guidance steered agents into the host repo's tests/ directory, which
+    // dangles and breaks the whole suite once the dev workspace is reset.
+    expect(instructions).not.toContain("Add tests under the repo-level `tests/` directory");
+    expect(instructions).not.toContain("pnpm vitest run tests/<name>.test.ts");
+  });
+
   it("exposes runtime widget design guidance to extension agents", async () => {
     const instructions = await readFile(resolve(import.meta.dirname, "../extensions/AGENTS.md"), "utf8");
 
     expect(instructions).toContain("Monochrome Lab");
-    expect(instructions).toContain("Design for a 360px macOS tray popover");
+    expect(instructions).toContain("Design for a 504px macOS tray popover");
     // The design system is delivered as components, not a wall of CSS classes.
     expect(instructions).toContain("@babymenu/ui");
     expect(instructions).toContain("DataTable");

--- a/tests/hello-world-widget.test.tsx
+++ b/tests/hello-world-widget.test.tsx
@@ -1,0 +1,42 @@
+/* @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { helloWorldWidget } from "../extensions/hello-world/widget";
+
+const writeText = vi.fn(async () => undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("hello-world widget examples", () => {
+  it("renders each example as a clickable button", () => {
+    render(<>{helloWorldWidget.render()}</>);
+    const button = screen.getByRole("button", {
+      name: /add a widget tracking my weekly claude code quota/i,
+    });
+    expect(button.tagName).toBe("BUTTON");
+  });
+
+  it("copies the example prompt to the clipboard when clicked", async () => {
+    render(<>{helloWorldWidget.render()}</>);
+    const prompt = "add a widget tracking my weekly claude code quota";
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(prompt, "i") }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(prompt));
+  });
+
+  it("shows transient copied feedback after a click", async () => {
+    render(<>{helloWorldWidget.render()}</>);
+    const prompt = "add a widget showing current cpu and memory usage %";
+    fireEvent.click(screen.getByRole("button", { name: new RegExp(prompt, "i") }));
+
+    await waitFor(() => expect(screen.getByText(/copied/i)).toBeTruthy());
+  });
+});

--- a/tests/ipc-capabilities.test.ts
+++ b/tests/ipc-capabilities.test.ts
@@ -33,6 +33,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
 
     registerIpcHandlers(rootDir, agentRuntime, undefined, undefined, undefined, undefined, undefined, { recipesDir });
@@ -53,6 +55,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
     const serverActions = {
       list: vi.fn(async () => [{ id: "demo.ping", extensionId: "demo", action: "ping" }]),
@@ -84,6 +88,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
 
     registerIpcHandlers(
@@ -111,6 +117,8 @@ describe("capabilities IPC", () => {
       }),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
 
     registerIpcHandlers("/repo", agentRuntime);
@@ -127,7 +135,7 @@ describe("capabilities IPC", () => {
   it("registers SQL database channels backed by a shared store", async () => {
     const { registerIpcHandlers } = await import("../src/main/ipc");
     const { createExtensionDatabase } = await import("../src/main/extension-database");
-    const agentRuntime = { send: vi.fn(), save: vi.fn(), rollback: vi.fn() };
+    const agentRuntime = { send: vi.fn(), save: vi.fn(), rollback: vi.fn(), currentSessionSnapshot: vi.fn(), currentTurn: vi.fn() };
     const database = createExtensionDatabase(":memory:");
 
     registerIpcHandlers("/repo", agentRuntime, undefined, undefined, undefined, undefined, undefined, { database });
@@ -149,6 +157,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
     const widgetModules = {
       list: vi.fn(async () => [{ id: "cpu-temp.widget", extensionId: "cpu-temp", moduleUrl: "/@fs/cpu-temp/widget.tsx" }]),
@@ -168,6 +178,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
     const popover = {
       setContentHeight: vi.fn(),
@@ -187,6 +199,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
     const appController = { quit: vi.fn() };
 
@@ -202,6 +216,8 @@ describe("capabilities IPC", () => {
       send: vi.fn(),
       save: vi.fn(),
       rollback: vi.fn(),
+      currentSessionSnapshot: vi.fn(),
+      currentTurn: vi.fn(),
     };
     const settings = {
       get: vi.fn(async () => ({ openAtLogin: false, agentName: "claude", agents: [] })),

--- a/tests/popover-position.test.ts
+++ b/tests/popover-position.test.ts
@@ -18,16 +18,16 @@ function createRendererWindow() {
 
 describe("calculatePopoverBounds", () => {
   it("uses the design-system tray popover width by default", () => {
-    expect(DEFAULT_POPOVER_SIZE.width).toBe(360);
-    expect(createPopoverOptions("/app/preload.js").width).toBe(360);
+    expect(DEFAULT_POPOVER_SIZE.width).toBe(504);
+    expect(createPopoverOptions("/app/preload.js").width).toBe(504);
   });
 
   it("clamps content-driven popover height to a usable range", () => {
     expect(MIN_POPOVER_HEIGHT).toBe(220);
     expect(MAX_POPOVER_HEIGHT).toBe(720);
-    expect(responsivePopoverSize(140)).toEqual({ width: 360, height: 220 });
-    expect(responsivePopoverSize(420.2)).toEqual({ width: 360, height: 421 });
-    expect(responsivePopoverSize(960)).toEqual({ width: 360, height: 720 });
+    expect(responsivePopoverSize(140)).toEqual({ width: 504, height: 220 });
+    expect(responsivePopoverSize(420.2)).toEqual({ width: 504, height: 421 });
+    expect(responsivePopoverSize(960)).toEqual({ width: 504, height: 720 });
   });
 
   it("centers the popover under a menu bar tray icon", () => {

--- a/tests/renderer-layout.test.ts
+++ b/tests/renderer-layout.test.ts
@@ -9,7 +9,7 @@ describe("renderer layout styles", () => {
     const css = await readFile(stylesPath, "utf8");
 
     expect(css).toContain('@import url("./colors_and_type.css")');
-    expect(css).toMatch(/\.app-shell\s*\{[^}]*width:\s*360px/s);
+    expect(css).toMatch(/\.app-shell\s*\{[^}]*width:\s*504px/s);
     expect(css).toMatch(/\.app-shell\s*\{[^}]*background:\s*var\(--bg-stage\)/s);
     expect(css).toMatch(/\.app-shell\s*\{[^}]*border-radius:\s*var\(--radius-xl\)/s);
   });

--- a/tests/renderer-monochrome-lab.test.tsx
+++ b/tests/renderer-monochrome-lab.test.tsx
@@ -12,6 +12,7 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
     git: {
       save: vi.fn(async () => ({ ok: true, commit: "abcdef123456" })),
       rollback: vi.fn(async () => ({ ok: true })),
+      status: vi.fn(async () => null),
     },
     agent: {
       send: vi.fn(async () => ({
@@ -25,6 +26,7 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
         },
       })),
       onStatus: vi.fn(() => () => undefined),
+      getActiveTurn: vi.fn(async () => null),
     },
     capabilities: {
       list: vi.fn(async () => []),
@@ -84,7 +86,7 @@ describe("Monochrome Lab renderer", () => {
     expect(
       screen.getByText((_, element) => element?.classList.contains("mark") === true && element.textContent === "baby_menu"),
     ).toBeTruthy();
-    expect(screen.getByPlaceholderText("ask the agent")).toBeTruthy();
+    expect(screen.getByPlaceholderText("talk to the baby")).toBeTruthy();
     expect(screen.queryByLabelText("Agent chat")).toBeNull();
     expect(screen.queryByText("dev-mode menu bar")).toBeNull();
     expect(screen.queryByText("live repo")).toBeNull();
@@ -102,12 +104,13 @@ describe("Monochrome Lab renderer", () => {
             }),
         ),
         onStatus: vi.fn(() => () => undefined),
+      getActiveTurn: vi.fn(async () => null),
       },
     });
 
     render(<App />);
 
-    fireEvent.change(screen.getByPlaceholderText("ask the agent"), {
+    fireEvent.change(screen.getByPlaceholderText("talk to the baby"), {
       target: { value: "add a cpu temperature widget" },
     });
     fireEvent.click(screen.getByRole("button", { name: "send" }));
@@ -144,14 +147,14 @@ describe("Monochrome Lab renderer", () => {
 
     render(<App />);
 
-    fireEvent.change(screen.getByPlaceholderText("ask the agent"), {
+    fireEvent.change(screen.getByPlaceholderText("talk to the baby"), {
       target: { value: "add a battery widget" },
     });
     fireEvent.click(screen.getByRole("button", { name: "send" }));
 
     await screen.findByText("Added a CPU temperature widget");
 
-    fireEvent.change(screen.getByPlaceholderText("ask the agent"), {
+    fireEvent.change(screen.getByPlaceholderText("talk to the baby"), {
       target: { value: "add weather" },
     });
     fireEvent.click(screen.getByRole("button", { name: "send" }));

--- a/tests/renderer-widget-host.test.tsx
+++ b/tests/renderer-widget-host.test.tsx
@@ -11,10 +11,12 @@ function installBabyMenuApi(widgets: BabyMenuApi["widgets"]) {
     git: {
       save: vi.fn(async () => ({ ok: true })),
       rollback: vi.fn(async () => ({ ok: true })),
+      status: vi.fn(async () => null),
     },
     agent: {
       send: vi.fn(async () => ({ assistantText: "done" })),
       onStatus: vi.fn(() => () => undefined),
+      getActiveTurn: vi.fn(async () => null),
     },
     capabilities: {
       list: vi.fn(async () => []),

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -15,8 +15,8 @@ function installBabyMenuApi(settings?: Partial<BabyMenuSettings>): BabyMenuApi {
   let current = base;
   const api: BabyMenuApi = {
     recipes: { list: vi.fn(async () => []) },
-    git: { save: vi.fn(async () => ({ ok: true })), rollback: vi.fn(async () => ({ ok: true })) },
-    agent: { send: vi.fn(async () => ({ assistantText: "" })), onStatus: vi.fn(() => () => undefined) },
+    git: { save: vi.fn(async () => ({ ok: true })), rollback: vi.fn(async () => ({ ok: true })), status: vi.fn(async () => null) },
+    agent: { send: vi.fn(async () => ({ assistantText: "" })), onStatus: vi.fn(() => () => undefined), getActiveTurn: vi.fn(async () => null) },
     capabilities: { list: vi.fn(async () => []), invoke: vi.fn(async () => undefined) as BabyMenuApi["capabilities"]["invoke"] },
     db: {
       query: vi.fn(async () => []),
@@ -59,7 +59,7 @@ describe("settings view", () => {
     render(<App />);
 
     // Menu view: composer present, no settings controls.
-    expect(screen.getByPlaceholderText("ask the agent")).toBeTruthy();
+    expect(screen.getByPlaceholderText("talk to the baby")).toBeTruthy();
     expect(screen.queryByText("launch at system start")).toBeNull();
 
     // Open settings.
@@ -68,7 +68,7 @@ describe("settings view", () => {
     const toggle = screen.getByRole("switch", { name: "launch at system start" });
     expect(toggle).toBeTruthy();
     // The agent composer is hidden in the settings context.
-    expect(screen.queryByPlaceholderText("ask the agent")).toBeNull();
+    expect(screen.queryByPlaceholderText("talk to the baby")).toBeNull();
 
     // Toggle the setting.
     fireEvent.click(toggle);
@@ -76,7 +76,7 @@ describe("settings view", () => {
 
     // Return to the menu.
     fireEvent.click(screen.getByRole("button", { name: "close settings" }));
-    expect(await screen.findByPlaceholderText("ask the agent")).toBeTruthy();
+    expect(await screen.findByPlaceholderText("talk to the baby")).toBeTruthy();
     expect(screen.queryByText("launch at system start")).toBeNull();
   });
 

--- a/tests/ui-components.test.tsx
+++ b/tests/ui-components.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { Badge, Button, DataTable, Field, Input, Progress, Skeleton, Sparkline, StatusDot } from "../src/ui";
+import { Badge, Button, DataTable, Field, Input, Progress, Skeleton, Sparkline, StatusDot, Tooltip } from "../src/ui";
 
 describe("@babymenu/ui components", () => {
   it("renders a button with variant styling and a safe default type", () => {
@@ -20,6 +20,18 @@ describe("@babymenu/ui components", () => {
     );
     expect(container.querySelector("[data-slot='status-dot']")?.className).toContain("bg-signal-warn");
     expect(container.querySelector("[data-slot='badge']")?.textContent).toBe("live");
+  });
+
+  it("pulses a status dot when asked", () => {
+    const { container } = render(<StatusDot tone="live" pulse />);
+    const dot = container.querySelector("[data-slot='status-dot']");
+    expect(dot?.className).toContain("animate-pulse");
+  });
+
+  it("does not pulse by default", () => {
+    const { container } = render(<StatusDot tone="live" />);
+    const dot = container.querySelector("[data-slot='status-dot']");
+    expect(dot?.className).not.toContain("animate-pulse");
   });
 
   it("associates a Field label with its control", () => {
@@ -59,6 +71,21 @@ describe("@babymenu/ui components", () => {
     const { container } = render(<Sparkline data={[1, 4, 2, 8, 5]} />);
     const path = container.querySelector("path");
     expect(path?.getAttribute("d")).toMatch(/^M0/);
+  });
+
+  it("does not mark its tooltip content as a full-height overlay", async () => {
+    // The popover grows to the overlay height whenever a [data-bm-overlay] element
+    // exists. A small positioned tooltip must not opt into that, or hovering a
+    // header button stretches the popover.
+    render(
+      <Tooltip content="Open settings" defaultOpen>
+        <button type="button">gear</button>
+      </Tooltip>,
+    );
+    const tip = document.querySelector("[data-slot='tooltip-content']");
+    expect(tip).not.toBeNull();
+    expect(tip?.textContent).toContain("Open settings");
+    expect(tip?.hasAttribute("data-bm-overlay")).toBe(false);
   });
 
   it("renders a skeleton placeholder", () => {

--- a/tests/widget-host.test.tsx
+++ b/tests/widget-host.test.tsx
@@ -47,15 +47,6 @@ describe("useViewRefresh", () => {
     expect(refreshView).toHaveBeenCalledTimes(3);
   });
 
-  it("supports manual refresh", () => {
-    const refreshView = vi.fn();
-
-    const { result } = renderHook(() => useViewRefresh({ id: "quota", viewRefreshIntervalMs: 1000, refreshView }));
-    act(() => result.current.refreshNow());
-
-    expect(refreshView).toHaveBeenCalledTimes(2);
-  });
-
   it("pauses the interval while the popover is hidden and resumes on show", () => {
     vi.useFakeTimers();
     const popover = installPopoverVisibility();


### PR DESCRIPTION
## Intent

The developer was refining Baby Menu’s initial UI, widget behavior, and agent recipe guidance so the app feels clearer and avoids misleading/generated mock data. They wanted specific copy changes in the Hello World/getting started widget, clickable examples that copy prompts, no ready indicator, no battery example, wider popover, no unreachable empty-state hint, no generic manual refresh button, and durable Keep/Rollback state that survives settings navigation or reloads without falsely showing completion mid-build. They also wanted quota-widget recipes for Claude Code and Codex to focus only on data acquisition, align with current credential sources, avoid mock/manual web-parser fallbacks, treat live API responses as canonical, and steer agents away from percent-used versus percent-remaining UI mistakes without prescribing layout. They explicitly required changes to apply to both source/default extensions and dev-mode mirrors where applicable, keep tests passing, update AGENTS.md guidance, and encourage agents to use web search for current dependency/API details when needed.

## What Changed

- Restores active and pending agent turn state through renderer remounts, settings navigation, and reloads so Keep/Undo actions only appear after a completed change session is available.
- Refines the initial Hello World widget, popover sizing, widget refresh behavior, and UI component styling to remove misleading hints and make getting-started examples copy prompts directly.
- Updates extension authoring docs and Claude Code/Codex quota recipes to emphasize real data sources, current credential/API guidance, and avoiding mock or misleading quota fallbacks.

## Risk Assessment

⚠️ Medium: The change is well covered conceptually but touches cross-process agent state restoration, renderer remount/reload behavior, and change-session prompts, so lifecycle risk remains even with no material findings identified.

## Testing

Focused Vitest coverage for the changed runtime, IPC, widget, layout, and recipe guidance passed, the full `pnpm test` suite passed, and Chrome-rendered evidence confirms the onboarding widget copy action, active-turn restoration, pending Keep/Undo restoration, and quota recipe surfaces render as intended.

- Evidence: Hello World widget copied prompt screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSRAN0HDYQ0P3AA3924PJ2NX/hello-world-widget-copied.png</code>)
- Evidence: Agent active turn restored screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSRAN0HDYQ0P3AA3924PJ2NX/agent-active-turn-restored.png</code>)
- Evidence: Agent pending Keep/Undo restored screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSRAN0HDYQ0P3AA3924PJ2NX/agent-pending-keep-undo-restored.png</code>)
- Evidence: Claude Code quota recipe rendered screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSRAN0HDYQ0P3AA3924PJ2NX/claude-code-quota-recipe.png</code>)
- Evidence: Codex quota recipe rendered screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSRAN0HDYQ0P3AA3924PJ2NX/codex-quota-recipe.png</code>)
<details>
<summary>Evidence: Copied prompt verification</summary>

```text
Chrome eval returned: "add a widget tracking my weekly claude code quota"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 47117193ab581857cf129ecb35d7f9686feb0f9d..d9df0aa9ed434b03e69ced69c698c084e95f076d`
- `pnpm vitest run tests/agent-chat.test.tsx tests/agent-runtime.test.ts tests/hello-world-widget.test.tsx tests/extension-layout.test.ts tests/ipc-capabilities.test.ts tests/popover-position.test.ts tests/renderer-widget-host.test.tsx tests/widget-host.test.tsx`
- `pnpm test`
- <code>Opened the temporary Hello World widget harness in Chrome, clicked the Claude quota example prompt, verified `document.body.dataset.copiedPrompt` was `add a widget tracking my weekly claude code quota`, and captured a screenshot of the copied state.</code>
- <code>Opened temporary AgentChat state harness pages in Chrome for `?mode=active` and `?mode=pending`, verifying the active turn shows the working strip without Keep/Undo while the completed session shows Keep/Undo.</code>
- <code>Opened `extensions/recipes/claude-code-quota.html` and `extensions/recipes/codex-quota.html` in Chrome and captured rendered recipe screenshots.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
