### PR TITLE
fix: preserve native binaries in universal macOS package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 Keep `typescript` in runtime dependencies unless that compiler path changes.
 `tailwindcss`, `@tailwindcss/postcss`, and `postcss` are externalized for the same reason: `widget-tailwind-css.ts` runs Tailwind in the main process to compile per-widget CSS in packaged mode.
 Keep them in runtime dependencies, and keep the single pinned `postcss` (`pnpm-workspace.yaml` `overrides`) so the Tailwind plugin and the processor share one version.
+Universal macOS packages must run on both Intel and Apple Silicon Macs, so `pnpm-workspace.yaml` keeps Darwin `x64` and `arm64` native prebuilt dependencies installed, and `electron-builder.yml` `x64ArchFiles` must preserve architecture-specific native package files during the universal merge.
 The renderer build adds `@tailwindcss/vite` and aliases `@babymenu/ui` to `src/ui/index.ts` so dev-mode widgets resolve the design system directly.
 
 ### Design system (`@babymenu/ui`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Use TDD for bug fixes and new features.
 - Tests live in `tests/` at the repo root.
 - Run `pnpm typecheck`, `pnpm test`, and `pnpm build` before pushing.
-- Run `pnpm package:mac` when changing packaging, runtime paths, extension compilation, or release behavior.
+- Run `pnpm package:mac` when changing packaging, runtime paths, extension compilation, native dependencies, or release behavior.
+- Keep universal macOS packaging compatible with both Intel and Apple Silicon Macs; native prebuilt packages must be installed for `x64` and `arm64` and preserved in `electron-builder.yml` `x64ArchFiles` when electron-builder merges the app.
 - Keep `pnpm-lock.yaml` changes with dependency changes.
 - Do not commit generated build output, release artifacts, runtime caches, or dev extension workspaces.
 - Do not hand-edit release-please metadata such as `CHANGELOG.md` or `.release-please-manifest.json`.

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 pnpm dev          # run Electron + renderer dev server with a gitignored extensions-dev/ sandbox
 pnpm dev:reset    # wipe extensions-dev/ and agent session cache, then start fresh
 pnpm build        # build main + preload + renderer into out/
-pnpm package:mac  # build and create an ad-hoc-signed .app in release/mac-universal/
-pnpm dist:mac     # build the .app and create a universal DMG in release/
+pnpm package:mac  # build and create an ad-hoc-signed universal .app in release/mac-universal/
+pnpm dist:mac     # build the universal .app and create a universal DMG in release/
 pnpm test         # run all Vitest tests
 pnpm test:e2e     # only e2e tests (spawn real acpx/runtime against acp-mock)
 pnpm typecheck    # tsc --noEmit
@@ -180,6 +180,7 @@ Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the
 Use `pnpm dev:reset` when recipe or extension guidance changes; it also clears `.cache/baby-menu/acp-sessions` so the embedded agent re-reads the fresh copied specs instead of continuing from prior conversation state.
 Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
 Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu.app`.
+The universal package is expected to run on both Intel and Apple Silicon Macs, so macOS native prebuilt dependencies must stay installed for `x64` and `arm64` and must stay covered by `electron-builder.yml` `x64ArchFiles` when new native packages are added.
 
 Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,7 +29,7 @@ mac:
   identity: null
   hardenedRuntime: false
   gatekeeperAssess: false
-  x64ArchFiles: Contents/Resources/app.asar.unpacked/node_modules/{@esbuild/**,esbuild/**}
+  x64ArchFiles: Contents/Resources/app.asar.unpacked/node_modules/{@esbuild/**,esbuild/**,@tailwindcss/oxide-*/**,lightningcss-*/**,lightningcss/**}
 
 dmg:
   artifactName: Baby-Menu-${version}-universal.dmg

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,15 @@ allowBuilds:
 
 overrides:
   postcss: ^8.5.15
+
+# Install macOS prebuilt native binaries for both architectures so the
+# universal electron-builder package runs on Intel and Apple Silicon.
+# "current" keeps the host platform's binaries for dev/CI on other OSes.
+supportedArchitectures:
+  os:
+    - current
+    - darwin
+  cpu:
+    - current
+    - x64
+    - arm64


### PR DESCRIPTION
## Intent

{"summary":"The developer wanted the failed GitHub Actions release pipeline investigated and fixed, specifically the macOS release packaging failure. After learning the initial packaging fix would not support Intel Macs, they explicitly required true Intel Mac support for the universal app. The resulting requirement was to ensure both arm64 and x64 macOS native dependencies are installed and bundled, rather than merely suppressing electron-builder's universal merge error."}

## What Changed

- Configure `pnpm` to install Darwin `x64` and `arm64` native prebuilt dependencies alongside the current platform architecture.
- Expand `electron-builder.yml` `x64ArchFiles` so esbuild, Tailwind Oxide, and Lightning CSS native package files are preserved during universal app merging.
- Document the universal macOS packaging requirement in the contributor and developer guidance.

## Risk Assessment

✅ Low: The change is narrowly scoped to pnpm optional dependency architecture selection and electron-builder universal merge patterns, with no material code-level risks found in the reviewed diff.

## Testing

Ran the targeted release configuration tests, built the real universal macOS `.app`, then inspected the packaged app executable and unpacked native dependency binaries to confirm both Intel x86_64 and Apple Silicon arm64 support are present; all checks passed.

<details>
<summary>Evidence: Universal native binary inspection</summary>

`Shows the packaged app executable is universal and the bundled @tailwindcss/oxide, lightningcss, and @esbuild native binaries include both x86_64 and arm64 variants.`

```text
Universal app executable:
release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu (for architecture x86_64):	Mach-O 64-bit executable x86_64
release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu (for architecture arm64):	Mach-O 64-bit executable arm64

Packaged native dependency directories:
@esbuild
@tailwindcss
esbuild
fsevents
lightningcss-darwin-arm64
lightningcss-darwin-x64

Tailwind native modules:
oxide-darwin-arm64
oxide-darwin-x64

Esbuild native modules:
darwin-arm64
darwin-x64

Native binary architectures:
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/@tailwindcss/oxide-darwin-x64/tailwindcss-oxide.darwin-x64.node:     Mach-O 64-bit dynamically linked shared library x86_64
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/@tailwindcss/oxide-darwin-arm64/tailwindcss-oxide.darwin-arm64.node: Mach-O 64-bit dynamically linked shared library arm64
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/lightningcss-darwin-x64/lightningcss.darwin-x64.node:                Mach-O 64-bit dynamically linked shared library x86_64
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/lightningcss-darwin-arm64/lightningcss.darwin-arm64.node:            Mach-O 64-bit dynamically linked shared library arm64
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/@esbuild/darwin-x64/bin/esbuild:                                     Mach-O 64-bit executable x86_64
release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules/@esbuild/darwin-arm64/bin/esbuild:                                   Mach-O 64-bit executable arm64
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm vitest run tests/release-config.test.ts`
- `pnpm package:mac`
- `file "release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu"`
- `lipo -archs "release/mac-universal/Baby Menu.app/Contents/MacOS/Baby Menu"`
- <code>Inspected `release/mac-universal/Baby Menu.app/Contents/Resources/app.asar.unpacked/node_modules` and recorded packaged native module directories and binary architectures in the evidence file.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
