### PR TITLE
fix(extensions): ship stable extension contract types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,22 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify generated contract types are up to date
+        run: |
+          set -eu
+          pnpm generate:contracts
+          if ! git diff --quiet -- extensions/babymenu-env.d.ts; then
+            {
+              echo "::error file=extensions/babymenu-env.d.ts::Generated contract types are out of date."
+              echo "extensions/babymenu-env.d.ts no longer matches src/shared/contracts.ts."
+              echo "Run 'pnpm generate:contracts' locally and commit the result."
+              echo
+              git --no-pager diff -- extensions/babymenu-env.d.ts
+            } >&2
+            exit 1
+          fi
+          echo "Generated contract types are up to date."
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,10 @@ Embedded agents launched from baby-menu should work from the active extension wo
 
 ## Commands
 
-- `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md` and `extensions/recipes/`, builds bundled ACP adapters into `out/adapters/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
-- `pnpm dev:reset` - removes `extensions-dev/` and `.cache/baby-menu/acp-sessions`, recreates the dev workspace with the latest `extensions/AGENTS.md` and `extensions/recipes/`, and starts dev mode.
+- `pnpm dev` - runs `scripts/dev.mjs`, prepares a gitignored `extensions-dev/` workspace by copying `extensions/AGENTS.md`, `extensions/babymenu-env.d.ts`, and `extensions/recipes/`, builds bundled ACP adapters into `out/adapters/`, and runs `electron-vite dev` from the current checkout. The app itself sees current uncommitted changes, while the embedded agent is launched inside `extensions-dev/`.
+- `pnpm dev:reset` - removes `extensions-dev/` and `.cache/baby-menu/acp-sessions`, recreates the dev workspace with the latest `extensions/AGENTS.md`, `extensions/babymenu-env.d.ts`, and `extensions/recipes/`, and starts dev mode.
 - `pnpm build` - build main, preload, renderer, and bundled ACP adapter bundles into `out/`.
+- `pnpm generate:contracts` - regenerates `extensions/babymenu-env.d.ts` (the `@babymenu/contracts` surface) from `src/shared/contracts.ts`. Run after changing any extension-facing type or `src/shared/extension-contract-names.ts`, then commit the result; CI fails on a stale file.
 - `pnpm package:mac` - cleans `release/`, builds the app, packages `release/mac-universal/Baby Menu Dev.app`, and ad-hoc signs it for local testing. Local/dev packaging uses `electron-builder.dev.yml`, which overrides `appId` to `com.kunchenguid.baby-menu.dev` and `productName` to `Baby Menu Dev` so locally-built bundles never collide with the released app (`com.kunchenguid.baby-menu`) in macOS LaunchServices. The CI release workflow builds from `electron-builder.yml` directly and keeps the production identity.
 - `pnpm dist:mac` - runs `package:mac` and creates `release/Baby-Menu-<version>-universal.dmg` from the dev bundle.
 - `pnpm test` - run all Vitest tests.
@@ -50,6 +51,8 @@ Three processes, kept deliberately separate:
 
 Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`, `BabyMenuSettingsSection`, `GitSessionSnapshot`, etc. The `Window.babyMenu` global is declared here.
 
+The extension-facing slice of that contract is a generated public surface, treated like the preload bridge and `@babymenu/ui` (see "Design system"). Extensions cannot see `src/shared/contracts.ts` (it lives inside the app bundle, not in the extension workspace), so the host ships those types into the workspace as the `@babymenu/contracts` virtual module, declared in `extensions/babymenu-env.d.ts`. That `.d.ts` is generated from `contracts.ts` by `scripts/generate-extension-dts.mjs` (run `pnpm generate:contracts`); the selected names live in `src/shared/extension-contract-names.ts`, and `BabyMenuExtensionApi` is the window-bridge subset extensions may use. Do not hand-edit `extensions/babymenu-env.d.ts`. After changing any extension-facing type in `contracts.ts`, or the name list, regenerate and commit the result - `tests/extension-contract-surface.test.ts` and the `ci.yml` "Verify generated contract types are up to date" step both fail on a stale file. Extensions import these types with a type-only `import ... from "@babymenu/contracts"`, which the compiler erases and never validates against the runtime import allowlist; importing a value from that specifier is rejected. The committed `babymenu-env.d.ts` is intentionally tracked (not release-only) because typecheck, `pnpm dev`, and packaging all read it. Never tell an extension or its agent to reach back into `../../src/shared/contracts`; that relative path resolves in source mode but does not exist in a packaged install, and chasing it is what previously sent the embedded agent scanning protected home-directory folders.
+
 `src/main/` module index:
 
 - `app.ts` - Electron lifecycle, popover window creation, packaged path setup, extension seeding, preferences, selectable-agent catalog wiring, protocols, tray, and IPC. `package.json#main` points here via `out/main/index.js`.
@@ -63,7 +66,7 @@ Shared types live in `src/shared/contracts.ts` - `BabyMenuApi`, `BabyMenuWidget`
 - `agent-turn-log.ts` - structured per-turn transcript log used by the renderer and tests.
 - `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
 - `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
-- `extension-seeder.ts` - seeds bundled extension templates into the packaged extension workspace.
+- `extension-seeder.ts` - self-heals the packaged extension workspace from the bundled template on every launch: it force-copies the shipped defaults (`AGENTS.md`, `babymenu-env.d.ts`, `recipes/`, and starter extensions) so a stale or edited managed file is restored, while leaving user-created extensions the template does not ship untouched (it never deletes them). Editing a managed default in `~/.baby-menu/extensions` therefore does not persist; change the source under `extensions/` instead.
 - `extension-module-compiler.ts` - compiles extension widget and server modules for production loading; rewrites the `react` and `@babymenu/ui` imports to host protocol modules and rejects any other external import.
 - `widget-tailwind-css.ts` - compiles a widget's authored Tailwind utilities against the `@babymenu/ui` `@theme` (single source of truth, `src/ui/theme.css`) for packaged loading.
 - `widget-module-registry.ts` - discovers widget modules, returning a renderer `/@fs` URL in dev and, in packaged mode, a compiled `baby-menu-widget://` module URL plus a sibling compiled `cssUrl`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Use TDD for bug fixes and new features.
 - Tests live in `tests/` at the repo root.
 - Run `pnpm typecheck`, `pnpm test`, and `pnpm build` before pushing.
+- Run `pnpm generate:contracts` and commit `extensions/babymenu-env.d.ts` after changing extension-facing types or `src/shared/extension-contract-names.ts`.
 - Run `pnpm package:mac` when changing packaging, runtime paths, extension compilation, native dependencies, or release behavior.
 - Local `pnpm package:mac` builds intentionally produce `Baby Menu Dev.app` with bundle id `com.kunchenguid.baby-menu.dev`; release automation uses `electron-builder.yml` directly for the production `Baby Menu.app` identity.
 - Keep universal macOS packaging compatible with both Intel and Apple Silicon Macs; native prebuilt packages must be installed for `x64` and `arm64` and preserved in `electron-builder.yml` `x64ArchFiles` when electron-builder merges the app.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Switching agents resets the current conversation after confirmation.
 ## Install Details
 
 The packaged app stores mutable extensions, the local extension database, caches, agent sessions, custom agent catalog, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets and extension state.
