### PR TITLE
fix(main): recover stale agent sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ The extension-facing slice of that contract is a generated public surface, treat
 - `ipc.ts` - registers all `ipcMain` handlers exposed via the preload bridge; the single place new generic IPC routes are added.
 - `agent-catalog.ts` - defines built-in agents, parses custom `agents.json`, computes Settings availability, and builds `acpx` registry overrides.
 - `agent-catalog-controller.ts` - owns the live agent catalog, validates Settings-added custom ACP agents, persists `agents.json`, and pushes refreshed registry overrides into the runtime without requiring an app restart.
-- `agent-runtime.ts` - `BabyMenuAgentRuntime` wrapping `acpx/runtime`; gates every `send()` through a change session.
-- `agent-turn-log.ts` - structured per-turn transcript log used by the renderer and tests.
+- `agent-runtime.ts` - `BabyMenuAgentRuntime` wrapping `acpx/runtime`; gates every `send()` through a change session, preserves structured turn failures, and retries once after deleting a stale persisted ACP session that reports `SESSION_RESUME_REQUIRED`.
+- `agent-turn-log.ts` - structured per-turn transcript log used by diagnostics and tests; failed turns include the runtime error message plus optional `code` and `detailCode`.
 - `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
 - `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
 - `extension-seeder.ts` - self-heals the packaged extension workspace from the bundled template on every launch: it force-copies the shipped defaults (`AGENTS.md`, `babymenu-env.d.ts`, `recipes/`, and starter extensions) so a stale or edited managed file is restored, while leaving user-created extensions the template does not ship untouched (it never deletes them). Editing a managed default in `~/.baby-menu/extensions` therefore does not persist; change the source under `extensions/` instead.
@@ -133,6 +133,8 @@ Every accepted `send()` call:
 3. Uses `GitChangeSession.begin(rootDir)` only for the tracked source `extensions/` workspace when that workspace is selected explicitly. If the working tree is dirty, it short-circuits and returns a refusal message instead of running the agent - this is intentional; do not bypass it for tracked edits.
 4. Lazily constructs the ACP runtime with `createFileSessionStore({ stateDir })` under `.cache/baby-menu/acp-sessions` in source mode or `~/.baby-menu/cache/acp-sessions` in packaged mode, with `permissionMode: "approve-all"`.
 5. Uses a fixed `sessionKey: "baby-menu-agent-chat"` so the agent has a single persistent conversation.
+6. If a failed turn returns `SESSION_RESUME_REQUIRED`, closes the runtime, removes `<stateDir>/sessions/baby-menu-agent-chat.json`, and retries the prompt once so bundled adapters that do not support `session/load` recover after an app restart.
+   The failed attempt is still written to `.cache/baby-menu/agent-turns` with its error `message`, `code`, and `detailCode`; if the retry fails, the renderer surfaces the real thrown message instead of replacing it with a generic unavailable reason.
 
 `GitChangeSession` (`src/main/git-change-session.ts`) is the safety boundary for Save/Rollback. Both operations refuse unless: the session started clean, the session is not already completed, and `HEAD` has not moved since the session began. `rollback()` runs `git reset --hard <recorded HEAD>` + `git clean -fd` - those destructive commands are only acceptable because of the preceding guards. Preserve this invariant.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ On launch, packaged Baby Menu refreshes bundled default extension files such as 
 Packaged release builds send anonymous, best-effort usage telemetry to a self-hosted Umami instance.
 Telemetry records app startup, popover opens, agent turn outcomes, and agent switches; it does not include a user or device id, prompts, file contents, generated code, extension data, or local paths, and network failures are ignored.
 Set `BABY_MENU_TELEMETRY=0` in the launch environment to opt out.
+If an agent send fails, the composer notice surfaces the underlying failure message instead of only showing a generic unavailable hint.
 Baby Menu detects supported agents from the catalog in order: Claude Code (`claude`), then Codex (`codex`).
 Those built-ins run through bundled clean-room ACP adapters that drive the authenticated local CLIs without inheriting user-level agent settings, skills, MCP servers, or extra rules.
 Use Settings to persist an agent choice across launches.
@@ -148,6 +149,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 - **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria.
   The agent reads the matching recipe before implementing.
 - **Bundled ACP adapters** - the built-in Claude Code and Codex entries launch `out/adapters/<name>/index.mjs`, which wraps the local authenticated CLI and keeps Baby Menu's embedded agent isolated from user-level agent configuration.
