### PR TITLE
fix(adapters): omit Codex color flag on resume

### DIFF
--- a/src/adapters/codex/driver.ts
+++ b/src/adapters/codex/driver.ts
@@ -57,12 +57,13 @@ export class CodexDriver implements SessionDriver {
       // context comes from the cwd (the workspace) and its AGENTS.md.
       "--ignore-user-config",
       "--ignore-rules",
-      "--color",
-      "never",
     ];
+    // `--color` is valid on `codex exec` but the `resume` subcommand rejects it
+    // (clap exits 2), so it stays off the resume path. Output is `--json`
+    // anyway, so this only suppresses any incidental coloring on the first turn.
     const args = this.threadId
       ? ["exec", "resume", this.threadId, ...common, text]
-      : ["exec", ...common, text];
+      : ["exec", ...common, "--color", "never", text];
 
     logDebug(SCOPE, "spawn", this.command, args.slice(0, -1).join(" "), "<prompt>");
     // codex exec takes the prompt as an arg and ignores stdin, but we pipe all

--- a/src/adapters/codex/driver.ts
+++ b/src/adapters/codex/driver.ts
@@ -16,8 +16,9 @@ export type CodexDriverOptions = {
 
 /**
  * Drives `codex exec --json` per turn. The first turn runs `codex exec <prompt>`
- * and captures the `thread.started` id; subsequent turns run
- * `codex exec resume <id> <prompt>` so conversation memory carries over.
+ * with `--color never` and captures the `thread.started` id; subsequent turns
+ * run `codex exec resume <id> <prompt>` without `--color`, because the resume
+ * subcommand rejects that flag, so conversation memory carries over.
  *
  * Each turn is its own short-lived child (exec is one-shot), which keeps us off
  * the `codex app-server` path that starts the computer-use MCP server behind

--- a/tests/adapter-codex-driver.test.ts
+++ b/tests/adapter-codex-driver.test.ts
@@ -44,6 +44,23 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     });
   });
 
+  it("does not pass --color to `exec resume` (codex rejects it with exit 2)", async () => {
+    // Regression: the resume subcommand in codex-cli 0.130.0 does not accept
+    // --color, so reusing the first-turn flag list on resume failed every
+    // follow-up turn with "codex exec exited with code 2". The fake CLI exits 2
+    // if it sees --color on a resume, mirroring real codex.
+    const d = makeDriver();
+    await d.start(tmpdir());
+    const s = new AbortController().signal;
+    await d.prompt("first", () => {}, s);
+    const updates: schema.SessionUpdate[] = [];
+    const stop = await d.prompt("second", (u) => updates.push(u), s);
+    expect(stop).toBe("end_turn");
+    expect(updates.find((u) => u.sessionUpdate === "agent_message_chunk")).toMatchObject({
+      content: { type: "text", text: "resumed:second" },
+    });
+  });
+
   it("surfaces a command tool_call and tool_call_update", async () => {
     const d = makeDriver();
     await d.start(tmpdir());

--- a/tests/fixtures/fake-clis/fake-codex.mjs
+++ b/tests/fixtures/fake-clis/fake-codex.mjs
@@ -10,6 +10,14 @@ const isResume = argv[0] === "exec" && argv[1] === "resume";
 // The prompt is the final positional arg.
 const prompt = argv[argv.length - 1] ?? "";
 
+// Mirror real codex-cli 0.130.0: `--color` is valid on `codex exec` but the
+// `resume` subcommand rejects it with a clap usage error (exit code 2). The
+// driver must not pass `--color` to resume.
+if (isResume && argv.includes("--color")) {
+  process.stderr.write("error: unexpected argument '--color' found\n");
+  process.exit(2);
+}
+
 if (prompt.includes("SLOW_CANCEL")) {
   emit({ type: "thread.started", thread_id: "fake-thread" });
   emit({ type: "turn.started" });


### PR DESCRIPTION
## Intent

The developer wanted to diagnose why the production Baby Menu build failed when using the Codex agent, then asked the assistant to fix the root cause. Their requirement was to prevent follow-up Codex turns from failing with exit code 2 by correcting the Codex adapter's resume invocation. They explicitly expected the project’s TDD convention to be followed, with a regression test added before changing the implementation. The fix needed to preserve initial-turn behavior while ensuring resume commands no longer pass the unsupported --color flag.

## What Changed
- Updated the Codex adapter so initial `exec` turns still pass `--color never`, while `exec resume` turns omit the unsupported color flag.
- Added Codex driver regression coverage and fake CLI behavior to catch resume invocations that incorrectly include `--color`.

## Risk Assessment

✅ Low: The change is tightly scoped to removing an unsupported Codex resume flag while preserving first-turn arguments and adds a focused fake-CLI regression guard.

## Testing

Focused Codex adapter tests passed, the targeted regression test produced a debug transcript showing `exec resume fake-thread` without `--color`, and the built production adapter was exercised over ACP through a fake Codex CLI that would fail on the old resume invocation but completed a resumed second turn successfully.

<details>
<summary>Evidence: Bundled adapter ACP resume evidence</summary>

<code>First invocation includes `--color never`; resume invocation is `exec resume fake-thread --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules second`; `Resume contains --color: false`; second prompt text `resumed:second`; stopReason `end_turn`.</code>

```text
[codex-adapter] initialize 1
[codex-adapter] newSession 8e9286e3-6329-46e5-aa1b-ec84b5b1ec8c /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/baby-menu-codex-acp-evidence-2gsmyU
[codex-adapter] spawn codex exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules --color never <prompt>
[codex-adapter] codex exec exited 0
[codex-adapter] spawn codex exec resume fake-thread --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules <prompt>
[codex-adapter] codex exec exited 0
First Codex CLI invocation: exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules --color never first
Resume Codex CLI invocation: exec resume fake-thread --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules second
Resume contains --color: false
Second prompt ACP text: resumed:second
Second prompt ACP stopReason: end_turn
```
</details>
<details>
<summary>Evidence: Focused regression debug transcript</summary>

<code>Targeted regression test debug output shows the first fake Codex spawn includes `--color never`, while the second spawn is `exec resume fake-thread ... &lt;prompt&gt;` with no `--color` and exits 0.</code>

```text
Already up to date
Done in 146ms using pnpm v11.1.1
Already up to date
Done in 153ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTM1P0S3P9MGV824WJPF5VH

[codex-adapter] spawn /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTM1P0S3P9MGV824WJPF5VH/tests/fixtures/fake-clis/fake-codex.mjs exec --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules --color never <prompt>
[codex-adapter] codex exec exited 0
[codex-adapter] spawn /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTM1P0S3P9MGV824WJPF5VH/tests/fixtures/fake-clis/fake-codex.mjs exec resume fake-thread --json --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --ignore-user-config --ignore-rules <prompt>
[codex-adapter] codex exec exited 0

 Test Files  1 passed (1)
      Tests  1 passed | 7 skipped (8)
   Start at  12:43:31
   Duration  133ms (transform 20ms, setup 0ms, import 27ms, tests 47ms, environment 0ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm vitest run tests/adapter-codex-driver.test.ts`
- `BABY_MENU_ADAPTER_DEBUG=1 pnpm vitest run tests/adapter-codex-driver.test.ts -t "does not pass --color"`
- `node scripts/build-adapters.mjs`
- <code>Bundled `out/adapters/codex/index.mjs` was driven over ACP for two prompts using a temporary fake `codex` binary that exits with code 2 if `exec resume` receives `--color`; the first turn used `--color never`, the resume turn omitted `--color`, returned `resumed:second`, and ended with `end_turn`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