+On launch, packaged Baby Menu refreshes bundled default extension files such as `AGENTS.md`, `babymenu-env.d.ts`, recipes, and starter extensions from the app template while preserving user-created extension directories.
 Baby Menu detects supported agents from the catalog in order: Claude Code (`claude`), then Codex (`codex`).
 Those built-ins run through bundled clean-room ACP adapters that drive the authenticated local CLIs without inheriting user-level agent settings, skills, MCP servers, or extra rules.
 Use Settings to persist an agent choice across launches.
@@ -148,7 +149,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
   Use this store for settings, history, rate baselines, and anything else that must survive reloads.
 - **Background tasks vs view refresh** - `refreshView` / `viewRefreshIntervalMs` keeps a visible widget current and pauses while the popover is hidden; `export const background` in `server.ts` runs on a host-owned timer, clamped to a 60-second minimum, for work that must continue while the popover is closed.
 - **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with internal snapshot save/rollback.
-  Tracked `extensions/` remain the source templates for dev and packaged extension workspaces.
+  Tracked `extensions/` remain the source templates for dev and packaged extension workspaces, including the generated `@babymenu/contracts` declaration in `extensions/babymenu-env.d.ts`.
+- **Stable extension contracts** - extension code imports public host types with type-only `import ... from "@babymenu/contracts"`; the generated declaration is shipped into each extension workspace so extensions never need to reach back into `src/shared/contracts.ts`.
 
 ## Layout
 