+  If a restart leaves behind a persisted ACP session that an adapter cannot resume, Baby Menu records the failed attempt, deletes that stale session record, and retries once with a fresh session.
 - **Live custom agent catalog** - Settings-owned custom ACP agents are persisted to `agents.json`, registered as `acpx` overrides immediately, and kept separate from read-only built-ins.
 - **Settings overlay** - Settings covers the default menu without unmounting it, so chat composer, widget, and run state survive opening and closing Settings.
 - **Release update indicator** - the main process checks the latest GitHub Release at most every four hours, keeps failures silent, and shows a header indicator with `brew update && brew upgrade --cask baby-menu` only when a newer packaged release exists.

--- a/src/main/agent-runtime.ts
+++ b/src/main/agent-runtime.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   createAcpRuntime,
@@ -48,6 +48,17 @@ type ResolveDefaultAgentNameOptions = {
 
 const DEFAULT_AGENT_TIMEOUT_MS = 300_000;
 
+// One persistent conversation per app, keyed for the file session store. The
+// persisted record outlives the app process, so a fresh launch tries to resume
+// it - see SESSION_KEY use below and the resume-recovery path in runSend.
+const SESSION_KEY = "baby-menu-agent-chat";
+
+// acpx flags a failed turn with this detailCode when a persisted session cannot
+// be resumed because the agent reports loadSession:false. The bundled adapters
+// mint a fresh session per process and never support session/load, so every
+// launch with a leftover persisted record hits this until we drop the record.
+const SESSION_RESUME_REQUIRED_DETAIL_CODE = "SESSION_RESUME_REQUIRED";
+
 function telemetryAgentName(agentName: string): string {
   return BUILT_IN_AGENT_NAMES.has(agentName) ? agentName : "custom";
 }
@@ -69,6 +80,34 @@ export class AgentTimeoutError extends Error {
     super(`Agent request timed out after ${timeoutMs}ms while ${phase}.`);
     this.name = "AgentTimeoutError";
   }
+}
+
+// Carries the acpx turn-result error so callers can branch on the structured
+// detailCode (for example to recover from SESSION_RESUME_REQUIRED) instead of
+// string-matching a flattened message.
+export class AgentTurnFailedError extends Error {
+  readonly code?: string;
+  readonly detailCode?: string;
+  readonly retryable?: boolean;
+
+  constructor(error: { message?: string; code?: string; detailCode?: string; retryable?: boolean }) {
+    super(error.message || "Agent turn failed");
+    this.name = "AgentTurnFailedError";
+    this.code = error.code;
+    this.detailCode = error.detailCode;
+    this.retryable = error.retryable;
+  }
+}
+
+function isSessionResumeRequiredError(error: unknown): boolean {
+  return error instanceof AgentTurnFailedError && error.detailCode === SESSION_RESUME_REQUIRED_DETAIL_CODE;
+}
+
+function turnFailureDetail(error: unknown): { message: string; code?: string; detailCode?: string } {
+  if (error instanceof AgentTurnFailedError) {
+    return { message: error.message, code: error.code, detailCode: error.detailCode };
+  }
+  return { message: error instanceof Error ? error.message : String(error) };
 }
 
 export function commandExists(command: string): boolean {
@@ -189,7 +228,7 @@ export function collectAgentTurnOutput(
 
     const result = await turn.result;
     if (result.status === "failed") {
-      throw new Error(result.error.message || "Agent turn failed");
+      throw new AgentTurnFailedError(result.error);
     }
     if (result.status === "cancelled") {
       throw new Error("Agent turn was cancelled");
@@ -388,6 +427,35 @@ export class BabyMenuAgentRuntime {
       };
     }
 
+    try {
+      return await this.runTurnAttempt(prompt, options, agentCwd, changeSession, telemetryAgent);
+    } catch (error) {
+      // A persisted session that the bundled (loadSession:false) adapter cannot
+      // resume after a restart fails the FIRST turn with SESSION_RESUME_REQUIRED.
+      // Drop the stale record and start a fresh session once so the agent does
+      // not look permanently "unavailable" until the cache is cleared by hand.
+      if (isSessionResumeRequiredError(error)) {
+        await this.discardPersistedSession("session-resume-required");
+        try {
+          return await this.runTurnAttempt(prompt, options, agentCwd, changeSession, telemetryAgent);
+        } catch (retryError) {
+          throw this.reportTurnError(retryError, telemetryAgent);
+        }
+      }
+      throw this.reportTurnError(error, telemetryAgent);
+    }
+  }
+
+  // Runs exactly one agent turn. Timeouts are terminal and resolved here into a
+  // user-facing result; any other failure throws (carrying the structured
+  // AgentTurnFailedError) so runSend can decide whether to recover and retry.
+  private async runTurnAttempt(
+    prompt: string,
+    options: BabyMenuAgentRuntimeSendOptions,
+    agentCwd: string,
+    changeSession: AgentChangeSession,
+    telemetryAgent: string,
+  ): Promise<AgentChatResult> {
     let runtime: AcpxRuntime | null = null;
     let handle: AcpRuntimeHandle | null = null;
     let turnLog: AgentTurnLogRecorder | null = null;
@@ -396,7 +464,7 @@ export class BabyMenuAgentRuntime {
       runtime = await this.ensureRuntime(agentCwd);
       handle = await withAgentTimeout(
         runtime.ensureSession({
-          sessionKey: "baby-menu-agent-chat",
+          sessionKey: SESSION_KEY,
           agent: this.agentName,
           mode: "persistent",
           cwd: agentCwd,
@@ -436,8 +504,7 @@ export class BabyMenuAgentRuntime {
       };
     } catch (error) {
       if (!(error instanceof AgentTimeoutError)) {
-        await turnLog?.finish("failed").catch(() => undefined);
-        this.telemetry?.track("agent_turn", { agent: telemetryAgent, status: "error" });
+        await turnLog?.finishFailed(turnFailureDetail(error)).catch(() => undefined);
         throw error;
       }
       await turnLog?.recordTimeout(error).catch(() => undefined);
@@ -453,6 +520,27 @@ export class BabyMenuAgentRuntime {
         session: changeSession.snapshot("Agent timed out. Review any partial repo changes, then Save or Rollback."),
       };
     }
+  }
+
+  private reportTurnError(error: unknown, telemetryAgent: string): unknown {
+    this.telemetry?.track("agent_turn", { agent: telemetryAgent, status: "error" });
+    return error;
+  }
+
+  /**
+   * Drops the persisted ACP session so the next turn starts a fresh one. The
+   * acpx file session store exposes no delete, and runtime.close's
+   * discardPersistentState does NOT remove the on-disk record, so we close the
+   * live runtime and delete the persisted session file ourselves.
+   */
+  private async discardPersistedSession(reason: string): Promise<void> {
+    await this.closeRuntime(reason, true, true);
+    await rm(this.persistedSessionFilePath(), { force: true }).catch(() => undefined);
+  }
+
+  private persistedSessionFilePath(): string {
+    const stateDir = this.paths?.agentStateDir ?? getAgentStateDir(this.rootDir);
+    return join(stateDir, "sessions", `${SESSION_KEY}.json`);
   }
 
   async save(message?: string) {

--- a/src/main/agent-turn-log.ts
+++ b/src/main/agent-turn-log.ts
@@ -21,6 +21,12 @@ type AgentTurnLogEvent = {
 
 type AgentTurnLogStatus = "started" | "completed" | "failed" | "timed_out";
 
+type FailureDetails = {
+  message: string;
+  code?: string;
+  detailCode?: string;
+};
+
 type AgentTurnLogRecord = {
   schemaVersion: 1;
   agentName: string;
@@ -32,6 +38,7 @@ type AgentTurnLogRecord = {
   status: AgentTurnLogStatus;
   events: AgentTurnLogEvent[];
   timeout?: TimeoutDetails;
+  error?: FailureDetails;
   gitStatusBeforeTimeout: string | null;
   gitStatusAfterTimeout?: string | null;
 };
@@ -100,6 +107,15 @@ export class AgentTurnLogRecorder {
   async finish(status: Exclude<AgentTurnLogStatus, "started" | "timed_out">): Promise<void> {
     this.record.status = status;
     this.record.endedAt = new Date().toISOString();
+    await this.write();
+  }
+
+  // Records why a turn failed so a swallowed runtime error (for example the
+  // adapter rejecting a stale persisted session) is diagnosable from the log.
+  async finishFailed(error: FailureDetails): Promise<void> {
+    this.record.status = "failed";
+    this.record.endedAt = new Date().toISOString();
+    this.record.error = error;
     await this.write();
   }
 

--- a/src/renderer/agent/useAgentRuntime.ts
+++ b/src/renderer/agent/useAgentRuntime.ts
@@ -115,12 +115,12 @@ export function useAgentRuntime() {
       const nextChange = sessionNoticeForResult(result.assistantText, trimmed, result.session);
       setPendingChange(nextChange.kind === "pending" ? nextChange : null);
       setNotice(nextChange.kind === "pending" ? null : nextChange);
-    } catch {
+    } catch (error) {
       setPendingChange(null);
       setNotice({
         kind: "error",
         summary: "Agent unavailable",
-        hint: unavailableText,
+        hint: failureReason(error) ?? unavailableText,
       });
     } finally {
       setRun(null);
@@ -201,6 +201,15 @@ function sessionNoticeForSnapshot(snapshot: GitSessionSnapshot): AgentSessionNot
     canKeep: snapshot.canSave,
     canUndo: snapshot.canRollback,
   };
+}
+
+// Surfaces the real reason a send failed instead of a blanket "unavailable".
+// Electron wraps IPC rejections as "Error invoking remote method '...': Error: <real>",
+// so we keep only the trailing message the main process actually threw.
+function failureReason(error: unknown): string | null {
+  if (!(error instanceof Error)) return null;
+  const message = error.message.replace(/^Error invoking remote method '[^']*':\s*/, "").replace(/^Error:\s*/, "").trim();
+  return message || null;
 }
 
 function summarizeAgentResult(assistantText: string, prompt: string): string {

--- a/tests/agent-chat.test.tsx
+++ b/tests/agent-chat.test.tsx
@@ -143,6 +143,20 @@ describe("AgentChat", () => {
     expect(screen.getByText("Review the generated changes, then Save or Rollback.")).toBeTruthy();
   });
 
+  it("surfaces the real failure reason when a send rejects", async () => {
+    installBabyMenuAgentMock();
+    window.babyMenu!.agent.send = vi.fn(async () => {
+      throw new Error("codex CLI exited with code 127");
+    });
+    render(<AgentChat />);
+
+    const composer = screen.getByPlaceholderText("talk to the baby");
+    fireEvent.change(composer, { target: { value: "add a widget" } });
+    fireEvent.submit(composer.closest("form")!);
+
+    expect(await screen.findByText("codex CLI exited with code 127")).toBeTruthy();
+  });
+
   it("does not show a prompt when no change session is open on mount", async () => {
     const agent = installBabyMenuAgentMock({ session: null });
     render(<AgentChat />);

--- a/tests/agent-runtime.test.ts
+++ b/tests/agent-runtime.test.ts
@@ -1,10 +1,12 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { AcpRuntimeEvent, AcpRuntimeTurn } from "acpx/runtime";
 import {
   AgentTimeoutError,
+  AgentTurnFailedError,
   BabyMenuAgentRuntime,
   agentRuntimeStatusForEvent,
   buildBabyMenuAgentPrompt,
@@ -586,5 +588,124 @@ describe("agent runtime telemetry", () => {
       name: "agent_turn",
       fields: { agent: "custom", status: "error" },
     });
+  });
+});
+
+describe("agent runtime session resume recovery", () => {
+  function failedTurn(error: {
+    message: string;
+    code?: string;
+    detailCode?: string;
+    retryable?: boolean;
+  }): AcpRuntimeTurn {
+    return {
+      requestId: "failed-turn",
+      events: (async function* () {})(),
+      result: Promise.resolve({ status: "failed", error }),
+      cancel: vi.fn(async () => undefined),
+      closeStream: vi.fn(async () => undefined),
+    };
+  }
+
+  it("throws a structured AgentTurnFailedError carrying the acpx detail code", async () => {
+    const turn = failedTurn({
+      message: "Persistent ACP session 810619c3 could not be resumed: agent does not support session/load",
+      code: "RUNTIME",
+      detailCode: "SESSION_RESUME_REQUIRED",
+      retryable: true,
+    });
+
+    await expect(collectAgentTurnOutput(turn, { idleTimeoutMs: 50 })).rejects.toMatchObject({
+      name: "AgentTurnFailedError",
+      detailCode: "SESSION_RESUME_REQUIRED",
+      retryable: true,
+    });
+  });
+
+  type RecoveryInternals = {
+    ensureAgentRuntimeCwd: () => Promise<string>;
+    beginChangeSession: () => Promise<unknown>;
+    ensureRuntime: () => Promise<unknown>;
+    collectTurnOutput: () => Promise<string>;
+  };
+
+  async function buildRecoveryRuntime(collectImpls: Array<() => Promise<string>>) {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-resume-"));
+    const extensionsDir = join(rootDir, "extensions-dev");
+    const agentStateDir = join(rootDir, ".cache", "acp-sessions");
+    const sessionFile = join(agentStateDir, "sessions", "baby-menu-agent-chat.json");
+    await mkdir(join(agentStateDir, "sessions"), { recursive: true });
+    await writeFile(sessionFile, JSON.stringify({ stale: true }), "utf8");
+
+    const telemetry: Array<{ name: string; fields: Record<string, unknown> }> = [];
+    const runtime = new BabyMenuAgentRuntime(rootDir, {
+      agentName: "codex",
+      telemetry: {
+        track: (name: string, fields: Record<string, unknown> = {}) => telemetry.push({ name, fields }),
+        pageview: () => {},
+        close: async () => {},
+      },
+      paths: { extensionsDir, agentStateDir, snapshotDir: join(rootDir, ".cache", "snapshots") },
+    });
+
+    const internals = runtime as unknown as RecoveryInternals;
+    internals.ensureAgentRuntimeCwd = vi.fn(async () => extensionsDir);
+    internals.beginChangeSession = vi.fn(async () => ({
+      startedClean: true,
+      canSave: true,
+      canRollback: true,
+      snapshot: (message?: string) => ({ startedClean: true, canSave: true, canRollback: true, head: "HEAD", message }),
+      save: vi.fn(async () => ({ ok: true })),
+      rollback: vi.fn(async () => ({ ok: true })),
+    }));
+    internals.ensureRuntime = vi.fn(async () => ({
+      ensureSession: vi.fn(async () => ({})),
+      startTurn: vi.fn(() => fakeTurn({ events: (async function* () {})() })),
+    }));
+    const collect = vi.fn();
+    for (const impl of collectImpls) collect.mockImplementationOnce(impl);
+    internals.collectTurnOutput = collect;
+
+    return { runtime, telemetry, sessionFile, collect };
+  }
+
+  it("recovers from SESSION_RESUME_REQUIRED by discarding the persisted session and retrying once", async () => {
+    const { runtime, telemetry, sessionFile, collect } = await buildRecoveryRuntime([
+      async () => {
+        throw new AgentTurnFailedError({
+          message: "Persistent ACP session could not be resumed: agent does not support session/load",
+          code: "RUNTIME",
+          detailCode: "SESSION_RESUME_REQUIRED",
+          retryable: true,
+        });
+      },
+      async () => "built the widget after a fresh session",
+    ]);
+
+    expect(existsSync(sessionFile)).toBe(true);
+
+    const result = await runtime.send("add a widget");
+
+    expect(result.assistantText).toContain("built the widget after a fresh session");
+    expect(collect).toHaveBeenCalledTimes(2);
+    // The stale persisted session record is deleted so the retry starts fresh.
+    expect(existsSync(sessionFile)).toBe(false);
+    // A recovered turn reports success, not error.
+    expect(telemetry).toContainEqual({ name: "agent_turn", fields: { agent: "codex", status: "success" } });
+    expect(telemetry).not.toContainEqual({ name: "agent_turn", fields: { agent: "codex", status: "error" } });
+  });
+
+  it("does not discard the session or retry for an unrelated turn failure", async () => {
+    const { runtime, telemetry, sessionFile, collect } = await buildRecoveryRuntime([
+      async () => {
+        throw new AgentTurnFailedError({ message: "model error", code: "RUNTIME", detailCode: "ACP_TURN_FAILED" });
+      },
+    ]);
+
+    await expect(runtime.send("add a widget")).rejects.toThrow("model error");
+
+    expect(collect).toHaveBeenCalledTimes(1);
+    expect(existsSync(sessionFile)).toBe(true);
+    expect(telemetry).toContainEqual({ name: "agent_turn", fields: { agent: "codex", status: "error" } });
   });
 });

--- a/tests/agent-turn-log.test.ts
+++ b/tests/agent-turn-log.test.ts
@@ -69,6 +69,36 @@ describe("AgentTurnLogRecorder", () => {
     ]);
   });
 
+  it("records the failure error detail when a turn fails", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-turn-log-"));
+    tempDirs.push(rootDir);
+
+    const recorder = await AgentTurnLogRecorder.start({
+      rootDir,
+      agentName: "codex",
+      requestId: "request-failed",
+      prompt: "do the thing",
+    });
+
+    await recorder.finishFailed({
+      message: "Persistent ACP session abc could not be resumed: agent does not support session/load",
+      code: "RUNTIME",
+      detailCode: "SESSION_RESUME_REQUIRED",
+    });
+
+    const log = await readLog(recorder.filePath);
+
+    expect(log).toMatchObject({
+      status: "failed",
+      error: {
+        message: expect.stringContaining("could not be resumed"),
+        code: "RUNTIME",
+        detailCode: "SESSION_RESUME_REQUIRED",
+      },
+    });
+    expect(log.endedAt).toEqual(expect.any(String));
+  });
+
   it("records git status before and after an idle timeout", async () => {
     const repo = await createRepo();
     tempDirs.push(repo);

--- a/tests/e2e-acp-runtime.test.ts
+++ b/tests/e2e-acp-runtime.test.ts
@@ -127,6 +127,55 @@ describe("BabyMenuAgentRuntime ACP e2e", () => {
   );
 
   it.skipIf(process.platform === "win32")(
+    "recovers a stale persisted session after a restart instead of failing the turn",
+    async () => {
+      const repo = await createRepo();
+      tempDirs.push(repo);
+      // Source mode gitignores runtime state; without this the untracked .cache
+      // files (turn logs, session store) would dirty the tree before the restart.
+      await writeFile(join(repo, ".gitignore"), ".cache/\n");
+      await git(repo, ["add", ".gitignore"]);
+      await git(repo, ["commit", "-m", "ignore runtime cache"]);
+      const logDir = await mkdtemp(join(tmpdir(), "baby-menu-acp-logs-"));
+      tempDirs.push(logDir);
+      const mockLogPath = join(logDir, "mock-acp.jsonl");
+
+      const makeRuntime = () =>
+        new BabyMenuAgentRuntime(repo, {
+          agentName: "mock-target",
+          registryOverrides: { "mock-target": buildMockCommand(mockLogPath) },
+        });
+
+      // First launch: run a turn and accept it so the tree is clean for the restart.
+      const first = makeRuntime();
+      await first.send("first turn");
+      await first.save("accept first");
+      await first.close();
+
+      // acpx persisted the session record to disk; a fresh process will try to resume it.
+      const sessionFile = join(repo, ".cache", "baby-menu", "acp-sessions", "sessions", "baby-menu-agent-chat.json");
+      expect(existsSync(sessionFile)).toBe(true);
+
+      // Restart: acp-mock reports loadSession:false, so resuming the stale record
+      // fails with SESSION_RESUME_REQUIRED. The runtime must discard it and start
+      // fresh rather than surfacing "Agent unavailable".
+      const second = makeRuntime();
+      const result = await second.send("second turn after restart");
+      await second.close();
+
+      expect(result.assistantText).toContain("mock acp turn completed");
+
+      const turnLogs = await readTurnLogs(repo);
+      const failed = turnLogs.find((log) => log.status === "failed");
+      // The failed attempt proves the restart actually hit the resume path (not that
+      // resume silently worked) and that the reason is now recorded in the log.
+      expect(failed?.error).toMatchObject({ detailCode: "SESSION_RESUME_REQUIRED" });
+      expect(turnLogs.filter((log) => log.status === "completed")).toHaveLength(2);
+    },
+    30_000,
+  );
+
+  it.skipIf(process.platform === "win32")(
     "rolls back changes produced through acpx and acp-mock",
     async () => {
       const repo = await createRepo();


### PR DESCRIPTION
## Intent

The developer wanted to diagnose why Baby Menu’s production build showed a generic agent-unavailable error after talking to the Codex agent, then confirm whether the failure was caused by switching agents or by a persisted-session restart issue. They asked for logs and a standalone reproduction to validate the theory, and after confirmation they approved implementing an auto-recovery fix. Their requirements were to handle stale persisted ACP sessions for adapters that do not support session/load, preserve diagnosability by logging and surfacing real failure details, and implement the fix test-first with a permanent repro-style test.

## What Changed

- Retry agent turns once after detecting a stale persisted ACP session, deleting the stale session file so adapters without `session/load` support can recover after restart.
- Preserve diagnosability by logging the failed stale-session attempt with error code details and surfacing the real retry failure instead of a generic unavailable message.
- Documented the recovery behavior and added regression coverage for runtime recovery, turn logs, renderer chat handling, and ACP runtime e2e recovery.

## Risk Assessment

✅ Low: The change is narrowly scoped to preserving structured ACP turn failures, retrying only the known stale-session detail code once, and surfacing clearer renderer errors without broad control-flow or persistence changes.

## Testing

After an initial parallel `pnpm` dependency-install race that resolved with a successful install, the targeted recovery, log/UI, and ACP e2e tests passed; the standalone evidence repro created a real git repo, ran one ACP turn, restarted with a persisted session, recorded the SESSION_RESUME_REQUIRED failed resume attempt, and then showed the retry completing successfully with `mock acp turn completed`.

<details>
<summary>Evidence: Standalone stale-session recovery repro test</summary>

```text
import { execFile } from "node:child_process";
import { existsSync } from "node:fs";
import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
import { join, resolve } from "node:path";
import { promisify } from "node:util";
import { expect, it } from "vitest";
import { BabyMenuAgentRuntime } from "/Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTYB6EKK958DEAGJRR0ZT3J/src/main/agent-runtime";
import { mockAgentCommand } from "/Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTYB6EKK958DEAGJRR0ZT3J/node_modules/acp-mock/dist/index.js";

const execFileAsync = promisify(execFile);
const workspace = "/Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSTYB6EKK958DEAGJRR0ZT3J";
const evidenceDir = "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J";
const acpMockBinPath = join(workspace, "node_modules", "acp-mock", "dist", "cli.js");

async function git(cwd: string, args: string[]) {
  return execFileAsync("git", args, { cwd });
}

async function readTurnLogs(repo: string): Promise<Record<string, unknown>[]> {
  const logDir = join(repo, ".cache", "baby-menu", "agent-turns");
  const files = await readdir(logDir);
  return Promise.all(files.map((file) => readFile(join(logDir, file), "utf8").then((text) => JSON.parse(text) as Record<string, unknown>)));
}

function buildMockCommand(eventLogPath: string) {
  return mockAgentCommand({
    bin: acpMockBinPath,
    eventLogPath,
    agentMessageJson: {
      summary: "mock acp turn completed",
      changed: ["README.md"],
    },
    appendFile: {
      path: "../README.md",
      text: "- edited by acp-mock\n",
    },
  });
}

it("captures stale persisted session recovery evidence", async () => {
  const repo = join(evidenceDir, "stale-session-repo");
  await rm(repo, { recursive: true, force: true });
  await mkdir(repo, { recursive: true });
  await git(repo, ["init", "-b", "main"]);
  await git(repo, ["config", "user.email", "tests@example.com"]);
  await git(repo, ["config", "user.name", "Baby Menu ACP Evidence"]);
  await writeFile(join(repo, "README.md"), "# fixture\n", "utf8");
  await writeFile(join(repo, ".gitignore"), ".cache/\n", "utf8");
  await git(repo, ["add", "."]);
  await git(repo, ["commit", "-m", "initial"]);

  const mockLogPath = join(evidenceDir, "mock-acp.jsonl");
  await rm(mockLogPath, { force: true });
  const makeRuntime = () =>
    new BabyMenuAgentRuntime(repo, {
      agentName: "mock-target",
      registryOverrides: { "mock-target": buildMockCommand(mockLogPath) },
    });

  const first = makeRuntime();
  const firstResult = await first.send("first turn");
  await first.save("accept first");
  await first.close();

  const sessionFile = join(repo, ".cache", "baby-menu", "acp-sessions", "sessions", "baby-menu-agent-chat.json");
  const sessionExistedBeforeRestart = existsSync(sessionFile);

  const second = makeRuntime();
  const secondResult = await second.send("second turn after restart");
  await second.close();

  const turnLogs = await readTurnLogs(repo);
  const failedAttempt = turnLogs.find((log) => log.status === "failed");
  const completedCount = turnLogs.filter((log) => log.status === "completed").length;
  const summary = {
    firstAssistantText: firstResult.assistantText,
    sessionExistedBeforeRestart,
    sessionExistsAfterRecovery: existsSync(sessionFile),
    secondAssistantText: secondResult.assistantText,
    failedAttemptError: failedAttempt?.error ?? null,
    completedTurnCount: completedCount,
    repo: resolve(repo),
    turnLogDirectory: resolve(repo, ".cache", "baby-menu", "agent-turns"),
    mockAcpEventLog: mockLogPath,
  };
  await writeFile(join(evidenceDir, "stale-session-recovery-summary.json"), JSON.stringify(summary, null, 2), "utf8");

  expect(sessionExistedBeforeRestart).toBe(true);
  expect(secondResult.assistantText).toContain("mock acp turn completed");
  expect(failedAttempt?.error).toMatchObject({ detailCode: "SESSION_RESUME_REQUIRED" });
  expect(completedCount).toBe(2);
});
```
</details>
<details>
<summary>Evidence: Recovery summary JSON</summary>

<code>Shows first and second assistant responses as `mock acp turn completed`, `sessionExistedBeforeRestart: true`, failed attempt `detailCode: SESSION_RESUME_REQUIRED`, and `completedTurnCount: 2`.</code>

```text
{
  "firstAssistantText": "{\"summary\":\"mock acp turn completed\",\"changed\":[\"README.md\"]}",
  "sessionExistedBeforeRestart": true,
  "sessionExistsAfterRecovery": true,
  "secondAssistantText": "{\"summary\":\"mock acp turn completed\",\"changed\":[\"README.md\"]}",
  "failedAttemptError": {
    "message": "Persistent ACP session 30b607f6b3ebfba54d4e996f9401713a could not be resumed: agent does not support session/load",
    "code": "RUNTIME",
    "detailCode": "SESSION_RESUME_REQUIRED"
  },
  "completedTurnCount": 2,
  "repo": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J/stale-session-repo",
  "turnLogDirectory": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J/stale-session-repo/.cache/baby-menu/agent-turns",
  "mockAcpEventLog": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J/mock-acp.jsonl"
}
```
</details>
<details>
<summary>Evidence: Failed resume turn log with structured detail code</summary>

<code>Turn log status is `failed` for prompt `second turn after restart`, with error `detailCode: SESSION_RESUME_REQUIRED` and message `agent does not support session/load`.</code>

```text
{
  "schemaVersion": 1,
  "agentName": "mock-target",
  "requestId": "5da26f78-2872-4e2f-b5d4-1f34e6520fca",
  "promptPreview": "second turn after restart",
  "startedAt": "2026-05-29T22:45:38.421Z",
  "status": "failed",
  "events": [],
  "gitStatusBeforeTimeout": "",
  "endedAt": "2026-05-29T22:45:38.494Z",
  "error": {
    "message": "Persistent ACP session 30b607f6b3ebfba54d4e996f9401713a could not be resumed: agent does not support session/load",
    "code": "RUNTIME",
    "detailCode": "SESSION_RESUME_REQUIRED"
  }
}
```
</details>
<details>
<summary>Evidence: Recovered retry turn log</summary>

<code>Turn log status is `completed` for the same `second turn after restart` prompt after the stale session was discarded and retried.</code>

```text
{
  "schemaVersion": 1,
  "agentName": "mock-target",
  "requestId": "25d9be52-f4e2-42fb-be11-7de3cdd2c424",
  "promptPreview": "second turn after restart",
  "startedAt": "2026-05-29T22:45:38.622Z",
  "status": "completed",
  "events": [
    {
      "at": "2026-05-29T22:45:38.632Z",
      "type": "text_delta",
      "stream": "output"
    }
  ],
  "gitStatusBeforeTimeout": "",
  "lastActivityAt": "2026-05-29T22:45:38.632Z",
  "endedAt": "2026-05-29T22:45:39.642Z"
}
```
</details>
<details>
<summary>Evidence: ACP mock event log</summary>

<code>Shows the first persisted session id, then after restart a fresh `agent:newSession` id followed by `agent:prompt:done`, demonstrating recovery through the same ACP path an end user would trigger.</code>

```text
{"timestamp":"2026-05-29T22:45:37.310Z","pid":23557,"event":"process:ready"}
{"timestamp":"2026-05-29T22:45:37.313Z","pid":23557,"event":"agent:initialize"}
{"timestamp":"2026-05-29T22:45:37.315Z","pid":23557,"event":"agent:newSession","sessionId":"30b607f6b3ebfba54d4e996f9401713a","cwd":"/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J/stale-session-repo/extensions"}
{"timestamp":"2026-05-29T22:45:37.326Z","pid":23557,"event":"agent:prompt:start","sessionId":"30b607f6b3ebfba54d4e996f9401713a"}
{"timestamp":"2026-05-29T22:45:37.326Z","pid":23557,"event":"workspace:changed","path":"../README.md"}
{"timestamp":"2026-05-29T22:45:37.326Z","pid":23557,"event":"agent:prompt:done"}
{"timestamp":"2026-05-29T22:45:38.486Z","pid":23672,"event":"process:ready"}
{"timestamp":"2026-05-29T22:45:38.489Z","pid":23672,"event":"agent:initialize"}
{"timestamp":"2026-05-29T22:45:38.552Z","pid":23678,"event":"process:ready"}
{"timestamp":"2026-05-29T22:45:38.555Z","pid":23678,"event":"agent:initialize"}
{"timestamp":"2026-05-29T22:45:38.617Z","pid":23684,"event":"process:ready"}
{"timestamp":"2026-05-29T22:45:38.620Z","pid":23684,"event":"agent:initialize"}
{"timestamp":"2026-05-29T22:45:38.622Z","pid":23684,"event":"agent:newSession","sessionId":"e86520c7d2d18c36ab5718a1d5ff7fed","cwd":"/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J/stale-session-repo/extensions"}
{"timestamp":"2026-05-29T22:45:38.631Z","pid":23684,"event":"agent:prompt:start","sessionId":"e86520c7d2d18c36ab5718a1d5ff7fed"}
{"timestamp":"2026-05-29T22:45:38.631Z","pid":23684,"event":"workspace:changed","path":"../README.md"}
{"timestamp":"2026-05-29T22:45:38.632Z","pid":23684,"event":"agent:prompt:done"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm vitest run tests/agent-runtime.test.ts -t &#34;agent runtime session resume recovery&#34;` (initial attempt hit a dependency-install race, rerun passed after install completed)</code>
- <code>`pnpm vitest run tests/e2e-acp-runtime.test.ts -t &#34;recovers a stale persisted session&#34;` (initial attempt hit the same dependency-install race, rerun passed after install completed)</code>
- `pnpm vitest run tests/agent-turn-log.test.ts tests/agent-chat.test.tsx`
- `pnpm vitest run --root "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYB6EKK958DEAGJRR0ZT3J" "stale-session-repro.test.ts"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