@@ -160,6 +162,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, settings, and app controls                        |
 | `src/ui/`                   | Shared `@babymenu/ui` design system for shell and extension renderer surfaces          |
 | `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `BabyMenuSettingsSection`, `GitSessionSnapshot`, etc. |
+| `src/shared/extension-contract-names.ts` | Public type names exported through `@babymenu/contracts`                  |
+| `extensions/babymenu-env.d.ts` | Generated `@babymenu/contracts` declarations copied into extension workspaces       |
 | `extensions/<id>/`          | Tracked extensions (`widget.tsx` descriptors, `components.tsx` views, `server.ts`)      |
 | `extensions/recipes/*.html` | Self-contained widget specs the agent reads                                            |
 | `extensions-dev/`           | Gitignored dev workspace prepared by `scripts/dev.mjs`                                 |
@@ -184,6 +188,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 pnpm dev          # run Electron + renderer dev server with a gitignored extensions-dev/ sandbox
 pnpm dev:reset    # wipe extensions-dev/ and agent session cache, then start fresh
 pnpm build        # build main + preload + renderer + bundled adapters into out/
+pnpm generate:contracts # regenerate extensions/babymenu-env.d.ts from src/shared/contracts.ts
 pnpm package:mac  # clean release/ and create an ad-hoc-signed Baby Menu Dev.app
 pnpm dist:mac     # build Baby Menu Dev.app and create a universal DMG in release/
 pnpm test         # run all Vitest tests
@@ -194,6 +199,7 @@ pnpm lint         # tsc --noEmit (same as typecheck)
 
 Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
 Use `pnpm dev:reset` when recipe or extension guidance changes; it also clears `.cache/baby-menu/acp-sessions` so the embedded agent re-reads the fresh copied specs instead of continuing from prior conversation state.
+Run `pnpm generate:contracts` after changing extension-facing types in `src/shared/contracts.ts` or the public name list in `src/shared/extension-contract-names.ts`; CI fails if the committed `extensions/babymenu-env.d.ts` is stale.
 Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
 Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu Dev.app`.
 Local packaging uses the `Baby Menu Dev` product name and `com.kunchenguid.baby-menu.dev` bundle id so local builds do not shadow the released `/Applications/Baby Menu.app` in macOS LaunchServices.

--- a/docs/extension-settings-sections.md
+++ b/docs/extension-settings-sections.md
@@ -17,6 +17,7 @@ The host owns the Settings page chrome (section title, dividers, spacing); the e
 ## Contract
 
 An extension may export a settings surface from `widget.tsx` alongside its widget.
+Import `BabyMenuSettingsSection` from the generated `@babymenu/contracts` type surface.
 The implemented shape mirrors `BabyMenuWidget`:
 
 ```ts
@@ -30,6 +31,7 @@ export type BabyMenuSettingsSection = {
 The section is renderer-only, like a widget.
 It reads and writes its own configuration through the existing bridges - `window.babyMenu.db` for normal values and extension server actions for privileged credential work - so no new per-extension IPC or preload methods are added.
 It may import `@babymenu/ui` and should build its form from `Field`, `Input`, `Switch`, `Select`, and `Button` so it matches the app shell for free.
+Extension authors should import the type from `@babymenu/contracts`; that generated type-only module is shipped as `babymenu-env.d.ts` in the extension workspace, so extensions should not import from host source paths such as `../../src/shared/contracts`.
 
 ## Discovery and rendering
 
@@ -60,6 +62,7 @@ The three open questions were resolved along the recommended lines:
 ## Implementation map
 
 - `src/shared/contracts.ts` - `BabyMenuSettingsSection` type.
+- `extensions/babymenu-env.d.ts` - generated `@babymenu/contracts` declaration that exposes `BabyMenuSettingsSection` inside extension workspaces.
 - `src/renderer/extension-modules.ts` - shared module loader (discovery, dynamic import, packaged-mode stylesheet injection) used by both the widget host and the settings view.
 - `src/renderer/settings/settings-sections.ts` - `settingsSectionsFromModule` and `loadRuntimeSettingsSections` (sorted by extension id).
 - `src/renderer/settings/SettingsView.tsx` - renders app settings first, including custom ACP agent management, then one framed section per discovered extension section.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,7 @@ extraResources:
     to: extensions-template
     filter:
       - AGENTS.md
+      - babymenu-env.d.ts
       - recipes/**
       - hello-world/**
   - from: assets/tray

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -4,6 +4,27 @@ This directory is for self-contained baby-menu extensions.
 An embedded agent launched from baby-menu should prefer editing files here instead of changing Electron core infrastructure.
 Do not modify files outside this directory unless the user explicitly asks.
 
+## Stay inside this workspace
+
+This extension workspace is your working directory, and you should keep every read, search, and edit inside it.
+Do not `cd` above this workspace, and do not run recursive `find`, `grep -r`, `rg`, or `ls -R` against your home directory, `/Users/<you>`, or any parent path.
+On macOS those parent paths include the protected `Documents`, `Downloads`, `Desktop`, `Music`, `Movies`, and `Pictures` folders, and traversing them makes the operating system pop a permission prompt for each one - a slow, alarming experience for the user that a widget task never needs.
+If a search returns nothing inside this workspace, stop and rely on the contracts documented below rather than widening the search outward.
+
+The Baby Menu host source is not present in this workspace.
+Files such as `src/shared/contracts` and the `@babymenu/ui` source live inside the installed app bundle, not on disk next to your extensions, so there is nothing to find by searching for them.
+Do not go hunting for them, and never import host-only paths like `../../src/shared/contracts` - that path does not exist in a packaged install and is exactly what sends a search outward.
+
+Instead, import the contract types from the stable `@babymenu/contracts` specifier:
+
+```tsx
+import type { RefreshableBabyMenuWidget, BabyMenuServerContext } from "@babymenu/contracts";
+```
+
+The full set of available types is declared in `babymenu-env.d.ts` at the root of this workspace - read that file when you need the exact shape of a widget descriptor, settings section, server `context`, `db`, background task, or the `window.babyMenu` bridge (`BabyMenuExtensionApi`).
+These are type-only imports, so the host erases them at compile time; they are always allowed and add no runtime dependency.
+Do not import a *value* from `@babymenu/contracts` - it carries types only.
+
 ## Extension Shape
 
 Each extension should live in its own directory under `<extension-id>/` inside this extension workspace.
@@ -20,6 +41,7 @@ Common files are:
 Packaged Baby Menu compiles extension modules before loading them.
 Keep imports package-safe: widget modules may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, the design system `@babymenu/ui`, and local helper files only.
 Server modules may import Node built-ins such as `node:fs` plus local helper files only.
+Both may additionally use type-only imports from `@babymenu/contracts` (see "Stay inside this workspace"); type-only imports are erased at compile time and do not count as runtime dependencies.
 Do not add arbitrary npm package imports to extension code unless the host compiler is updated to support them.
 
 When you need current details about a dependency, CLI, local credential layout, or an external API a widget talks to - package versions, command flags, endpoints, request headers, or response shapes - use web search to confirm the latest information before relying on it. APIs and tools change; do not guess field names, versions, or endpoints from memory when a quick search can verify them.

--- a/extensions/babymenu-env.d.ts
+++ b/extensions/babymenu-env.d.ts
@@ -142,3 +142,7 @@ declare module "@babymenu/contracts" {
     };
   };
 }
+
+interface Window {
+  babyMenu?: import("@babymenu/contracts").BabyMenuExtensionApi;
+}

--- a/extensions/babymenu-env.d.ts
+++ b/extensions/babymenu-env.d.ts
@@ -1,0 +1,144 @@
+// AUTO-GENERATED - DO NOT EDIT BY HAND.
+// Generated from src/shared/contracts.ts by scripts/generate-extension-dts.mjs.
+// Run `pnpm generate:contracts` after changing the extension-facing contract.
+//
+// This file makes `@babymenu/contracts` resolve inside the extension workspace,
+// where the host source (src/shared/contracts.ts) is not present. Import the
+// types you need from the stable specifier - never reach back into host paths
+// like ../../src/shared/contracts, which do not exist in a packaged install:
+//
+//   import type { RefreshableBabyMenuWidget, BabyMenuServerContext } from "@babymenu/contracts";
+//
+// These are type-only imports: the host compiler erases them, so they add no
+// runtime dependency and are always allowed. Importing a *value* from this
+// specifier will be rejected - there is nothing to import at runtime.
+
+declare module "@babymenu/contracts" {
+  import type { ReactNode } from "react";
+
+  // SQL bind parameters: positional (an array) or named (an object keyed by the
+  // bare parameter name, e.g. { name } for ":name").
+  export type SqlParams = unknown[] | Record<string, unknown>;
+
+  export type SqlRunResult = {
+    changes: number;
+    lastInsertRowid: number | bigint;
+  };
+
+  // The synchronous SQL surface extensions use from server actions and background
+  // tasks. The host's ExtensionDatabase implements this plus lifecycle (close).
+  export type BabyMenuDatabase = {
+    query: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => T[];
+    get: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => T | undefined;
+    run: (sql: string, params?: SqlParams) => SqlRunResult;
+    exec: (sql: string) => void;
+    transaction: <T>(fn: () => T) => T;
+  };
+
+  export type BabyMenuNotification = {
+    title: string;
+    body?: string;
+  };
+
+  // Passed to every server action and background task. Privileged, main-process side.
+  export type BabyMenuServerContext = {
+    rootDir: string;
+    db: BabyMenuDatabase;
+    // Show a native system notification. The main reason a background task is worth
+    // having: it can alert the user (e.g. a threshold breach) while the popover is closed.
+    notify: (notification: BabyMenuNotification) => void;
+  };
+
+  // Declared as `export const background` in an extension's server.ts. The host runs
+  // `run` on its own timer (clamped to a 60s floor) whether or not the popover is open,
+  // so it is the place for work that must keep happening in the background. Persist
+  // results with `context.db` and a widget can read them on open.
+  export type BabyMenuBackgroundTask = {
+    intervalMs: number;
+    run: (context: BabyMenuServerContext) => void | Promise<void>;
+    // Whether to run once as soon as the task is scheduled (default true) so data is
+    // warm before the first refresh tick.
+    runOnStart?: boolean;
+  };
+
+  export type BackgroundTaskUpdate = {
+    extensionId: string;
+  };
+
+  export type BabyMenuCapabilityDescriptor = {
+    id: string;
+    extensionId: string;
+    action: string;
+  };
+
+  export type BabyMenuWidget = {
+    id: string;
+    title: string;
+    render: () => ReactNode;
+  };
+
+  // A configuration surface an extension contributes to the Settings page,
+  // exported from `widget.tsx` alongside its widget. Renderer-only, like a widget:
+  // the host draws the section frame (title, dividers, spacing) and the extension
+  // owns only the body. It reads and writes its own configuration through the
+  // existing bridges (`window.babyMenu.db`), so no per-extension IPC is added.
+  export type BabyMenuSettingsSection = {
+    // Matches the extension id; used as the section key and for stable sort order.
+    extensionId: string;
+    // Terse section label, e.g. "CALENDAR".
+    title: string;
+    // Body only; the host draws the section frame around it.
+    render: () => ReactNode;
+  };
+
+  export type RefreshableBabyMenuWidget = BabyMenuWidget &
+    (
+      | {
+          // View refresh re-renders a visible widget. It is owned by the host and
+          // paused while the popover is hidden. It is not a way to sync data in the
+          // background - declare a `background` task in server.ts for that.
+          viewRefreshIntervalMs?: number;
+          refreshView: () => void | Promise<void>;
+        }
+      | {
+          viewRefreshIntervalMs?: never;
+          refreshView?: never;
+        }
+    );
+
+  export type PopoverVisibilityState = {
+    visible: boolean;
+  };
+
+  // The slice of the window.babyMenu bridge that extension widgets are meant to
+  // use: invoking server actions, reading the shared store, reacting to background
+  // runs, and the popover visibility signal. Host-only surfaces (git, agent,
+  // settings, app, recipes, widgets) are deliberately excluded. This is the value
+  // side of the `@babymenu/contracts` public surface; see extensions/babymenu-env.d.ts.
+  //
+  // Written out explicitly (not Pick<BabyMenuApi, ...>) so the codegen in
+  // scripts/generate-extension-dts.mjs can copy it verbatim into the shipped
+  // declaration file. A type test in tests/extension-contract-surface.test.ts
+  // asserts it stays structurally equal to the matching BabyMenuApi members, so
+  // the explicit copy and BabyMenuApi cannot silently drift apart.
+  export type BabyMenuExtensionApi = {
+    capabilities: {
+      list: () => Promise<BabyMenuCapabilityDescriptor[]>;
+      invoke: <T = unknown>(extensionId: string, action: string, input?: unknown) => Promise<T>;
+    };
+    db: {
+      query: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => Promise<T[]>;
+      get: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => Promise<T | undefined>;
+      run: (sql: string, params?: SqlParams) => Promise<SqlRunResult>;
+      exec: (sql: string) => Promise<void>;
+    };
+    background: {
+      onUpdate: (listener: (event: BackgroundTaskUpdate) => void) => () => void;
+    };
+    popover: {
+      setContentHeight: (height: number) => Promise<{ ok: boolean }>;
+      getVisibility: () => Promise<PopoverVisibilityState>;
+      onVisibility: (listener: (state: PopoverVisibilityState) => void) => () => void;
+    };
+  };
+}

--- a/extensions/hello-world/widget.tsx
+++ b/extensions/hello-world/widget.tsx
@@ -1,4 +1,4 @@
-import type { RefreshableBabyMenuWidget } from "../../src/shared/contracts";
+import type { RefreshableBabyMenuWidget } from "@babymenu/contracts";
 import { HelloWorldView } from "./components";
 
 // The widget descriptor is a plain object (not a React component), so editing

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "node scripts/dev.mjs",
     "dev:reset": "node scripts/dev.mjs --reset",
     "build": "electron-vite build && node scripts/build-adapters.mjs",
+    "generate:contracts": "node scripts/generate-extension-dts.mjs",
     "package:mac": "rm -rf release && pnpm build && electron-builder --mac dir --universal --config electron-builder.dev.yml && node scripts/adhoc-sign-mac-app.mjs \"release/mac-universal/Baby Menu Dev.app\"",
     "dist:mac": "pnpm package:mac && node scripts/create-dmg.mjs \"release/mac-universal/Baby Menu Dev.app\"",
     "test": "vitest run tests",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -29,6 +29,7 @@ function resolveDevExtensionsDir(rootDir, env) {
 function prepareDevExtensions({ rootDir, devExtensionsDir, mkdirSyncFn, copyFileSyncFn, cpSyncFn }) {
   mkdirSyncFn(devExtensionsDir, { recursive: true });
   copyFileSyncFn(join(rootDir, "extensions", "AGENTS.md"), join(devExtensionsDir, "AGENTS.md"));
+  copyFileSyncFn(join(rootDir, "extensions", "babymenu-env.d.ts"), join(devExtensionsDir, "babymenu-env.d.ts"));
   cpSyncFn(join(rootDir, "extensions", "recipes"), join(devExtensionsDir, "recipes"), { recursive: true });
 }
 

--- a/scripts/generate-extension-dts.d.mts
+++ b/scripts/generate-extension-dts.d.mts
@@ -1,0 +1,3 @@
+// Types for the JS codegen module so the TypeScript test can import it under
+// allowJs:false. The implementation lives in generate-extension-dts.mjs.
+export function generateExtensionDts(contractsSource: string, contractNames: readonly string[]): string;

--- a/scripts/generate-extension-dts.mjs
+++ b/scripts/generate-extension-dts.mjs
@@ -1,0 +1,90 @@
+// Generates extensions/babymenu-env.d.ts from src/shared/contracts.ts.
+//
+// Extensions cannot see the host source (it lives inside the app bundle, not in
+// the extension workspace), so the host ships the extension-facing contract
+// types into the workspace as the `@babymenu/contracts` virtual module. This
+// script copies the declarations named in src/shared/extension-contract-names.ts
+// verbatim out of contracts.ts and wraps them in a `declare module` block, so the
+// shipped types can never drift from the host's real types.
+//
+// Run `pnpm generate:contracts` after changing the extension-facing contract.
+// tests/extension-contract-surface.test.ts fails if the committed file is stale.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const PREAMBLE = `// AUTO-GENERATED - DO NOT EDIT BY HAND.
+// Generated from src/shared/contracts.ts by scripts/generate-extension-dts.mjs.
+// Run \`pnpm generate:contracts\` after changing the extension-facing contract.
+//
+// This file makes \`@babymenu/contracts\` resolve inside the extension workspace,
+// where the host source (src/shared/contracts.ts) is not present. Import the
+// types you need from the stable specifier - never reach back into host paths
+// like ../../src/shared/contracts, which do not exist in a packaged install:
+//
+//   import type { RefreshableBabyMenuWidget, BabyMenuServerContext } from "@babymenu/contracts";
+//
+// These are type-only imports: the host compiler erases them, so they add no
+// runtime dependency and are always allowed. Importing a *value* from this
+// specifier will be rejected - there is nothing to import at runtime.
+`;
+
+/**
+ * Build the babymenu-env.d.ts contents from the contracts.ts source text and the
+ * list of extension-facing type names. Pure: same inputs -> identical output.
+ */
+export function generateExtensionDts(contractsSource, contractNames) {
+  const sourceFile = ts.createSourceFile("contracts.ts", contractsSource, ts.ScriptTarget.Latest, true);
+  const wanted = new Set(contractNames);
+  const byName = new Map();
+  for (const statement of sourceFile.statements) {
+    if (ts.isTypeAliasDeclaration(statement) && wanted.has(statement.name.text)) {
+      byName.set(statement.name.text, declarationText(statement, sourceFile));
+    }
+  }
+  const missing = contractNames.filter((name) => !byName.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Names in EXTENSION_CONTRACT_NAMES missing from contracts.ts: ${missing.join(", ")}`);
+  }
+  // Emit in contracts.ts source order (Map preserves insertion order).
+  const body = [...byName.values()].map(indentBlock).join("\n\n");
+  return `${PREAMBLE}\ndeclare module "@babymenu/contracts" {\n  import type { ReactNode } from "react";\n\n${body}\n}\n`;
+}
+
+// The verbatim source text of a declaration including its leading JSDoc comment,
+// with the blank lines before the comment trimmed off.
+function declarationText(node, sourceFile) {
+  return node
+    .getFullText(sourceFile)
+    .replace(/^[\r\n]+/, "")
+    .trimEnd();
+}
+
+function indentBlock(text) {
+  return text
+    .split("\n")
+    .map((line) => (line.trim() === "" ? "" : `  ${line}`))
+    .join("\n");
+}
+
+// Pull the quoted names out of `EXTENSION_CONTRACT_NAMES = [ ... ] as const`.
+// Interspersed `//` comments contain no quotes, so a quote scan is safe here.
+function parseContractNames(namesSource) {
+  const arrayMatch = namesSource.match(/EXTENSION_CONTRACT_NAMES\s*=\s*\[([\s\S]*?)\]\s*as const/);
+  if (!arrayMatch) throw new Error("Could not find EXTENSION_CONTRACT_NAMES array in extension-contract-names.ts");
+  return [...arrayMatch[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+}
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const contractsPath = join(repoRoot, "src", "shared", "contracts.ts");
+const namesPath = join(repoRoot, "src", "shared", "extension-contract-names.ts");
+const outputPath = join(repoRoot, "extensions", "babymenu-env.d.ts");
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const contractsSource = readFileSync(contractsPath, "utf8");
+  const contractNames = parseContractNames(readFileSync(namesPath, "utf8"));
+  writeFileSync(outputPath, generateExtensionDts(contractsSource, contractNames));
+  console.log(`Wrote ${outputPath}`);
+}

--- a/scripts/generate-extension-dts.mjs
+++ b/scripts/generate-extension-dts.mjs
@@ -50,7 +50,7 @@ export function generateExtensionDts(contractsSource, contractNames) {
   }
   // Emit in contracts.ts source order (Map preserves insertion order).
   const body = [...byName.values()].map(indentBlock).join("\n\n");
-  return `${PREAMBLE}\ndeclare module "@babymenu/contracts" {\n  import type { ReactNode } from "react";\n\n${body}\n}\n`;
+  return `${PREAMBLE}\ndeclare module "@babymenu/contracts" {\n  import type { ReactNode } from "react";\n\n${body}\n}\n\ninterface Window {\n  babyMenu?: import("@babymenu/contracts").BabyMenuExtensionApi;\n}\n`;
 }
 
 // The verbatim source text of a declaration including its leading JSDoc comment,

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -339,7 +339,14 @@ function matchesForPattern(
 }
 
 function isTypeOnlyImport(statement: string): boolean {
-  return /^\s*(?:import|export)\s+type\b/.test(statement);
+  if (/^\s*(?:import|export)\s+type\b/.test(statement)) return true;
+  const namedImport = statement.match(/^\s*(?:import|export)\s*\{([\s\S]*?)\}\s*from\s*["']/);
+  if (!namedImport) return false;
+  return namedImport[1]
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean)
+    .every((specifier) => specifier.startsWith("type "));
 }
 
 function applyReplacements(source: string, replacements: Array<{ start: number; end: number; value: string }>): string {

--- a/src/main/extension-seeder.ts
+++ b/src/main/extension-seeder.ts
@@ -11,10 +11,10 @@ export async function seedExtensionWorkspace(options: SeedExtensionWorkspaceOpti
 
   await mkdir(options.extensionsDir, { recursive: true });
   // Self-heal the bundled defaults: every file the template ships (AGENTS.md,
-  // recipes, starter extensions) is force-copied so a stale or edited managed
-  // file is restored on launch. cp only writes paths present in the template,
-  // so user-created extensions the template does not ship are left untouched
-  // and are never deleted.
+  // babymenu-env.d.ts, recipes, starter extensions) is force-copied so a stale
+  // or edited managed file is restored on launch. cp only writes paths present
+  // in the template, so user-created extensions the template does not ship are
+  // left untouched and are never deleted.
   await cp(options.templateDir, options.extensionsDir, { recursive: true, force: true });
   return true;
 }

--- a/src/main/extension-seeder.ts
+++ b/src/main/extension-seeder.ts
@@ -10,7 +10,12 @@ export async function seedExtensionWorkspace(options: SeedExtensionWorkspaceOpti
   if (!(await pathExists(options.templateDir))) return false;
 
   await mkdir(options.extensionsDir, { recursive: true });
-  await cp(options.templateDir, options.extensionsDir, { recursive: true, force: false, errorOnExist: false });
+  // Self-heal the bundled defaults: every file the template ships (AGENTS.md,
+  // recipes, starter extensions) is force-copied so a stale or edited managed
+  // file is restored on launch. cp only writes paths present in the template,
+  // so user-created extensions the template does not ship are left untouched
+  // and are never deleted.
+  await cp(options.templateDir, options.extensionsDir, { recursive: true, force: true });
   return true;
 }
 

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -245,6 +245,38 @@ export type BabyMenuApi = {
   };
 };
 
+// The slice of the window.babyMenu bridge that extension widgets are meant to
+// use: invoking server actions, reading the shared store, reacting to background
+// runs, and the popover visibility signal. Host-only surfaces (git, agent,
+// settings, app, recipes, widgets) are deliberately excluded. This is the value
+// side of the `@babymenu/contracts` public surface; see extensions/babymenu-env.d.ts.
+//
+// Written out explicitly (not Pick<BabyMenuApi, ...>) so the codegen in
+// scripts/generate-extension-dts.mjs can copy it verbatim into the shipped
+// declaration file. A type test in tests/extension-contract-surface.test.ts
+// asserts it stays structurally equal to the matching BabyMenuApi members, so
+// the explicit copy and BabyMenuApi cannot silently drift apart.
+export type BabyMenuExtensionApi = {
+  capabilities: {
+    list: () => Promise<BabyMenuCapabilityDescriptor[]>;
+    invoke: <T = unknown>(extensionId: string, action: string, input?: unknown) => Promise<T>;
+  };
+  db: {
+    query: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => Promise<T[]>;
+    get: <T = Record<string, unknown>>(sql: string, params?: SqlParams) => Promise<T | undefined>;
+    run: (sql: string, params?: SqlParams) => Promise<SqlRunResult>;
+    exec: (sql: string) => Promise<void>;
+  };
+  background: {
+    onUpdate: (listener: (event: BackgroundTaskUpdate) => void) => () => void;
+  };
+  popover: {
+    setContentHeight: (height: number) => Promise<{ ok: boolean }>;
+    getVisibility: () => Promise<PopoverVisibilityState>;
+    onVisibility: (listener: (state: PopoverVisibilityState) => void) => () => void;
+  };
+};
+
 declare global {
   interface Window {
     babyMenu?: BabyMenuApi;

--- a/src/shared/extension-contract-names.ts
+++ b/src/shared/extension-contract-names.ts
@@ -1,0 +1,33 @@
+// The public, extension-facing slice of the Baby Menu contract surface.
+//
+// Extensions cannot see src/shared/contracts.ts (it lives inside the app bundle,
+// not in the extension workspace), so the host ships these types into the
+// workspace as the `@babymenu/contracts` virtual module declared in
+// extensions/babymenu-env.d.ts. This list is the single source of truth for
+// which names that module exposes: tests/extension-contract-surface.test.ts
+// fails the moment the declaration file or contracts.ts drifts from it, the same
+// way UI_EXPORT_NAMES guards the @babymenu/ui surface.
+//
+// Every name here must be an exported type in src/shared/contracts.ts. Keep the
+// host-only surfaces (git, agent, settings, app, recipes, widget loading) out.
+export const EXTENSION_CONTRACT_NAMES = [
+  // Widget and settings descriptors exported from widget.tsx.
+  "BabyMenuWidget",
+  "RefreshableBabyMenuWidget",
+  "BabyMenuSettingsSection",
+  // server.ts surface: the action/background context and what it carries.
+  "BabyMenuServerContext",
+  "BabyMenuDatabase",
+  "BabyMenuNotification",
+  "BabyMenuBackgroundTask",
+  "SqlParams",
+  "SqlRunResult",
+  // Bridge data shapes widgets receive over window.babyMenu.
+  "BabyMenuCapabilityDescriptor",
+  "BackgroundTaskUpdate",
+  "PopoverVisibilityState",
+  // The window.babyMenu subset widgets call.
+  "BabyMenuExtensionApi",
+] as const;
+
+export type ExtensionContractName = (typeof EXTENSION_CONTRACT_NAMES)[number];

--- a/tests/app-paths.test.ts
+++ b/tests/app-paths.test.ts
@@ -54,7 +54,7 @@ describe("Baby Menu runtime paths", () => {
     });
   });
 
-  it("seeds missing packaged extension templates without overwriting user files", async () => {
+  it("refreshes bundled template files while preserving user-created extensions", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-seed-"));
     tempDirs.push(rootDir);
     const templateDir = join(rootDir, "Resources", "extensions-template");
@@ -70,17 +70,30 @@ describe("Baby Menu runtime paths", () => {
     expect(seeded).toBe(true);
     await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("template rules\n");
 
-    await writeFile(join(extensionsDir, "AGENTS.md"), "user rules\n");
+    // The user (via the embedded agent) creates their own extension and edits a
+    // managed default file. The template also gains a new recipe and the
+    // managed files change between launches.
+    await mkdir(join(extensionsDir, "system-usage"), { recursive: true });
+    await writeFile(join(extensionsDir, "system-usage", "widget.tsx"), "export const systemUsageWidget = {};\n");
+    await writeFile(join(extensionsDir, "AGENTS.md"), "user edited rules\n");
+    await writeFile(join(templateDir, "AGENTS.md"), "template rules v2\n");
     await mkdir(join(templateDir, "goodbye-world"), { recursive: true });
     await writeFile(join(templateDir, "recipes", "new.html"), "<title>New</title>\n");
     await writeFile(join(templateDir, "goodbye-world", "widget.tsx"), "export const goodbyeWorldWidget = {};\n");
+
     const reseeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
 
     expect(reseeded).toBe(true);
-    await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("user rules\n");
+    // Managed default files self-heal back to the bundled template, even if edited.
+    await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("template rules v2\n");
+    // New bundled defaults are added.
     await expect(readFile(join(extensionsDir, "recipes", "new.html"), "utf8")).resolves.toBe("<title>New</title>\n");
     await expect(readFile(join(extensionsDir, "goodbye-world", "widget.tsx"), "utf8")).resolves.toBe(
       "export const goodbyeWorldWidget = {};\n",
+    );
+    // User-created extensions the template does not ship are left untouched.
+    await expect(readFile(join(extensionsDir, "system-usage", "widget.tsx"), "utf8")).resolves.toBe(
+      "export const systemUsageWidget = {};\n",
     );
   });
 });

--- a/tests/dev-launcher.test.ts
+++ b/tests/dev-launcher.test.ts
@@ -82,6 +82,10 @@ describe("dev launcher", () => {
       source: join("/repo", "extensions", "AGENTS.md"),
       destination: join("/repo", "extensions-dev", "AGENTS.md"),
     });
+    expect(harness.copiedFiles).toContainEqual({
+      source: join("/repo", "extensions", "babymenu-env.d.ts"),
+      destination: join("/repo", "extensions-dev", "babymenu-env.d.ts"),
+    });
     expect(harness.copiedDirectories).toContainEqual({
       source: join("/repo", "extensions", "recipes"),
       destination: join("/repo", "extensions-dev", "recipes"),

--- a/tests/extension-contract-surface.test.ts
+++ b/tests/extension-contract-surface.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { generateExtensionDts } from "../scripts/generate-extension-dts.mjs";
+import type { BabyMenuApi, BabyMenuExtensionApi } from "../src/shared/contracts";
+import { EXTENSION_CONTRACT_NAMES } from "../src/shared/extension-contract-names";
+
+// The `@babymenu/contracts` surface is a stability contract, exactly like
+// `@babymenu/ui`: the canonical name list, the host's contracts.ts, and the
+// declaration file shipped into the extension workspace must all agree, or an
+// extension that imports a type will silently get `any` (or fail to resolve).
+// The declaration file is generated from contracts.ts, so it cannot drift in
+// body - these tests guard the inputs to that codegen and that it was re-run.
+
+const repoRoot = join(__dirname, "..");
+const declarationPath = join(repoRoot, "extensions", "babymenu-env.d.ts");
+const contractsPath = join(repoRoot, "src", "shared", "contracts.ts");
+
+describe("@babymenu/contracts public surface contract", () => {
+  it("keeps extensions/babymenu-env.d.ts in sync with contracts.ts (run `pnpm generate:contracts`)", async () => {
+    const contractsSource = await readFile(contractsPath, "utf8");
+    const committed = await readFile(declarationPath, "utf8");
+    const regenerated = generateExtensionDts(contractsSource, [...EXTENSION_CONTRACT_NAMES]);
+    expect(committed).toBe(regenerated);
+  });
+
+  it("only names types that actually exist in contracts.ts", async () => {
+    const contracts = await readFile(contractsPath, "utf8");
+    const exported = new Set([...contracts.matchAll(/^export\s+type\s+([A-Za-z0-9_]+)/gm)].map((m) => m[1]));
+    const missing = EXTENSION_CONTRACT_NAMES.filter((name) => !exported.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("keeps the explicit BabyMenuExtensionApi equal to the BabyMenuApi subset", () => {
+    // BabyMenuExtensionApi is written out explicitly so the codegen can copy it
+    // verbatim; this asserts it still matches the real bridge in BabyMenuApi, so
+    // the two definitions cannot silently diverge.
+    expectTypeOf<BabyMenuExtensionApi>().toEqualTypeOf<
+      Pick<BabyMenuApi, "capabilities" | "db" | "background" | "popover">
+    >();
+  });
+
+  it("ships a starter widget that imports the stable specifier, not a relative host path", async () => {
+    // The agent copies the starter's import style. A relative import back into
+    // host source (../../src/shared/contracts) resolves in source mode but points
+    // at nothing in a packaged install - exactly the footgun that sent the agent
+    // scanning the home directory. The starter must model the workspace-stable form.
+    const starter = await readFile(join(repoRoot, "extensions", "hello-world", "widget.tsx"), "utf8");
+    expect(starter).toMatch(/from\s+["']@babymenu\/contracts["']/);
+    expect(starter).not.toMatch(/from\s+["'][^"']*src\/shared\/contracts["']/);
+  });
+});

--- a/tests/extension-contract-surface.test.ts
+++ b/tests/extension-contract-surface.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { generateExtensionDts } from "../scripts/generate-extension-dts.mjs";
@@ -55,5 +55,31 @@ describe("@babymenu/contracts public surface contract", () => {
     const starter = await readFile(join(repoRoot, "extensions", "hello-world", "widget.tsx"), "utf8");
     expect(starter).toMatch(/from\s+["']@babymenu\/contracts["']/);
     expect(starter).not.toMatch(/from\s+["'][^"']*src\/shared\/contracts["']/);
+  });
+
+  it("keeps source extension contract imports within the generated public surface", async () => {
+    const extensionRoot = join(repoRoot, "extensions");
+    const extensionDirs = await readdir(extensionRoot, { withFileTypes: true });
+    const importedNames = new Set<string>();
+
+    for (const entry of extensionDirs) {
+      if (!entry.isDirectory()) continue;
+
+      for (const file of await readdir(join(extensionRoot, entry.name), { withFileTypes: true })) {
+        if (!file.isFile() || !/\.[cm]?[tj]sx?$/.test(file.name)) continue;
+
+        const source = await readFile(join(extensionRoot, entry.name, file.name), "utf8");
+        for (const match of source.matchAll(/import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+["']@babymenu\/contracts["']/g)) {
+          for (const specifier of match[1].split(",")) {
+            const name = specifier.replace(/^\s*type\s+/, "").trim().split(/\s+as\s+|\s+/)[0];
+            if (name) importedNames.add(name);
+          }
+        }
+      }
+    }
+
+    const publicNames = new Set<string>(EXTENSION_CONTRACT_NAMES);
+    const nonPublicImports = [...importedNames].filter((name) => !publicNames.has(name));
+    expect(nonPublicImports).toEqual([]);
   });
 });

--- a/tests/extension-contract-surface.test.ts
+++ b/tests/extension-contract-surface.test.ts
@@ -24,6 +24,13 @@ describe("@babymenu/contracts public surface contract", () => {
     expect(committed).toBe(regenerated);
   });
 
+  it("declares the extension window bridge globally", async () => {
+    const declaration = await readFile(declarationPath, "utf8");
+
+    expect(declaration).toContain("interface Window {");
+    expect(declaration).toContain("babyMenu?: import(\"@babymenu/contracts\").BabyMenuExtensionApi;");
+  });
+
   it("only names types that actually exist in contracts.ts", async () => {
     const contracts = await readFile(contractsPath, "utf8");
     const exported = new Set([...contracts.matchAll(/^export\s+type\s+([A-Za-z0-9_]+)/gm)].map((m) => m[1]));

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -68,6 +68,29 @@ describe("extension module compiler", () => {
     await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("@babymenu/contracts");
   });
 
+  it("ignores inline type-only contract imports when collecting widget dependencies", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions", "inline-contract");
+    const entryFile = join(extensionDir, "widget.tsx");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `import { type RefreshableBabyMenuWidget } from "@babymenu/contracts";
+      export const widget: RefreshableBabyMenuWidget = { id: "inline-contract", title: "Inline", render: () => "ok", refreshView: async () => undefined };`,
+    );
+
+    const compiled = await compileExtensionModule({
+      kind: "widget",
+      extensionId: "inline-contract",
+      extensionDir,
+      entryFile,
+      cacheRoot: join(rootDir, "cache", "widgets"),
+    });
+
+    await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("@babymenu/contracts");
+  });
+
   it("reuses cached output for unchanged extension modules", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
     tempDirs.push(rootDir);

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -51,7 +51,7 @@ describe("extension module compiler", () => {
     await mkdir(extensionDir, { recursive: true });
     await writeFile(
       entryFile,
-      `import type { RefreshableBabyMenuWidget } from "../../src/shared/contracts";
+      `import type { RefreshableBabyMenuWidget } from "@babymenu/contracts";
       export const widget: RefreshableBabyMenuWidget = { id: "starter", title: "Starter", render: () => "ok", refreshView: async () => undefined };`,
     );
 
@@ -63,7 +63,9 @@ describe("extension module compiler", () => {
       cacheRoot: join(rootDir, "cache", "widgets"),
     });
 
-    await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("../../src/shared/contracts");
+    // The stable contract specifier is type-only, so it is erased at compile time
+    // and never reaches the runtime import allowlist.
+    await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("@babymenu/contracts");
   });
 
   it("reuses cached output for unchanged extension modules", async () => {

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -36,6 +36,7 @@ describe("distribution config", () => {
 
     expect(config).toContain("appId: com.kunchenguid.baby-menu");
     expect(config).toContain("to: extensions-template");
+    expect(config).toContain("babymenu-env.d.ts");
     expect(config).toContain("to: tray");
     expect(config).toContain("baby_menuTemplate*.png");
     expect(config).toContain("identity: null");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,8 +17,10 @@
     "jsx": "react-jsx",
     "types": ["node", "vitest/globals"],
     "paths": {
+      "@babymenu/contracts": ["./src/shared/contracts.ts"],
       "@babymenu/ui": ["./src/ui/index.ts"]
     }
   },
-  "include": ["electron.vite.config.ts", "vitest.config.ts", "src", "extensions", "tests"]
+  "include": ["electron.vite.config.ts", "vitest.config.ts", "src", "extensions", "tests"],
+  "exclude": ["extensions/babymenu-env.d.ts"]
 }


### PR DESCRIPTION
## Intent

The developer wanted to prevent packaged Baby Menu agents from scanning macOS-protected user directories after an agent recursively searched the home directory for contract types and triggered permission prompts. They required stronger workspace guidance in extensions/AGENTS.md, self-healing packaged extension defaults that overwrite bundled files in ~/.baby-menu/extensions while preserving user-created extensions, and a stable @babymenu/contracts type surface so agents do not import or hunt for ../../src/shared/contracts. They also wanted extensions/babymenu-env.d.ts generated from src/shared/contracts.ts, kept tracked, and verified in the PR CI pipeline by regenerating it and failing if it differs. Before committing, they asked to keep the root AGENTS.md in sync with these new maintenance rules and pitfalls.

## What Changed

- Added a generated and tracked `extensions/babymenu-env.d.ts` surface for `@babymenu/contracts`, including the extension bridge types and validation tests to keep it in sync with `src/shared/contracts.ts`.
- Updated extension compilation and TypeScript wiring so allowed contract imports are type-only and extension code is checked against the shipped contract surface.
- Packaged the generated contract declarations into extension templates, seeded them into dev and packaged workspaces, and documented the new extension authoring and maintenance rules.

## Risk Assessment

⚠️ Medium: The packaging and seeding changes are well bounded, but the source-mode type surface remains looser than the generated packaged extension contract, leaving a real drift risk for future extension edits.

## Testing

Focused tests passed for generated contract drift, stable extension imports, dev/package inclusion, extension compiler import handling, and packaged template self-healing; `pnpm generate:contracts` left `extensions/babymenu-env.d.ts` unchanged, and the evidence artifact shows managed packaged defaults are restored while a user-created extension is preserved. No UI screenshot was captured because this change is packaging/type/workspace behavior with no rendered end-user UI surface.

<details>
<summary>Evidence: Contract and packaged seeding evidence</summary>

<code>Shows packaged reseed restoring `AGENTS.md` and `babymenu-env.d.ts`, preserving a user-created extension, copying a new bundled widget, matching regenerated declarations to the committed file, and confirming the starter uses `@babymenu/contracts` rather than a relative host path.</code>

```text
# Contract and packaged seeding evidence

- Packaged reseed restores AGENTS.md: "template rules v2\n"
- Packaged reseed restores babymenu-env.d.ts: "contracts v2\n"
- User-created extension preserved: "export const userWidget = { id: \"user-widget\" };\n"
- New bundled widget copied: "export const bundledWidget = { id: \"new-bundled-widget\" };\n"
- Regenerated declarations match committed file: true
- Stable contracts module declared: true
- Window bridge declared: true
- Starter imports @babymenu/contracts: true
- Starter imports relative host contracts path: false

Public contract names:

- BabyMenuWidget
- RefreshableBabyMenuWidget
- BabyMenuSettingsSection
- BabyMenuServerContext
- BabyMenuDatabase
- BabyMenuNotification
- BabyMenuBackgroundTask
- SqlParams
- SqlRunResult
- BabyMenuCapabilityDescriptor
- BackgroundTaskUpdate
- PopoverVisibilityState
- BabyMenuExtensionApi
```
</details>
<details>
<summary>Evidence: Contract and packaged seeding evidence JSON</summary>

`Machine-readable evidence for the same packaged reseed and generated contract checks.`

```text
{
  "packagedSelfHealing": {
    "agentsMdAfterReseed": "template rules v2\n",
    "envDtsAfterReseed": "contracts v2\n",
    "userExtensionAfterReseed": "export const userWidget = { id: \"user-widget\" };\n",
    "newBundledWidgetAfterReseed": "export const bundledWidget = { id: \"new-bundled-widget\" };\n"
  },
  "contractSurface": {
    "generatedMatchesCommitted": true,
    "declaredModulePresent": true,
    "windowBridgePresent": true,
    "exportedNames": [
      "BabyMenuWidget",
      "RefreshableBabyMenuWidget",
      "BabyMenuSettingsSection",
      "BabyMenuServerContext",
      "BabyMenuDatabase",
      "BabyMenuNotification",
      "BabyMenuBackgroundTask",
      "SqlParams",
      "SqlRunResult",
      "BabyMenuCapabilityDescriptor",
      "BackgroundTaskUpdate",
      "PopoverVisibilityState",
      "BabyMenuExtensionApi"
    ],
    "starterUsesStableContractsSpecifier": true,
    "starterUsesRelativeHostContractsPath": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- 🚨 `src/main/extension-seeder.ts:16` - Packaged installs still will not receive `babymenu-env.d.ts`: the new seeder only copies files present in the bundled template, but `electron-builder.yml`&#39;s `extraResources` filter still includes only `AGENTS.md`, `recipes/**`, and `hello-world/**`. Add `babymenu-env.d.ts` to the packaged template filter so packaged agents can read the stable `@babymenu/contracts` declarations instead of falling back to host-path searches.

🔧 Fix: Package extension contract declarations
2 warnings still open:
- ⚠️ `scripts/generate-extension-dts.mjs:53` - The generated `babymenu-env.d.ts` exports `BabyMenuExtensionApi` but does not augment `Window`, so dev/packaged extension workspaces still do not get a typed `window.babyMenu` bridge from the shipped env file. Add a generated `Window` declaration, for example `babyMenu?: BabyMenuExtensionApi`, so agents do not need casts or host-source lookups to discover the bridge shape.
- ⚠️ `extensions/AGENTS.md:44` - This says type-only imports from `@babymenu/contracts` are allowed, but the compiler only ignores statements that start with `import type` or `export type`; a valid inline type-only form like `import { type BabyMenuWidget } from &#34;@babymenu/contracts&#34;` is still treated as an external runtime import and rejected. Teach the import scanner to recognize inline type-only imports from the contracts specifier or narrow the guidance to only `import type`.

🔧 Fix: Type extension bridge and inline imports
1 warning still open:
- ⚠️ `tsconfig.json:20` - The source-mode alias resolves `@babymenu/contracts` to the full host `src/shared/contracts.ts`, so repo typecheck will accept extension imports of host-only types that are absent from the generated `extensions/babymenu-env.d.ts` shipped to dev/packaged workspaces. Point the alias at the generated declaration surface, or otherwise validate extension imports against `EXTENSION_CONTRACT_NAMES`, so source extensions cannot depend on a contract that packaged agents cannot see.

🔧 Fix: Validate extension contract imports
1 warning still open:
- ⚠️ `tsconfig.json:20` - Source extension typechecking still resolves `@babymenu/contracts` to the full host contract file and excludes the generated env file, so extension code in `extensions/` can typecheck against host-only APIs such as `window.babyMenu.agent`/`settings` or host-only exported types that are not shipped in `babymenu-env.d.ts`. Validate source extensions against the generated extension surface, or add a dedicated extension typecheck that uses `babymenu-env.d.ts`, so source-mode extensions cannot depend on contracts packaged agents cannot see.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-status dab648de2e347f468fbe4520978b59cea81197bf..018cc6c5d27aad6207275b9c23e5d09f17417482` to identify the changed surface and select focused tests</code>
- `pnpm vitest run tests/extension-contract-surface.test.ts tests/app-paths.test.ts tests/dev-launcher.test.ts tests/release-config.test.ts`
- `pnpm vitest run tests/extension-module-compiler.test.ts`
- `pnpm generate:contracts && git diff --exit-code -- extensions/babymenu-env.d.ts`
- <code>Packaged-style manual evidence script that seeded a temp `Resources/extensions-template`, edited managed defaults and added a user extension, reseeded with `seedExtensionWorkspace`, regenerated declarations with `generateExtensionDts`, and wrote evidence files under `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSSFRBCBWBN6AZ7DHP64DXB7`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
