### PR TITLE
feat: support custom popover layouts

### DIFF
--- a/.agents/skills/baby-menu-design/README.md
+++ b/.agents/skills/baby-menu-design/README.md
@@ -12,7 +12,7 @@ Baby Menu is a tray-popover OS-level utility built around a single moving surfac
 
 When the user sends a request, the composer momentarily becomes a `RunStrip`: a single live affordance with a pulsing mint dot, the agent's current step, and an elapsed timer. **No log, no step history.** When the agent finishes, a `SessionBar` slides in with a plain-language summary of what was added (`Added a CPU temperature widget`) and two buttons: **Keep** and **Undo**. The user never sees commit SHAs, file counts, or the word "git" — those are infrastructure they shouldn't have to think about.
 
-The popover surface is dynamic-height.
+The popover surface is adaptive: 504px wide by default, wider when a root `layout.tsx` owns a custom canvas, and dynamic-height within the host limits.
 On the main menu, the composer is pinned to the bottom; everything above it stacks and grows.
 The header keeps compact update, settings, and quit controls together; the update control appears only when a newer release is available, while quit stays neutral at rest and shifts to danger coral only on hover.
 Settings replaces the menu body and composer, and includes both the `open at login` preference and the embedded-agent picker.
@@ -206,7 +206,7 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 ### Layout rules
 
-- Width is fixed at **504px** in the live popover. Do not design responsive popover widths unless the runtime sizing code changes.
+- Width is **504px by default** in the live popover. A custom root `layout.tsx` may set a wider explicit canvas, and the host resizes the popover to fit within the screen.
 - **Height is auto.** The popover grows to fit. Plan layouts for any height between 220px and 720px. Once the popover reaches its max height, the popover body scrolls; the header and active agent-control surface stay pinned.
 - The **composer** is pinned to the bottom on the main menu and idle agent surface; it is hidden while the settings view is open and replaced by the RunStrip while an agent run is in flight.
 - The **SessionBar** is pinned just above the composer **only when** the agent has just added or undone something and is waiting for the user to decide.
@@ -215,7 +215,9 @@ Easings: `--ease` `cubic-bezier(0.22, 0.61, 0.36, 1)` for entry; `--ease-in-out`
 
 ### Card anatomy (widget)
 
-A widget is a vertical stack inside the popover body, separated from its neighbors by a `1px dashed` divider — *not* a contained card. Top to bottom:
+A default-layout widget is a vertical stack inside the popover body, separated from its neighbors by a `1px dashed` divider - *not* a contained card.
+A custom root `layout.tsx` may arrange widgets in another canvas, but each widget body should still avoid card-like containment.
+Top to bottom:
 
 1. **Head row** — tracked-caps `key` (e.g. `CLAUDE · WEEKLY`) on the left. The host does not render a generic manual refresh button.
 2. **Value row** — the big number (weight 300, 28–36px, tabular numerals, tight tracking) with the unit at small. Optional status word on the right.

--- a/.agents/skills/baby-menu-design/SKILL.md
+++ b/.agents/skills/baby-menu-design/SKILL.md
@@ -15,7 +15,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 - `README.md` — full brand brief: product context, content fundamentals, visual foundations, iconography.
 - `colors_and_type.css` — prototype and app-shell token reference. For production widgets, use `@babymenu/ui` and the live Tailwind tokens in `src/ui/theme.css`; never invent new tokens without updating the relevant source first.
 - `preview/` — small HTML cards that document each token / component visually.
-- `ui_kits/popup-menu/` — the canonical UI kit: a clickable recreation of the redesigned tray popover with `MenuBar`, `Composer`, `RunStrip`, `SessionBar`, `WidgetHost` and three sample widgets.
+- `ui_kits/popup-menu/` - the canonical UI kit: a clickable recreation of the redesigned tray popover with `MenuBar`, `Composer`, `RunStrip`, `SessionBar`, `WidgetHost` and three sample widgets.
 
 ## The direction in one paragraph
 
@@ -23,7 +23,7 @@ If the user invokes this skill without any other guidance, ask them what they wa
 
 ## Hard rules
 
-1. Baby Menu is a **macOS tray popover**, 504px wide, dynamic-height. Never design for a full browser window.
+1. Baby Menu is a **macOS tray popover**, 504px wide by default and adaptive in both width and height when a root `layout.tsx` defines a wider canvas. Never design for a full browser window.
 2. **The agent's work is not a chat.** No transcript, no bubbles, no history. Use the `RunStrip` pattern: one live affordance (pulsing mint dot + current step + timer), replaced by a `SessionBar` when done.
 3. **No build-mode toggle.** On the main idle surface, the composer is one slim row pinned to the bottom of the popover. It auto-grows to a second line when the user types more. During an active agent run, `RunStrip` replaces the composer; the settings view also replaces it while open.
 4. **Never expose git, files, or commits to the user.** The SessionBar reads "Added a CPU temperature widget", not "3 files committed · b8d3a2c". Buttons are **Keep** and **Undo**, not Save and Rollback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Three processes, kept deliberately separate:
 
 1. **Main** (`src/main/`) - app lifecycle, tray, popover window, IPC, git, agent runtime. Never call agent or git from the renderer directly.
 2. **Preload** (`src/preload/index.ts`) - the stable bridge. Exposes `window.babyMenu` via `contextBridge`. Do not add one-off preload methods for each widget.
-3. **Renderer** (`src/renderer/`) - React UI: `AgentChat`, `WidgetHost`, `SettingsView`, `UpdateIndicator`, and app-shell controls such as Quit. Widgets and extension settings sections should be hot reloadable and should not require an Electron restart for each new capability. The app shell and extension renderer surfaces share one design system, `@babymenu/ui` (`src/ui/`); see "Design system" below.
+3. **Renderer** (`src/renderer/`) - React UI: `AgentChat`, `WidgetHost`, custom popover layouts, `SettingsView`, `UpdateIndicator`, and app-shell controls such as Quit. Widgets, root `layout.tsx`, and extension settings sections should be hot reloadable and should not require an Electron restart for each new capability. The app shell and extension renderer surfaces share one design system, `@babymenu/ui` (`src/ui/`); see "Design system" below.
 4. **Extension server actions and background tasks** - privileged filesystem, shell, network, credential, token, storage, notification, and background work should live behind extension-owned `server.ts` modules.
    Renderer widgets call these actions with `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
    Server actions live in the active extension workspace under `<extension-id>/server.ts` and export an `actions` object; background tasks export `background` from the same file.
@@ -59,7 +59,7 @@ The extension-facing slice of that contract is a generated public surface, treat
 - `app.ts` - Electron lifecycle, popover window creation, packaged path setup, extension seeding, preferences, selectable-agent catalog wiring, protocols, tray, and IPC. `package.json#main` points here via `out/main/index.js`.
 - `app-paths.ts` - resolves source paths versus packaged `~/.baby-menu` paths.
 - `tray.ts` - macOS tray icon and click handling (`createBabyMenuTray`).
-- `popover.ts` - popover `BrowserWindow` options (`createPopoverOptions`), bounds math (`calculatePopoverBounds`), and renderer URL/file loading (`loadPopoverRenderer`).
+- `popover.ts` - popover `BrowserWindow` options (`createPopoverOptions`), adaptive width/height sizing (`responsivePopoverSize`), bounds math (`calculatePopoverBounds`), and renderer URL/file loading (`loadPopoverRenderer`).
 - `ipc.ts` - registers all `ipcMain` handlers exposed via the preload bridge; the single place new generic IPC routes are added.
 - `agent-catalog.ts` - defines built-in agents, parses custom `agents.json`, computes Settings availability, and builds `acpx` registry overrides.
 - `agent-catalog-controller.ts` - owns the live agent catalog, validates Settings-added custom ACP agents, persists `agents.json`, and pushes refreshed registry overrides into the runtime without requiring an app restart.
@@ -68,10 +68,10 @@ The extension-facing slice of that contract is a generated public surface, treat
 - `git-change-session.ts` - the tracked-source Save/Rollback safety boundary (see below).
 - `dev-extension-change-session.ts` - the snapshot Save/Rollback boundary for gitignored dev and packaged extension workspaces.
 - `extension-seeder.ts` - self-heals the packaged extension workspace from the bundled template on every launch: it force-copies the shipped defaults (`AGENTS.md`, `babymenu-env.d.ts`, `recipes/`, and starter extensions) so a stale or edited managed file is restored, while leaving user-created extensions the template does not ship untouched (it never deletes them). Editing a managed default in `~/.baby-menu/extensions` therefore does not persist; change the source under `extensions/` instead.
-- `extension-module-compiler.ts` - compiles extension widget and server modules for production loading; rewrites the `react` and `@babymenu/ui` imports to host protocol modules and rejects any other external import.
-- `widget-tailwind-css.ts` - compiles a widget's authored Tailwind utilities against the `@babymenu/ui` `@theme` (single source of truth, `src/ui/theme.css`) for packaged loading.
-- `widget-module-registry.ts` - discovers widget modules, returning a renderer `/@fs` URL in dev and, in packaged mode, a compiled `baby-menu-widget://` module URL plus a sibling compiled `cssUrl`.
-- `widget-protocol.ts` - registers custom protocols for compiled widget modules, the per-widget `.css`, and the renderer host shims (`react`, `react/jsx-runtime`, and `@babymenu/ui` re-exported from the host global).
+- `extension-module-compiler.ts` - compiles extension widget, root layout, and server modules for production loading; rewrites the `react` and `@babymenu/ui` imports to host protocol modules and rejects any other external import.
+- `widget-tailwind-css.ts` - compiles widget and layout authored Tailwind utilities against the `@babymenu/ui` `@theme` (single source of truth, `src/ui/theme.css`) for packaged loading.
+- `widget-module-registry.ts` - discovers widget modules and the optional root `layout.tsx`, returning renderer `/@fs` URLs in dev and, in packaged mode, compiled `baby-menu-widget://` module URLs plus sibling compiled `cssUrl` files.
+- `widget-protocol.ts` - registers custom protocols for compiled widget and layout modules, their `.css`, and the renderer host shims (`react`, `react/jsx-runtime`, and `@babymenu/ui` re-exported from the host global).
 - `preferences.ts` - stores app preferences, including the selected agent, under the active app data root and applies login-item settings only when login items are allowed, keeping source/dev mode as a no-op for macOS login items.
 - `shell-path.ts` - expands `PATH` for GUI launches so packaged apps can find agent CLIs.
 - `update-checker.ts` - checks the latest GitHub Release at most every 4 hours, compares it to the running app version, opens the release page externally, and simulates an available update in source/dev mode so the header indicator can be exercised.
@@ -88,7 +88,7 @@ The adapters intentionally run lean: they do not inherit user-level agent settin
 
 `src/renderer/` extension loading modules:
 
-- `extension-modules.ts` - shared runtime loader for extension `widget.tsx` modules, including dynamic import and packaged-mode stylesheet injection for widgets and settings sections.
+- `extension-modules.ts` - shared runtime loader for extension `widget.tsx` and root `layout.tsx` modules, including dynamic import and packaged-mode stylesheet injection for widgets, layouts, and settings sections.
 - `settings/settings-sections.ts` - extracts `BabyMenuSettingsSection` exports from loaded extension modules and sorts them by extension id for stable Settings page order.
 
 ### Electron build wiring
@@ -105,7 +105,7 @@ Packaged builds keep `out/adapters/**` in `app.asar.unpacked` because adapter pr
 
 `typescript` is intentionally externalized from the production main bundle because `extension-module-compiler.ts` imports it at runtime to compile packaged extensions.
 Keep `typescript` in runtime dependencies unless that compiler path changes.
-`tailwindcss`, `@tailwindcss/postcss`, and `postcss` are externalized for the same reason: `widget-tailwind-css.ts` runs Tailwind in the main process to compile per-widget CSS in packaged mode.
+`tailwindcss`, `@tailwindcss/postcss`, and `postcss` are externalized for the same reason: `widget-tailwind-css.ts` runs Tailwind in the main process to compile widget and layout CSS in packaged mode.
 Keep them in runtime dependencies, and keep the single pinned `postcss` (`pnpm-workspace.yaml` `overrides`) so the Tailwind plugin and the processor share one version.
 Universal macOS packages must run on both Intel and Apple Silicon Macs, so `pnpm-workspace.yaml` keeps Darwin `x64` and `arm64` native prebuilt dependencies installed, and `electron-builder.yml` `x64ArchFiles` must preserve architecture-specific native package files during the universal merge.
 Keep `electron-builder` at `26.8.2` or newer; older releases can omit transitive dependencies from pnpm-deduped package trees and ship broken app bundles.
@@ -114,10 +114,10 @@ The renderer build adds `@tailwindcss/vite` and aliases `@babymenu/ui` to `src/u
 ### Design system (`@babymenu/ui`)
 
 `src/ui/` is a shadcn-derived component kit (Radix + Tailwind v4) restyled to the Monochrome Lab tokens, shared by the app shell and extension widgets.
-`src/ui/theme.css` is the single `@theme` source of truth: it wipes Tailwind's default palette so only token colors exist, and it is consumed by both the renderer build (`src/ui/styles.css`) and the per-widget compiler (imported `?raw` into the main bundle).
+`src/ui/theme.css` is the single `@theme` source of truth: it wipes Tailwind's default palette so only token colors exist, and it is consumed by both the renderer build (`src/ui/styles.css`) and the per-widget/layout compiler (imported `?raw` into the main bundle).
 Delivery mirrors the React shim exactly: `main.tsx` installs the kit on `window.__BABY_MENU_WIDGET_HOST__.ui`, `widget-protocol.ts` serves `baby-menu-host://ui/index.mjs` as a thin re-export, and the compiler rewrites the bare `@babymenu/ui` specifier to that URL - so Radix, cva, and lucide stay inside the host bundle and never reach the widget import allowlist.
 `src/shared/ui-exports.ts` is the public surface contract (treated like the preload bridge): the barrel, the contract list, and the generated host shim are kept in lockstep by `tests/ui-export-contract.test.ts`, so changing a public export is a deliberate, tested act.
-Extension widgets and settings sections may additionally import only `@babymenu/ui`; they author token-scoped Tailwind utilities, and the per-widget stylesheet is compiled and injected automatically.
+Extension widgets, root layouts, and settings sections may additionally import only `@babymenu/ui`; they author token-scoped Tailwind utilities, and their stylesheet is compiled and injected automatically.
 
 `createPopoverOptions` enforces `frame:false`, `contextIsolation:true`, `nodeIntegration:false`, `skipTaskbar:true`, `alwaysOnTop:true`. Do not relax these without a reason.
 On macOS, `app.ts` appends Chromium's `use-mock-keychain` switch before app readiness, so do not rely on Chromium or renderer storage for keychain-backed secrets.
@@ -142,8 +142,9 @@ Do not write generated extension files, the local extension database, compiled m
 ### Recipes and extensions
 
 - Recipes are HTML files in `recipes/` inside the active extension workspace. `recipe-loader.ts` discovers `*.html`, sorts them, and extracts the title from `<title>` or first `<h1>`. They are intentionally HTML so the embedded agent can read them from its cwd and use embedded interactive demos.
-- Extensions live in the active extension workspace under `<extension-id>/` and may include `widget.tsx`, `server.ts`, and local helper files.
-- Packaged widgets, settings sections, and server actions are compiled into `~/.baby-menu/cache` and loaded through custom protocols or cached modules; dev mode keeps Vite `/@fs` loading for renderer modules.
+- Extensions live in the active extension workspace under `<extension-id>/` and may include `widget.tsx`, `server.ts`, and local helper files; the workspace may also include one root `layout.tsx` that arranges active widgets.
+- Packaged widgets, root layouts, settings sections, and server actions are compiled into `~/.baby-menu/cache` and loaded through custom protocols or cached modules; dev mode keeps Vite `/@fs` loading for renderer modules.
+- Root `layout.tsx` default-exports a `BabyMenuLayout`, receives active widget metadata plus `renderWidget(id)`, owns the popover canvas arrangement, and lets the popover adapt in both width and height.
 - Widgets conform to `BabyMenuWidget` / `RefreshableBabyMenuWidget`. The `WidgetHost` owns visible-widget refresh timing via `useViewRefresh`, using the main-process popover visibility signal - widgets should not start their own polling.
 - Settings sections conform to `BabyMenuSettingsSection`, are exported from `widget.tsx`, and own only the section body; `SettingsView` owns the frame and rediscovers sections when settings refresh or the popover reopens.
 - New widgets and capabilities should be built as self-contained extensions behind the stable `window.babyMenu` bridge.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 
 ```
    ┌─────────────────────┐
-   │  macOS tray popover │   (React renderer, 504px wide)
+   │  macOS tray popover │   (React renderer, adaptive size)
    │ + Menu / Settings   │
    │ + Update indicator  │
    │ + Quit              │
@@ -131,15 +131,15 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
               ▼                               ▼
    ┌─────────────────────┐       ┌──────────────────────┐
    │ active extensions/  │       │   save snapshot or   │
-   │  widget.tsx         │◄──────┤   rollback files     │
-   │  components.tsx     │       │   safely             │
-   │  server.ts          │       │                      │
+   │  layout.tsx         │◄──────┤   rollback files     │
+   │  <id>/widget.tsx    │       │   safely             │
+   │  <id>/server.ts     │       │                      │
    └──────────┬──────────┘       │                      │
               │ hot-reload       └──────────────────────┘
               ▼
    ┌─────────────────────┐
    │     WidgetHost      │
-   │  mounts new widget  │
+   │ mounts layout/widget│
    └─────────────────────┘
 ```
 
@@ -153,6 +153,8 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 - **Release update indicator** - the main process checks the latest GitHub Release at most every four hours, keeps failures silent, and shows a header indicator with `brew update && brew upgrade --cask baby-menu` only when a newer packaged release exists.
   Source/dev mode simulates an available update so the UI can be exercised locally.
   The released Homebrew Cask relaunches Baby Menu after an upgrade only when the old app was running before uninstall started.
+- **Custom popover layouts** - an extension workspace may include a root `layout.tsx` default export that receives active widgets and `renderWidget(id)`, arranges the popover canvas, and lets the window adapt to both width and height.
+  Workspaces without `layout.tsx` keep the built-in stacked column.
 - **Extension settings sections** - extensions may export `BabyMenuSettingsSection` from `widget.tsx`; the Settings page discovers those renderer-only sections through the same module pipeline as widgets and renders the host-owned frame around each body.
 - **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets and settings sections via `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
   No per-widget IPC channels.
@@ -173,11 +175,12 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | `src/adapters/`             | Bundled clean-room ACP adapters for built-in Claude Code and Codex agents              |
 | `src/main/`                 | Electron lifecycle, tray, popover, IPC, git, agent runtime, update checks              |
 | `src/preload/index.ts`      | The stable `window.babyMenu` bridge                                                    |
-| `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, settings, update indicator, and app controls      |
+| `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, custom layouts, settings, updates, app controls   |
 | `src/ui/`                   | Shared `@babymenu/ui` design system for shell and extension renderer surfaces          |
 | `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `BabyMenuSettingsSection`, `GitSessionSnapshot`, etc. |
 | `src/shared/extension-contract-names.ts` | Public type names exported through `@babymenu/contracts`                  |
 | `extensions/babymenu-env.d.ts` | Generated `@babymenu/contracts` declarations copied into extension workspaces       |
+| `extensions/layout.tsx`     | Optional root popover layout component for arranging active widgets                     |
 | `extensions/<id>/`          | Tracked extensions (`widget.tsx` descriptors, `components.tsx` views, `server.ts`)      |
 | `extensions/recipes/*.html` | Self-contained widget specs the agent reads                                            |
 | `extensions-dev/`           | Gitignored dev workspace prepared by `scripts/dev.mjs`                                 |

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -32,6 +32,7 @@ Use lowercase kebab-case ids such as `codex-quota`.
 
 Common files are:
 
+- `layout.tsx` - optional root workspace layout component that arranges active widgets and controls the popover canvas size.
 - `widget.tsx` - the entry module that exports the `BabyMenuWidget` descriptor (and any settings section).
 - `components.tsx` - the widget's React components, exporting components only so edits hot reload in place.
 - `server.ts` for privileged server actions and background tasks.
@@ -39,7 +40,7 @@ Common files are:
 - Optional notes that make the extension understandable and shareable.
 
 Packaged Baby Menu compiles extension modules before loading them.
-Keep imports package-safe: widget modules may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, the design system `@babymenu/ui`, and local helper files only.
+Keep imports package-safe: widget and layout modules may import `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, the design system `@babymenu/ui`, and local helper files only.
 Server modules may import Node built-ins such as `node:fs` plus local helper files only.
 Both may additionally use type-only imports from `@babymenu/contracts` (see "Stay inside this workspace"); type-only imports are erased at compile time and do not count as runtime dependencies.
 Do not add arbitrary npm package imports to extension code unless the host compiler is updated to support them.
@@ -265,11 +266,11 @@ export function ServiceStatusView() {
 
 ### Style with Tailwind tokens
 
-Widgets are styled with Tailwind utility classes, and the per-widget stylesheet is compiled for you - you never configure Tailwind.
+Widgets and `layout.tsx` are styled with Tailwind utility classes, and the per-module stylesheet is compiled for you - you never configure Tailwind.
 Prefer Baby Menu token utilities for color, type, radius, and surfaces so widgets match the host app.
 Default Tailwind palette colors such as `bg-red-500` and `text-blue-300` are unavailable, but arbitrary Tailwind values can still compile.
 Use arbitrary color values only when a widget genuinely needs them, and keep them rare.
-Keep class names statically visible in the widget source so the dev stylesheet and packaged per-widget compiler can discover them.
+Keep class names statically visible in the widget or layout source so the dev stylesheet and packaged compiler can discover them.
 Avoid constructing Tailwind class fragments dynamically; choose complete class strings from a small map instead.
 
 Use these token utilities:

--- a/extensions/AGENTS.md
+++ b/extensions/AGENTS.md
@@ -77,13 +77,71 @@ Do not store tokens or secrets in renderer or browser storage; Baby Menu disable
 It is not a way to keep data fresh in the background - if data must stay current while the popover is closed, use a background task (see "Background tasks").
 A widget may also read data directly with `window.babyMenu.db` and subscribe to `window.babyMenu.background.onUpdate` to re-read when a background task finishes.
 
+## Popover Layout
+
+By default the popover stacks every widget in a single column and sizes itself to that content.
+To take full control of the arrangement and the overall popover size, author one optional file at the **root** of this workspace: `layout.tsx`.
+It default-exports a `BabyMenuLayout` component that receives the active widgets and decides how they fit on the canvas.
+
+This is purely additive and backwards compatible.
+When there is no `layout.tsx`, the host renders the built-in column, so doing nothing keeps the current behavior.
+Older app versions that predate this feature simply ignore the file and render the column, so shipping a layout never breaks them.
+
+The host passes the layout two props (`BabyMenuLayoutProps`):
+
+- `widgets`: a `BabyMenuLayoutWidget[]` of `{ id, title }` for every active extension, so you can iterate or look up what is available.
+- `renderWidget(id)`: returns the fully wired render of one widget by id (or `null` for an unknown id). Always render a widget through this, never by importing another extension's files.
+
+Rules:
+
+- The layout owns its own width: set an explicit width on its root element (for example `className="w-[840px]"` or a fixed grid), and the popover window resizes to fit both that width and the rendered height. Use a normal, content-driven height; do not hard-code the popover height.
+- The layout is renderer-only and may import only `react`, `@babymenu/ui`, and type-only `@babymenu/contracts` - the same import rules as `widget.tsx`. It must not read files, run commands, or do privileged work.
+- The host no longer draws a title above each widget; the widget owns its entire area. If you want a heading, render it inside the widget or the layout.
+- Place every widget you want visible. Any widget you do not render simply will not appear.
+- If the layout throws while rendering, the host falls back to the built-in column so the popover never blanks.
+
+Editing `layout.tsx` hot-reloads like a widget.
+
+Start from this boilerplate, which reproduces the default column, then rearrange it:
+
+```tsx
+import type { BabyMenuLayoutProps } from "@babymenu/contracts";
+
+export default function Layout({ widgets, renderWidget }: BabyMenuLayoutProps) {
+  return (
+    <div className="flex w-[504px] flex-col gap-3 p-3">
+      {widgets.map((widget) => (
+        <div key={widget.id}>{renderWidget(widget.id)}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+A two-column canvas, for comparison, is just a wider root with a grid:
+
+```tsx
+import type { BabyMenuLayoutProps } from "@babymenu/contracts";
+
+export default function Layout({ widgets, renderWidget }: BabyMenuLayoutProps) {
+  return (
+    <div className="grid w-[840px] grid-cols-2 gap-3 p-3">
+      {widgets.map((widget) => (
+        <div key={widget.id}>{renderWidget(widget.id)}</div>
+      ))}
+    </div>
+  );
+}
+```
+
 ## Widget Design System
 
 Baby Menu uses the Monochrome Lab direction in runtime widgets.
-Design for a 504px macOS tray popover, not a web page, dashboard, or chat transcript.
-The host owns the outer widget wrapper, title row, dashed dividers, scrolling, and popover chrome.
-`widget.title` should be a terse tracked-caps key such as `BATTERY`, `CPU TEMP`, or `CLAUDE · WEEKLY`.
-`render()` should return only the body content that belongs below the host title row.
+Design for a macOS tray popover (504px wide by default; a custom `layout.tsx` can widen it - see "Popover Layout"), not a web page, dashboard, or chat transcript.
+The host owns the outer wrapper, dashed dividers, scrolling, and popover chrome, but it no longer draws a title above your widget - the widget owns its entire area.
+So `render()` must include its own affordance to say what it is showing whenever that is not obvious from the content: a terse tracked-caps key such as `BATTERY`, `CPU TEMP`, or `CLAUDE · WEEKLY`, a labeled value, or an icon.
+This is not a mandate to draw a title bar - a self-evident widget (a single big labeled number, a clearly captioned chart) needs no separate heading; just make sure the user can tell what they are looking at.
+`widget.title` is still required, but it is now metadata (the id-stable label the host uses for ordering and accessibility and that a `layout.tsx` reads to place widgets), not something the host renders - keep it terse and tracked-caps, and render your own heading from it if you want one visible.
 
 ### Build with @babymenu/ui first
 
@@ -244,20 +302,23 @@ Spacing, flex, and grid utilities are standard Tailwind.
 
 ### Example data-widget body
 
+The host draws no title, so this body labels itself with a terse tracked-caps key (here matching `widget.title`) so the user can tell what the `72%` is. Drop the key only when the content is already self-evident.
+
 ```tsx
 import { Progress, StatusDot } from "@babymenu/ui";
 
 export function QuotaView() {
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-baseline justify-between">
-        <span className="text-2xl font-light tracking-value text-ink-strong">
-          72<span className="ml-0.5 text-sm text-ink-soft">%</span>
-        </span>
-        <span className="flex items-center gap-1.5 text-xxs uppercase tracking-caps text-signal-live">
+      <div className="flex items-center justify-between text-xxs uppercase tracking-caps text-ink-label">
+        <span>quota</span>
+        <span className="flex items-center gap-1.5 text-signal-live">
           <StatusDot /> live
         </span>
       </div>
+      <span className="text-2xl font-light tracking-value text-ink-strong">
+        72<span className="ml-0.5 text-sm text-ink-soft">%</span>
+      </span>
       <Progress value={72} />
       <div className="flex justify-between text-xxs uppercase tracking-caps text-ink-label">
         <span>last sync 12:04</span>

--- a/extensions/babymenu-env.d.ts
+++ b/extensions/babymenu-env.d.ts
@@ -106,6 +106,27 @@ declare module "@babymenu/contracts" {
         }
     );
 
+  // The metadata the host hands a custom layout for each active extension so it
+  // can decide what to place and where. The layout never imports widget files
+  // directly; it places each one by id through `renderWidget`.
+  export type BabyMenuLayoutWidget = {
+    id: string;
+    title: string;
+  };
+
+  // Props the host passes to the default export of `layout.tsx`. `renderWidget`
+  // returns the refresh-wired, title-less render of one extension by id (null for
+  // an unknown id), so the layout keeps the host's view-refresh wiring while
+  // owning the arrangement and the overall canvas size (the host measures the
+  // rendered layout and resizes the popover to fit its width and height).
+  export type BabyMenuLayoutProps = {
+    widgets: BabyMenuLayoutWidget[];
+    renderWidget: (id: string) => ReactNode;
+  };
+
+  // The default export shape of an `extensions/layout.tsx` module.
+  export type BabyMenuLayout = (props: BabyMenuLayoutProps) => ReactNode;
+
   export type PopoverVisibilityState = {
     visible: boolean;
   };
@@ -137,6 +158,7 @@ declare module "@babymenu/contracts" {
     };
     popover: {
       setContentHeight: (height: number) => Promise<{ ok: boolean }>;
+      setContentSize: (size: { width: number; height: number }) => Promise<{ ok: boolean }>;
       getVisibility: () => Promise<PopoverVisibilityState>;
       onVisibility: (listener: (state: PopoverVisibilityState) => void) => () => void;
     };

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -25,7 +25,7 @@ import { getDefaultTelemetry, initDefaultTelemetry } from "./telemetry";
 import { expandProcessPathForGuiLaunch } from "./shell-path";
 import { createUpdateChecker } from "./update-checker";
 import { createBabyMenuTray, type BabyMenuTray } from "./tray";
-import { createWidgetModuleRegistry } from "./widget-module-registry";
+import { createLayoutModuleRegistry, createWidgetModuleRegistry } from "./widget-module-registry";
 import { registerBabyMenuProtocolHandlers, registerBabyMenuProtocolSchemes } from "./widget-protocol";
 
 if (process.platform === "darwin") {
@@ -116,12 +116,21 @@ function sendPopoverVisibility(visible: boolean): void {
   sendToPopover("baby-menu:popover:visibility", { visible });
 }
 
-function setPopoverContentHeight(height: number) {
-  latestPopoverSize = responsivePopoverSize(height);
+function setPopoverContentSize(size: { width: number; height: number }) {
+  const workArea = latestTrayBounds
+    ? screen.getDisplayNearestPoint({ x: latestTrayBounds.x, y: latestTrayBounds.y }).workArea
+    : undefined;
+  latestPopoverSize = responsivePopoverSize(size, workArea);
   if (!latestTrayBounds || !popoverWindow || popoverWindow.isDestroyed()) return;
 
   const display = screen.getDisplayNearestPoint({ x: latestTrayBounds.x, y: latestTrayBounds.y });
   popoverWindow.setBounds(calculatePopoverBounds(latestTrayBounds, display.workArea, latestPopoverSize));
+}
+
+// Retained for the height-only bridge call; keeps the current width and lets the
+// new width+height path own the full adaptive sizing.
+function setPopoverContentHeight(height: number) {
+  setPopoverContentSize({ width: latestPopoverSize.width, height });
 }
 
 export async function startBabyMenuApp(): Promise<void> {
@@ -231,12 +240,14 @@ export async function startBabyMenuApp(): Promise<void> {
     db: database,
     notify,
   });
-  const widgetModules = createWidgetModuleRegistry({
+  const widgetRegistryOptions = {
     rootDir: paths.appDataRoot,
     extensionsDir: paths.extensionsDir,
-    mode: paths.isPackaged ? "compiled" : "vite",
+    mode: (paths.isPackaged ? "compiled" : "vite") as "compiled" | "vite",
     widgetCacheDir: paths.widgetCacheDir,
-  });
+  };
+  const widgetModules = createWidgetModuleRegistry(widgetRegistryOptions);
+  const layoutModules = createLayoutModuleRegistry(widgetRegistryOptions);
 
   const updateChecker = createUpdateChecker({
     currentVersion: app.getVersion(),
@@ -251,14 +262,18 @@ export async function startBabyMenuApp(): Promise<void> {
     agentRuntime,
     serverActions,
     widgetModules,
-    { setContentHeight: setPopoverContentHeight, getVisibility: () => ({ visible: popoverWindow?.isVisible() ?? false }) },
+    {
+      setContentHeight: setPopoverContentHeight,
+      setContentSize: setPopoverContentSize,
+      getVisibility: () => ({ visible: popoverWindow?.isVisible() ?? false }),
+    },
     settingsController,
     {
       quit: () => app.quit(),
       getUpdateStatus: () => updateChecker.getStatus(),
       openReleasePage: () => updateChecker.openReleasePage(),
     },
-    { recipesDir: paths.recipesDir, database },
+    { recipesDir: paths.recipesDir, database, layoutModules },
   );
   activeTray = createBabyMenuTray(
     (bounds) => {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -79,8 +79,8 @@ async function createPopoverWindow(): Promise<BrowserWindow> {
 }
 
 async function togglePopover(trayBounds: Rectangle): Promise<void> {
-  const window = await createPopoverWindow();
   latestTrayBounds = trayBounds;
+  const window = await createPopoverWindow();
   if (window.isVisible()) {
     window.hide();
     return;

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -5,7 +5,10 @@ import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
 
-export type ExtensionModuleKind = "widget" | "server";
+// "layout" is the root layout.tsx module; it is a React surface with the exact
+// same import rules as a widget (react, react/jsx-runtime, @babymenu/ui), so it
+// shares the widget rewrite path.
+export type ExtensionModuleKind = "widget" | "server" | "layout";
 
 export type CompileExtensionModuleOptions = {
   kind: ExtensionModuleKind;
@@ -211,7 +214,7 @@ async function rewriteImportSpecifier(options: {
   validateExternalImports: boolean;
 }): Promise<string> {
   if (!isLocalSpecifier(options.specifier)) {
-    if (options.kind === "widget") return rewriteWidgetExternalImport(options);
+    if (options.kind === "widget" || options.kind === "layout") return rewriteWidgetExternalImport(options);
     if (options.validateExternalImports) {
       assertSupportedExternalImport(options.kind, options.specifier, options.extensionId, options.extensionDir, options.filePath);
     }

--- a/src/main/extension-module-compiler.ts
+++ b/src/main/extension-module-compiler.ts
@@ -251,7 +251,7 @@ function assertSupportedExternalImport(
   filePath: string,
 ) {
   if (
-    kind === "widget" &&
+    (kind === "widget" || kind === "layout") &&
     (specifier === "react" ||
       specifier === "react/jsx-runtime" ||
       specifier === "react/jsx-dev-runtime" ||

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,7 +17,12 @@ import { BabyMenuAgentRuntime, type BabyMenuAgentRuntimeSendOptions } from "./ag
 import { createExtensionDatabase, type ExtensionDatabase } from "./extension-database";
 import { loadRecipes } from "./recipe-loader";
 import { createServerActionRegistry, type ServerActionRegistry } from "./server-action-registry";
-import { createWidgetModuleRegistry, type WidgetModuleRegistry } from "./widget-module-registry";
+import {
+  createLayoutModuleRegistry,
+  createWidgetModuleRegistry,
+  type LayoutModuleRegistry,
+  type WidgetModuleRegistry,
+} from "./widget-module-registry";
 
 type AgentRuntimeFacade = Pick<
   BabyMenuAgentRuntime,
@@ -28,6 +33,7 @@ type AgentRuntimeFacade = Pick<
 
 type PopoverController = {
   setContentHeight: (height: number) => void | Promise<void>;
+  setContentSize: (size: { width: number; height: number }) => void | Promise<void>;
   getVisibility: () => PopoverVisibilityState | Promise<PopoverVisibilityState>;
 };
 
@@ -49,6 +55,7 @@ type AppController = {
 type IpcRuntimeOptions = {
   recipesDir?: string;
   database?: ExtensionDatabase;
+  layoutModules?: LayoutModuleRegistry;
 };
 
 export function registerIpcHandlers(
@@ -56,7 +63,11 @@ export function registerIpcHandlers(
   agentRuntime: AgentRuntimeFacade = new BabyMenuAgentRuntime(rootDir),
   serverActions: ServerActionRegistry = createServerActionRegistry({ rootDir, actionRoots: [getExtensionsDir(rootDir)] }),
   widgetModules: WidgetModuleRegistry = createWidgetModuleRegistry(rootDir),
-  popover: PopoverController = { setContentHeight: () => undefined, getVisibility: () => ({ visible: false }) },
+  popover: PopoverController = {
+    setContentHeight: () => undefined,
+    setContentSize: () => undefined,
+    getVisibility: () => ({ visible: false }),
+  },
   settings: SettingsController = {
     get: () => ({ openAtLogin: false, agentName: "", agents: [] }),
     setOpenAtLogin: (openAtLogin) => ({ openAtLogin, agentName: "", agents: [] }),
@@ -70,6 +81,7 @@ export function registerIpcHandlers(
 ) {
   const recipesDir = runtimeOptions.recipesDir ?? getRecipesDir(rootDir);
   const database = runtimeOptions.database ?? createExtensionDatabase(":memory:");
+  const layoutModules = runtimeOptions.layoutModules ?? createLayoutModuleRegistry(rootDir);
 
   ipcMain.handle("baby-menu:recipes:list", async (): Promise<RecipeMetadata[]> => {
     return loadRecipes(pathToFileURL(`${recipesDir}/`));
@@ -125,8 +137,17 @@ export function registerIpcHandlers(
     return widgetModules.list();
   });
 
+  ipcMain.handle("baby-menu:layout:get", async () => {
+    return layoutModules.get();
+  });
+
   ipcMain.handle("baby-menu:popover:set-content-height", async (_event, height: number) => {
     await popover.setContentHeight(height);
+    return { ok: true };
+  });
+
+  ipcMain.handle("baby-menu:popover:set-content-size", async (_event, size: { width: number; height: number }) => {
+    await popover.setContentSize(size);
     return { ok: true };
   });
 

--- a/src/main/popover.ts
+++ b/src/main/popover.ts
@@ -18,6 +18,7 @@ export const DEFAULT_POPOVER_SIZE: Size = {
 
 export const MIN_POPOVER_HEIGHT = 220;
 export const MAX_POPOVER_HEIGHT = 720;
+export const MIN_POPOVER_WIDTH = 320;
 
 const EDGE_PADDING = 8;
 
@@ -48,10 +49,20 @@ export function calculatePopoverBounds(
   return { x, y, width: size.width, height: size.height };
 }
 
-export function responsivePopoverSize(contentHeight: number): Size {
+// Clamps the renderer-reported canvas size into the range the popover can
+// actually display, so both width and height adapt to the layout content. The
+// reported size is taken as-is (not max-ratcheted), so the popover grows AND
+// shrinks back as a layout changes. When a work area is given, the size is also
+// capped to it (minus edge padding) so an oversized layout never escapes the
+// screen.
+export function responsivePopoverSize(content: Size, workArea?: Rectangle): Size {
+  const maxWidth = workArea ? Math.max(MIN_POPOVER_WIDTH, workArea.width - EDGE_PADDING * 2) : Number.POSITIVE_INFINITY;
+  const maxHeight = workArea
+    ? Math.max(MIN_POPOVER_HEIGHT, Math.min(MAX_POPOVER_HEIGHT, workArea.height - EDGE_PADDING * 2))
+    : MAX_POPOVER_HEIGHT;
   return {
-    width: DEFAULT_POPOVER_SIZE.width,
-    height: Math.ceil(clamp(contentHeight, MIN_POPOVER_HEIGHT, MAX_POPOVER_HEIGHT)),
+    width: Math.ceil(clamp(content.width, MIN_POPOVER_WIDTH, maxWidth)),
+    height: Math.ceil(clamp(content.height, MIN_POPOVER_HEIGHT, maxHeight)),
   };
 }
 

--- a/src/main/widget-module-registry.ts
+++ b/src/main/widget-module-registry.ts
@@ -1,7 +1,7 @@
 import type { Dirent } from "node:fs";
 import { access, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
-import type { BabyMenuWidgetModuleDescriptor } from "../shared/contracts";
+import type { BabyMenuLayoutModuleDescriptor, BabyMenuWidgetModuleDescriptor } from "../shared/contracts";
 import { getExtensionsDir } from "../shared/paths";
 import { compileExtensionModule } from "./extension-module-compiler";
 import { compileWidgetTailwindCss, widgetTailwindCssCacheKey } from "./widget-tailwind-css";
@@ -27,6 +27,14 @@ export type DiscoverWidgetModulesOptions = {
 
 const STARTER_EXTENSION_ID = "hello-world";
 const WIDGET_FILE_PATTERN = /^widget\.(tsx|jsx|ts|js|mjs)$/;
+// The agent-authored layout component lives at the root of the extension
+// workspace. It is discovered separately from widgets (which live one directory
+// down as `widget.tsx`), so the recursive widget scan never picks it up.
+const LAYOUT_FILE_PATTERN = /^layout\.(tsx|jsx|ts|js|mjs)$/;
+// Reserved namespace for the single root layout module in the widget cache and
+// the `baby-menu-widget://` protocol. Not a real extension id, so it never
+// collides with a user-created extension directory.
+const LAYOUT_EXTENSION_ID = "__layout";
 
 type CreateWidgetModuleRegistryOptions = DiscoverWidgetModulesOptions;
 
@@ -57,6 +65,82 @@ export async function discoverWidgetModules({
   return modules
     .filter((module): module is BabyMenuWidgetModuleDescriptor => Boolean(module))
     .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+export type LayoutModuleRegistry = {
+  get: () => Promise<BabyMenuLayoutModuleDescriptor | null>;
+};
+
+export function createLayoutModuleRegistry(rootDir: string | CreateWidgetModuleRegistryOptions): LayoutModuleRegistry {
+  const options = typeof rootDir === "string" ? { rootDir } : rootDir;
+  return {
+    get: () => discoverLayoutModule(options),
+  };
+}
+
+// Resolves the optional root `layout.tsx`, or null when the workspace ships
+// none (the renderer then falls back to the built-in column). Mirrors widget
+// discovery: a `/@fs` URL in dev, a compiled `baby-menu-widget://` module plus a
+// sibling `cssUrl` when packaged.
+export async function discoverLayoutModule({
+  rootDir,
+  extensionsDir = getExtensionsDir(rootDir),
+  mode = "vite",
+  widgetCacheDir,
+}: DiscoverWidgetModulesOptions): Promise<BabyMenuLayoutModuleDescriptor | null> {
+  const resolvedExtensionsDir = resolve(extensionsDir);
+  const filePath = await findLayoutFile(resolvedExtensionsDir);
+  if (!filePath) return null;
+
+  try {
+    if (mode === "compiled") {
+      return await compiledLayoutModuleUrls({ extensionsDir: resolvedExtensionsDir, filePath, widgetCacheDir });
+    }
+    const fileStat = await stat(filePath);
+    return { moduleUrl: rendererModuleUrl(filePath, fileStat.mtimeMs) };
+  } catch (error) {
+    if (mode !== "compiled") throw error;
+    return null;
+  }
+}
+
+async function findLayoutFile(extensionsDir: string): Promise<string | null> {
+  let entries: Dirent<string>[];
+  try {
+    entries = await readdir(extensionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const match = entries
+    .filter((entry) => entry.isFile() && LAYOUT_FILE_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort()[0];
+  return match ? join(extensionsDir, match) : null;
+}
+
+async function compiledLayoutModuleUrls({
+  extensionsDir,
+  filePath,
+  widgetCacheDir,
+}: {
+  extensionsDir: string;
+  filePath: string;
+  widgetCacheDir?: string;
+}): Promise<BabyMenuLayoutModuleDescriptor> {
+  if (!widgetCacheDir) throw new Error("widgetCacheDir is required for compiled layout modules");
+  const compiled = await compileExtensionModule({
+    kind: "layout",
+    extensionId: LAYOUT_EXTENSION_ID,
+    extensionDir: extensionsDir,
+    entryFile: filePath,
+    cacheRoot: widgetCacheDir,
+  });
+
+  const cssFileUrl = await ensureWidgetCss({ extensionDir: extensionsDir, outputDir: compiled.outputDir });
+  const encodedExtensionId = encodeURIComponent(LAYOUT_EXTENSION_ID);
+  const moduleUrl = `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodeModulePath(compiled.outputDir, compiled.outputPath)}`;
+  const cssUrl = `baby-menu-widget://${encodedExtensionId}/${compiled.hash}/${encodeModulePath(compiled.outputDir, cssFileUrl)}`;
+  return { moduleUrl, cssUrl };
 }
 
 async function discoverWidgetFiles(rootDir: string): Promise<string[]> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -40,6 +40,9 @@ const api: BabyMenuApi = {
   widgets: {
     list: () => ipcRenderer.invoke("baby-menu:widgets:list"),
   },
+  layout: {
+    get: () => ipcRenderer.invoke("baby-menu:layout:get"),
+  },
   background: {
     onUpdate: (listener: (event: BackgroundTaskUpdate) => void) => {
       const handler = (_event: unknown, update: BackgroundTaskUpdate) => listener(update);
@@ -49,6 +52,8 @@ const api: BabyMenuApi = {
   },
   popover: {
     setContentHeight: (height: number) => ipcRenderer.invoke("baby-menu:popover:set-content-height", height),
+    setContentSize: (size: { width: number; height: number }) =>
+      ipcRenderer.invoke("baby-menu:popover:set-content-size", size),
     getVisibility: () => ipcRenderer.invoke("baby-menu:popover:get-visibility"),
     onVisibility: (listener: (state: PopoverVisibilityState) => void) => {
       const handler = (_event: unknown, state: PopoverVisibilityState) => listener(state);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { Power, Settings, X } from "lucide-react";
 import { Button, Tooltip } from "../ui";
 import { AgentChat } from "./agent/AgentChat";
 import { MenuSurface } from "./menu/MenuSurface";
-import { measurePopoverContentHeight } from "./popover-content-height";
+import { measurePopoverContentSize } from "./popover-content-height";
 import { SettingsView } from "./settings/SettingsView";
 import { UpdateIndicator } from "./UpdateIndicator";
 
@@ -108,15 +108,17 @@ function usePopoverContentHeight() {
     if (!element || !window.babyMenu?.popover) return undefined;
 
     let animationFrame = 0;
+    let lastWidth = 0;
     let lastHeight = 0;
     const report = () => {
       if (animationFrame) window.cancelAnimationFrame(animationFrame);
       animationFrame = window.requestAnimationFrame(() => {
         animationFrame = 0;
-        const height = measurePopoverContentHeight(element);
-        if (!height || height === lastHeight) return;
+        const { width, height } = measurePopoverContentSize(element);
+        if (!height || (width === lastWidth && height === lastHeight)) return;
+        lastWidth = width;
         lastHeight = height;
-        void window.babyMenu?.popover.setContentHeight(height);
+        void window.babyMenu?.popover.setContentSize({ width, height });
       });
     };
 
@@ -129,20 +131,31 @@ function usePopoverContentHeight() {
     // body subtree to react when one opens or closes. Also observe the overlay
     // itself: a tall overlay can be max-h-clamped while the window is small, then
     // expand once the window grows, so we need to re-measure until it settles.
-    let observedOverlay: Element | null = null;
-    const syncOverlayObservation = () => {
-      const overlay = document.querySelector("[data-bm-overlay]");
-      if (overlay === observedOverlay) return;
-      if (observedOverlay) resizeObserver?.unobserve(observedOverlay);
-      observedOverlay = overlay;
-      if (overlay) resizeObserver?.observe(overlay);
+    // Observe the overlay and the layout canvas directly. The shell width is
+    // 100% of the window, so a custom layout that changes only its own width (the
+    // canvas overflows the shell) does not resize .app-shell and would otherwise
+    // be missed; observing the canvas catches it so the window keeps adapting.
+    const observed = new Map<string, Element>();
+    const syncExtraObservations = () => {
+      for (const selector of ["[data-bm-overlay]", "[data-bm-canvas]"]) {
+        const next = document.querySelector(selector);
+        const current = observed.get(selector) ?? null;
+        if (next === current) continue;
+        if (current) resizeObserver?.unobserve(current);
+        if (next) {
+          observed.set(selector, next);
+          resizeObserver?.observe(next);
+        } else {
+          observed.delete(selector);
+        }
+      }
     };
-    syncOverlayObservation();
+    syncExtraObservations();
     const mutationObserver =
       typeof MutationObserver === "undefined"
         ? null
         : new MutationObserver(() => {
-            syncOverlayObservation();
+            syncExtraObservations();
             report();
           });
     mutationObserver?.observe(document.body, { childList: true, subtree: true });

--- a/src/renderer/menu/WidgetHost.tsx
+++ b/src/renderer/menu/WidgetHost.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useState } from "react";
-import type { RefreshableBabyMenuWidget } from "../../shared/contracts";
+import { Component, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import type { BabyMenuLayout, BabyMenuLayoutWidget, RefreshableBabyMenuWidget } from "../../shared/contracts";
 import { helloWorldWidget } from "../../../extensions/hello-world/widget";
-import { importRuntimeModule, loadExtensionModules, type RuntimeModuleImporter } from "../extension-modules";
+import {
+  ensureWidgetStylesheet,
+  importRuntimeModule,
+  loadExtensionModules,
+  type RuntimeModuleImporter,
+} from "../extension-modules";
 import { useViewRefresh } from "./useViewRefresh";
 
 export type RuntimeWidgetImporter = RuntimeModuleImporter;
@@ -17,13 +22,67 @@ function WidgetCard({ widget }: { widget: RefreshableBabyMenuWidget }) {
     refreshView: widget.refreshView ?? (() => undefined),
   });
 
+  // No host-drawn title: the extension owns its entire area.
+  return <article className="widget">{widget.render()}</article>;
+}
+
+// The built-in layout: the historical stacked column, used whenever the
+// workspace ships no `layout.tsx`. Keeps old extensions and the no-layout case
+// rendering exactly as before.
+function WidgetColumn({ widgets }: { widgets: RefreshableBabyMenuWidget[] }) {
   return (
-    <article className="widget">
-      <header className="w-head">
-        <h3 className="key">{widget.title}</h3>
-      </header>
-      <div>{widget.render()}</div>
-    </article>
+    <div className="widget-host">
+      {widgets.map((widget) => (
+        <WidgetCard key={widget.id} widget={widget} />
+      ))}
+    </div>
+  );
+}
+
+// Resets to the built-in column if the agent-authored layout throws while
+// rendering, so a broken layout never blanks the popover. Clears the error when
+// the layout module changes (e.g. the agent fixes it) so it can recover live.
+class LayoutBoundary extends Component<
+  { layout: BabyMenuLayout; fallback: ReactNode; children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidUpdate(prev: { layout: BabyMenuLayout }) {
+    if (prev.layout !== this.props.layout && this.state.hasError) this.setState({ hasError: false });
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}
+
+function WidgetCanvas({ layout, widgets }: { layout: BabyMenuLayout | null; widgets: RefreshableBabyMenuWidget[] }) {
+  const byId = useMemo(() => new Map(widgets.map((widget) => [widget.id, widget] as const)), [widgets]);
+  const renderWidget = useCallback(
+    (id: string): ReactNode => {
+      const widget = byId.get(id);
+      return widget ? <WidgetCard widget={widget} /> : null;
+    },
+    [byId],
+  );
+
+  if (!layout) return <WidgetColumn widgets={widgets} />;
+
+  // The layout decides the arrangement and its own width; [data-bm-canvas] marks
+  // it so the host measures that intrinsic width and resizes the popover to fit.
+  const meta: BabyMenuLayoutWidget[] = widgets.map(({ id, title }) => ({ id, title }));
+  const Layout = layout;
+  return (
+    <div className="widget-canvas" data-bm-canvas>
+      <LayoutBoundary layout={layout} fallback={<WidgetColumn widgets={widgets} />}>
+        <Layout widgets={meta} renderWidget={renderWidget} />
+      </LayoutBoundary>
+    </div>
   );
 }
 
@@ -31,9 +90,13 @@ type WidgetHostProps = {
   widgets?: RefreshableBabyMenuWidget[];
   runtimeImporter?: RuntimeWidgetImporter;
   runtimeRefreshIntervalMs?: number;
+  // Test/override hook: a custom layout component (or null for the built-in
+  // column), bypassing runtime discovery. Undefined means discover at runtime.
+  layout?: BabyMenuLayout | null;
+  layoutImporter?: RuntimeModuleImporter;
 };
 
-export function WidgetHost({ widgets, runtimeImporter, runtimeRefreshIntervalMs }: WidgetHostProps) {
+export function WidgetHost({ widgets, runtimeImporter, runtimeRefreshIntervalMs, layout, layoutImporter }: WidgetHostProps) {
   const runtimeWidgets = useRuntimeWidgets({
     enabled: widgets === undefined,
     importer: runtimeImporter,
@@ -41,13 +104,14 @@ export function WidgetHost({ widgets, runtimeImporter, runtimeRefreshIntervalMs 
   });
   const visibleWidgets = widgets ?? (runtimeWidgets.length > 0 ? runtimeWidgets : [helloWorldWidget]);
 
-  return (
-    <div className="widget-host">
-      {visibleWidgets.map((widget) => (
-        <WidgetCard key={widget.id} widget={widget} />
-      ))}
-    </div>
-  );
+  const runtimeLayout = useRuntimeLayout({
+    enabled: widgets === undefined && layout === undefined,
+    importer: layoutImporter,
+    refreshIntervalMs: runtimeRefreshIntervalMs,
+  });
+  const activeLayout = layout === undefined ? runtimeLayout : layout;
+
+  return <WidgetCanvas layout={activeLayout} widgets={visibleWidgets} />;
 }
 
 function useRuntimeWidgets({
@@ -87,9 +151,77 @@ function useRuntimeWidgets({
   return widgets;
 }
 
+// Polls for the root layout module on the same cadence as widget discovery, so
+// editing `layout.tsx` hot-reloads the arrangement. Returns null when there is
+// no layout module (the canvas then renders the built-in column).
+function useRuntimeLayout({
+  enabled,
+  importer = importRuntimeModule,
+  refreshIntervalMs = DEFAULT_RUNTIME_REFRESH_INTERVAL_MS,
+}: {
+  enabled: boolean;
+  importer?: RuntimeModuleImporter;
+  refreshIntervalMs?: number;
+}) {
+  const [layout, setLayout] = useState<BabyMenuLayout | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+    let cancelled = false;
+
+    async function refresh() {
+      const loaded = await loadRuntimeLayout(importer);
+      // setState updater form because the stored value is itself a function.
+      if (!cancelled) setLayout(() => loaded);
+    }
+
+    void refresh();
+    if (!refreshIntervalMs || refreshIntervalMs <= 0) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const timer = window.setInterval(() => void refresh(), refreshIntervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [enabled, importer, refreshIntervalMs]);
+
+  return layout;
+}
+
 export async function loadRuntimeWidgets(importer: RuntimeWidgetImporter = importRuntimeModule) {
   const modules = await loadExtensionModules(importer);
   return modules.flatMap(widgetsFromModule);
+}
+
+export async function loadRuntimeLayout(
+  importer: RuntimeModuleImporter = importRuntimeModule,
+): Promise<BabyMenuLayout | null> {
+  try {
+    // Optional-chain `layout` too: an older host bridge without it must degrade
+    // to the built-in column, not throw an unhandled rejection.
+    const descriptor = await window.babyMenu?.layout?.get?.();
+    if (!descriptor) return null;
+    if (descriptor.cssUrl) ensureWidgetStylesheet(descriptor.cssUrl);
+    const module = await importer(descriptor.moduleUrl);
+    const layout = layoutFromModule(module);
+    if (!layout) console.warn("[baby-menu] layout.tsx has no default-export component; using the built-in column");
+    return layout;
+  } catch (error) {
+    // A broken layout module must not blank the menu - fall back to the column,
+    // but surface why so a failed custom layout is debuggable in dev.
+    console.warn("[baby-menu] failed to load layout.tsx; using the built-in column", error);
+    return null;
+  }
+}
+
+export function layoutFromModule(module: unknown): BabyMenuLayout | null {
+  if (!module || typeof module !== "object") return null;
+  const candidate = (module as { default?: unknown }).default;
+  return typeof candidate === "function" ? (candidate as BabyMenuLayout) : null;
 }
 
 export function widgetsFromModule(module: unknown): RefreshableBabyMenuWidget[] {

--- a/src/renderer/popover-content-height.ts
+++ b/src/renderer/popover-content-height.ts
@@ -37,6 +37,6 @@ export function measurePopoverContentHeight(shell: HTMLElement): number {
  */
 export function measurePopoverContentSize(shell: HTMLElement): { width: number; height: number } {
   const canvas = document.querySelector<HTMLElement>("[data-bm-canvas]");
-  const width = canvas ? Math.ceil(canvas.scrollWidth) : DEFAULT_POPOVER_CONTENT_WIDTH;
+  const width = canvas ? Math.ceil(Math.max(canvas.scrollWidth, shell.scrollWidth)) : DEFAULT_POPOVER_CONTENT_WIDTH;
   return { width, height: measurePopoverContentHeight(shell) };
 }

--- a/src/renderer/popover-content-height.ts
+++ b/src/renderer/popover-content-height.ts
@@ -3,6 +3,11 @@
 // against the window edges.
 export const OVERLAY_MARGIN = 32;
 
+// The width the popover reports when no agent-authored layout is active - the
+// historical fixed column width. A custom layout (marked with [data-bm-canvas])
+// reports its own intrinsic width instead, so the popover adapts to the canvas.
+export const DEFAULT_POPOVER_CONTENT_WIDTH = 504;
+
 /**
  * Height the tray popover window should request for the current content.
  *
@@ -18,4 +23,20 @@ export function measurePopoverContentHeight(shell: HTMLElement): number {
   if (!overlay) return shellHeight;
   const overlayHeight = Math.ceil(overlay.getBoundingClientRect().height) + OVERLAY_MARGIN;
   return Math.max(shellHeight, overlayHeight);
+}
+
+/**
+ * Size the popover window should request so both dimensions adapt to the content.
+ *
+ * Height reuses {@link measurePopoverContentHeight}. Width is the intrinsic width
+ * of the active layout canvas ([data-bm-canvas], which shrink-wraps an
+ * agent-authored layout that sets its own width) so the popover grows and shrinks
+ * with the canvas. Without a custom layout there is no canvas element and the
+ * historical fixed column width is reported, so the default popover is unchanged.
+ * The main process clamps the result to a usable range and the screen.
+ */
+export function measurePopoverContentSize(shell: HTMLElement): { width: number; height: number } {
+  const canvas = document.querySelector<HTMLElement>("[data-bm-canvas]");
+  const width = canvas ? Math.ceil(canvas.scrollWidth) : DEFAULT_POPOVER_CONTENT_WIDTH;
+  return { width, height: measurePopoverContentHeight(shell) };
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -52,7 +52,10 @@ button:disabled,
 
 .app-shell {
   position: relative;
-  width: 504px;
+  /* Fills the popover window, whose width the main process sizes to the reported
+     content width (the historical 504 by default, or the active layout canvas).
+     So both dimensions adapt to the content. */
+  width: 100%;
   height: auto;
   /* A fixed cap, not a viewport-relative one: the viewport height equals the
      auto-sized window, so capping to it would ratchet the popover - it could
@@ -139,6 +142,13 @@ button:disabled,
   min-height: 0;
 }
 
+/* An agent-authored layout owns its arrangement and its own width. The canvas
+   shrink-wraps it (max-content) so its intrinsic width is measurable even while
+   the popover window is still narrower, letting the host grow the window to fit. */
+.widget-canvas {
+  width: max-content;
+}
+
 .widget-host {
   display: flex;
   flex-direction: column;
@@ -162,23 +172,6 @@ button:disabled,
   padding-bottom: 4px;
   border-bottom: 0;
 }
-
-.widget .w-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-
-.widget .key {
-  color: var(--ink-label);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: var(--weight-reg);
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-}
-
 
 .quota-widget,
 .widget > div {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -139,6 +139,18 @@ export type BabyMenuWidgetModuleDescriptor = {
   cssUrl?: string;
 };
 
+// The optional, agent-authored layout module at the root of the extension
+// workspace (`layout.tsx`). When present the host renders its default export in
+// place of the built-in stacked column; when absent the host falls back to the
+// column, so this is purely additive and older apps that never look for it keep
+// working. Loaded through the same pipeline as a widget module - `moduleUrl`
+// (a `/@fs` URL in dev, a `baby-menu-widget://` URL when compiled) plus a sibling
+// compiled `cssUrl` in packaged mode.
+export type BabyMenuLayoutModuleDescriptor = {
+  moduleUrl: string;
+  cssUrl?: string;
+};
+
 export type BabyMenuWidget = {
   id: string;
   title: string;
@@ -173,6 +185,27 @@ export type RefreshableBabyMenuWidget = BabyMenuWidget &
         refreshView?: never;
       }
   );
+
+// The metadata the host hands a custom layout for each active extension so it
+// can decide what to place and where. The layout never imports widget files
+// directly; it places each one by id through `renderWidget`.
+export type BabyMenuLayoutWidget = {
+  id: string;
+  title: string;
+};
+
+// Props the host passes to the default export of `layout.tsx`. `renderWidget`
+// returns the refresh-wired, title-less render of one extension by id (null for
+// an unknown id), so the layout keeps the host's view-refresh wiring while
+// owning the arrangement and the overall canvas size (the host measures the
+// rendered layout and resizes the popover to fit its width and height).
+export type BabyMenuLayoutProps = {
+  widgets: BabyMenuLayoutWidget[];
+  renderWidget: (id: string) => ReactNode;
+};
+
+// The default export shape of an `extensions/layout.tsx` module.
+export type BabyMenuLayout = (props: BabyMenuLayoutProps) => ReactNode;
 
 export type PopoverVisibilityState = {
   visible: boolean;
@@ -227,6 +260,12 @@ export type BabyMenuApi = {
   widgets: {
     list: () => Promise<BabyMenuWidgetModuleDescriptor[]>;
   };
+  // Host-only: the agent-authored root layout module, or null when the workspace
+  // has no `layout.tsx` (the renderer then uses the built-in column). Not part of
+  // BabyMenuExtensionApi - extensions author the layout, they do not load it.
+  layout: {
+    get: () => Promise<BabyMenuLayoutModuleDescriptor | null>;
+  };
   background: {
     // Fires when an extension's background task finishes a run, so an open widget
     // can re-read its data. Nothing arrives while the task runs with the popover
@@ -235,6 +274,11 @@ export type BabyMenuApi = {
   };
   popover: {
     setContentHeight: (height: number) => Promise<{ ok: boolean }>;
+    // Reports the desired popover size so both width and height adapt to the
+    // layout content. The main process clamps to a usable range and the screen
+    // work area, then repositions. `setContentHeight` is retained for older
+    // callers; new code should use this.
+    setContentSize: (size: { width: number; height: number }) => Promise<{ ok: boolean }>;
     getVisibility: () => Promise<PopoverVisibilityState>;
     onVisibility: (listener: (state: PopoverVisibilityState) => void) => () => void;
   };
@@ -287,6 +331,7 @@ export type BabyMenuExtensionApi = {
   };
   popover: {
     setContentHeight: (height: number) => Promise<{ ok: boolean }>;
+    setContentSize: (size: { width: number; height: number }) => Promise<{ ok: boolean }>;
     getVisibility: () => Promise<PopoverVisibilityState>;
     onVisibility: (listener: (state: PopoverVisibilityState) => void) => () => void;
   };

--- a/src/shared/extension-contract-names.ts
+++ b/src/shared/extension-contract-names.ts
@@ -15,6 +15,10 @@ export const EXTENSION_CONTRACT_NAMES = [
   "BabyMenuWidget",
   "RefreshableBabyMenuWidget",
   "BabyMenuSettingsSection",
+  // Root layout.tsx surface: the canvas component and the props the host passes it.
+  "BabyMenuLayout",
+  "BabyMenuLayoutProps",
+  "BabyMenuLayoutWidget",
   // server.ts surface: the action/background context and what it carries.
   "BabyMenuServerContext",
   "BabyMenuDatabase",

--- a/tests/agent-chat.test.tsx
+++ b/tests/agent-chat.test.tsx
@@ -43,8 +43,10 @@ function installBabyMenuAgentMock({
       list: vi.fn(async () => []),
     },
     background: { onUpdate: vi.fn(() => () => undefined) },
+    layout: { get: vi.fn(async () => null) },
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
+      setContentSize: vi.fn(async () => ({ ok: true })),
       getVisibility: vi.fn(async () => ({ visible: true })),
       onVisibility: vi.fn(() => () => undefined),
     },

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -92,6 +92,7 @@ vi.mock("../src/main/extension-database", () => ({
 
 vi.mock("../src/main/widget-module-registry", () => ({
   createWidgetModuleRegistry: vi.fn(() => ({})),
+  createLayoutModuleRegistry: vi.fn(() => ({ get: vi.fn(async () => null) })),
 }));
 
 vi.mock("../src/main/widget-protocol", () => ({

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -193,6 +193,23 @@ describe("startBabyMenuApp", () => {
     expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 504, height: 333 });
   });
 
+  it("caps initial renderer size reports before first popover bounds", async () => {
+    const appModule = await import("../src/main/app");
+
+    await appModule.startBabyMenuApp();
+    const onTrayClick = createBabyMenuTray.mock.calls.at(-1)?.[0];
+    browserWindowInstance.loadFile.mockImplementationOnce(async () => {
+      const popoverController = registerIpcHandlers.mock.calls.at(-1)?.[4];
+      popoverController.setContentSize({ width: 2000, height: 300 });
+    });
+
+    await onTrayClick?.({ x: 100, y: 10, width: 24, height: 24 });
+
+    await vi.waitFor(() =>
+      expect(browserWindowInstance.setBounds).toHaveBeenLastCalledWith({ x: 8, y: 42, width: 1424, height: 300 }),
+    );
+  });
+
   it("starts the background scheduler and only forwards task-run events to visible renderer", async () => {
     const { createBackgroundTaskScheduler } = await import("../src/main/background-task-scheduler");
     const appModule = await import("../src/main/app");

--- a/tests/extension-layout.test.ts
+++ b/tests/extension-layout.test.ts
@@ -73,7 +73,15 @@ describe("extension layout", () => {
     const instructions = await readFile(resolve(import.meta.dirname, "../extensions/AGENTS.md"), "utf8");
 
     expect(instructions).toContain("Monochrome Lab");
-    expect(instructions).toContain("Design for a 504px macOS tray popover");
+    expect(instructions).toContain("Design for a macOS tray popover");
+    // The host no longer draws a per-widget title, and a custom layout.tsx can
+    // resize/rearrange the popover - both must be documented so the agent knows
+    // it owns its own labeling and how to arrange widgets.
+    expect(instructions).toContain("it no longer draws a title above your widget");
+    expect(instructions).toContain("not a mandate to draw a title bar");
+    expect(instructions).toContain("## Popover Layout");
+    expect(instructions).toContain("layout.tsx");
+    expect(instructions).toContain("BabyMenuLayoutProps");
     // The design system is delivered as components, not a wall of CSS classes.
     expect(instructions).toContain("@babymenu/ui");
     expect(instructions).toContain("DataTable");

--- a/tests/extension-module-compiler.test.ts
+++ b/tests/extension-module-compiler.test.ts
@@ -91,6 +91,33 @@ describe("extension module compiler", () => {
     await expect(readFile(compiled.outputPath, "utf8")).resolves.not.toContain("@babymenu/contracts");
   });
 
+  it("compiles TSX layouts with host React and UI shims", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
+    tempDirs.push(rootDir);
+    const extensionDir = join(rootDir, "extensions");
+    const entryFile = join(extensionDir, "layout.tsx");
+    await mkdir(extensionDir, { recursive: true });
+    await writeFile(
+      entryFile,
+      `import { useState } from "react";
+      import { Button } from "@babymenu/ui";
+      export default function Layout() { return <Button>{useState("Ready")[0]}</Button>; }`,
+    );
+
+    const compiled = await compileExtensionModule({
+      kind: "layout",
+      extensionId: "__layout",
+      extensionDir,
+      entryFile,
+      cacheRoot: join(rootDir, "cache", "widgets"),
+    });
+
+    const output = await readFile(compiled.outputPath, "utf8");
+    expect(output).toContain(`from "baby-menu-host://react/index.mjs"`);
+    expect(output).toContain(`from "baby-menu-host://ui/index.mjs"`);
+    expect(output).toContain(`from "baby-menu-host://react-jsx-runtime/index.mjs"`);
+  });
+
   it("reuses cached output for unchanged extension modules", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-compiler-"));
     tempDirs.push(rootDir);

--- a/tests/ipc-capabilities.test.ts
+++ b/tests/ipc-capabilities.test.ts
@@ -183,6 +183,7 @@ describe("capabilities IPC", () => {
     };
     const popover = {
       setContentHeight: vi.fn(),
+      setContentSize: vi.fn(),
       getVisibility: vi.fn(() => ({ visible: false })),
     };
 
@@ -190,6 +191,10 @@ describe("capabilities IPC", () => {
 
     await expect(handlers.get("baby-menu:popover:set-content-height")?.({}, 333)).resolves.toEqual({ ok: true });
     expect(popover.setContentHeight).toHaveBeenCalledWith(333);
+    await expect(handlers.get("baby-menu:popover:set-content-size")?.({}, { width: 820, height: 400 })).resolves.toEqual({
+      ok: true,
+    });
+    expect(popover.setContentSize).toHaveBeenCalledWith({ width: 820, height: 400 });
     await expect(handlers.get("baby-menu:popover:get-visibility")?.({})).resolves.toEqual({ visible: false });
   });
 

--- a/tests/layout-module-registry.test.ts
+++ b/tests/layout-module-registry.test.ts
@@ -1,0 +1,73 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { discoverLayoutModule, discoverWidgetModules } from "../src/main/widget-module-registry";
+
+describe("layout module registry", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("returns null when the workspace has no root layout module", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-layout-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, "extensions-dev");
+    await mkdir(join(extensionsDir, "cpu-temp"), { recursive: true });
+    await writeFile(join(extensionsDir, "cpu-temp", "widget.tsx"), "export const cpuTempWidget = {};\n");
+
+    expect(await discoverLayoutModule({ rootDir, extensionsDir })).toBeNull();
+  });
+
+  it("discovers a dev-mode root layout module via /@fs", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-layout-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, "extensions-dev");
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(join(extensionsDir, "layout.tsx"), "export default function Layout() { return null; }\n");
+
+    const descriptor = await discoverLayoutModule({ rootDir, extensionsDir });
+
+    expect(descriptor?.moduleUrl).toContain("/@fs/");
+    expect(descriptor?.moduleUrl).toContain("layout.tsx");
+    expect(descriptor?.moduleUrl).toContain("babyMenuWidgetVersion=");
+  });
+
+  it("returns a compiled custom protocol URL for the production layout module", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-layout-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, ".baby-menu", "extensions");
+    await mkdir(extensionsDir, { recursive: true });
+    await writeFile(
+      join(extensionsDir, "layout.tsx"),
+      `import type { BabyMenuLayoutProps } from "@babymenu/contracts";\n` +
+        `export default function Layout({ widgets, renderWidget }: BabyMenuLayoutProps) {\n` +
+        `  return widgets.map((w) => renderWidget(w.id));\n}\n`,
+    );
+
+    const descriptor = await discoverLayoutModule({
+      rootDir,
+      extensionsDir,
+      mode: "compiled",
+      widgetCacheDir: join(rootDir, "cache", "widgets"),
+    });
+
+    expect(descriptor?.moduleUrl).toMatch(/^baby-menu-widget:\/\/__layout\/[a-f0-9]{16}\/layout\.mjs$/);
+    expect(descriptor?.cssUrl).toMatch(/^baby-menu-widget:\/\/__layout\/[a-f0-9]{16}\/widget\.css$/);
+  });
+
+  it("excludes the root layout file from widget discovery", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-layout-registry-"));
+    tempDirs.push(rootDir);
+    const extensionsDir = join(rootDir, "extensions-dev");
+    await mkdir(join(extensionsDir, "cpu-temp"), { recursive: true });
+    await writeFile(join(extensionsDir, "cpu-temp", "widget.tsx"), "export const cpuTempWidget = {};\n");
+    await writeFile(join(extensionsDir, "layout.tsx"), "export default function Layout() { return null; }\n");
+
+    const modules = await discoverWidgetModules({ rootDir, extensionsDir });
+
+    expect(modules.map((module) => module.id)).toEqual(["cpu-temp.widget"]);
+  });
+});

--- a/tests/popover-content-height.test.ts
+++ b/tests/popover-content-height.test.ts
@@ -78,4 +78,13 @@ describe("measurePopoverContentSize", () => {
     canvas(840);
     expect(measurePopoverContentSize(shell)).toEqual({ width: 840, height: 360 });
   });
+
+  it("includes shell chrome around a custom layout canvas", () => {
+    const shell = document.createElement("main");
+    stubHeight(shell, 360);
+    Object.defineProperty(shell, "scrollWidth", { value: 870, configurable: true });
+    document.body.appendChild(shell);
+    canvas(840);
+    expect(measurePopoverContentSize(shell)).toEqual({ width: 870, height: 360 });
+  });
 });

--- a/tests/popover-content-height.test.ts
+++ b/tests/popover-content-height.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest";
-import { measurePopoverContentHeight, OVERLAY_MARGIN } from "../src/renderer/popover-content-height";
+import {
+  DEFAULT_POPOVER_CONTENT_WIDTH,
+  measurePopoverContentHeight,
+  measurePopoverContentSize,
+  OVERLAY_MARGIN,
+} from "../src/renderer/popover-content-height";
 
 function stubHeight(el: HTMLElement, height: number): void {
   el.getBoundingClientRect = () =>
@@ -43,5 +48,34 @@ describe("measurePopoverContentHeight", () => {
     document.body.appendChild(shell);
     overlay(480);
     expect(measurePopoverContentHeight(shell)).toBe(480 + OVERLAY_MARGIN);
+  });
+});
+
+function canvas(scrollWidth: number): HTMLElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-bm-canvas", "");
+  Object.defineProperty(el, "scrollWidth", { value: scrollWidth, configurable: true });
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("measurePopoverContentSize", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("reports the default column width when no custom layout canvas is present", () => {
+    const shell = document.createElement("main");
+    stubHeight(shell, 300);
+    document.body.appendChild(shell);
+    expect(measurePopoverContentSize(shell)).toEqual({ width: DEFAULT_POPOVER_CONTENT_WIDTH, height: 300 });
+  });
+
+  it("reports the intrinsic canvas width when a custom layout is active", () => {
+    const shell = document.createElement("main");
+    stubHeight(shell, 360);
+    document.body.appendChild(shell);
+    canvas(840);
+    expect(measurePopoverContentSize(shell)).toEqual({ width: 840, height: 360 });
   });
 });

--- a/tests/popover-position.test.ts
+++ b/tests/popover-position.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_POPOVER_SIZE,
   MAX_POPOVER_HEIGHT,
   MIN_POPOVER_HEIGHT,
+  MIN_POPOVER_WIDTH,
   calculatePopoverBounds,
   createPopoverOptions,
   loadPopoverRenderer,
@@ -22,12 +23,27 @@ describe("calculatePopoverBounds", () => {
     expect(createPopoverOptions("/app/preload.js").width).toBe(504);
   });
 
-  it("clamps content-driven popover height to a usable range", () => {
+  it("clamps content-driven popover width and height to a usable range", () => {
     expect(MIN_POPOVER_HEIGHT).toBe(220);
     expect(MAX_POPOVER_HEIGHT).toBe(720);
-    expect(responsivePopoverSize(140)).toEqual({ width: 504, height: 220 });
-    expect(responsivePopoverSize(420.2)).toEqual({ width: 504, height: 421 });
-    expect(responsivePopoverSize(960)).toEqual({ width: 504, height: 720 });
+    expect(MIN_POPOVER_WIDTH).toBe(320);
+    // Height clamps as before; width passes through above the floor so the
+    // popover adapts to whatever canvas the layout reports.
+    expect(responsivePopoverSize({ width: 504, height: 140 })).toEqual({ width: 504, height: 220 });
+    expect(responsivePopoverSize({ width: 840, height: 420.2 })).toEqual({ width: 840, height: 421 });
+    expect(responsivePopoverSize({ width: 504, height: 960 })).toEqual({ width: 504, height: 720 });
+    // A layout narrower than the floor is pulled back up to the minimum width.
+    expect(responsivePopoverSize({ width: 120, height: 300 })).toEqual({ width: 320, height: 300 });
+  });
+
+  it("caps the popover size to the display work area when one is given", () => {
+    const workArea = { x: 0, y: 0, width: 700, height: 600 };
+    // A layout asking for more than the screen can show is capped to the work
+    // area minus edge padding (8px each side), in both dimensions.
+    expect(responsivePopoverSize({ width: 2000, height: 2000 }, workArea)).toEqual({
+      width: 684,
+      height: 584,
+    });
   });
 
   it("centers the popover under a menu bar tray icon", () => {

--- a/tests/renderer-layout.test.ts
+++ b/tests/renderer-layout.test.ts
@@ -5,13 +5,17 @@ import { describe, expect, it } from "vitest";
 const stylesPath = resolve(import.meta.dirname, "../src/renderer/styles.css");
 
 describe("renderer layout styles", () => {
-  it("uses the Monochrome Lab token file and fixed tray popover width", async () => {
+  it("uses the Monochrome Lab token file and fills the content-sized popover window", async () => {
     const css = await readFile(stylesPath, "utf8");
 
     expect(css).toContain('@import url("./colors_and_type.css")');
-    expect(css).toMatch(/\.app-shell\s*\{[^}]*width:\s*504px/s);
+    // The shell fills the window; the main process sizes the window's width to
+    // the reported content (504 by default, or the active layout canvas).
+    expect(css).toMatch(/\.app-shell\s*\{[^}]*width:\s*100%/s);
     expect(css).toMatch(/\.app-shell\s*\{[^}]*background:\s*var\(--bg-stage\)/s);
     expect(css).toMatch(/\.app-shell\s*\{[^}]*border-radius:\s*var\(--radius-xl\)/s);
+    // A custom layout canvas shrink-wraps its content so its width is measurable.
+    expect(css).toMatch(/\.widget-canvas\s*\{[^}]*width:\s*max-content/s);
   });
 
   it("keeps widgets as dashed log sections in a scroll region above a pinned composer", async () => {

--- a/tests/renderer-monochrome-lab.test.tsx
+++ b/tests/renderer-monochrome-lab.test.tsx
@@ -42,8 +42,10 @@ function installBabyMenuApi(overrides: Partial<BabyMenuApi> = {}) {
       list: vi.fn(async () => []),
     },
     background: { onUpdate: vi.fn(() => () => undefined) },
+    layout: { get: vi.fn(async () => null) },
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
+      setContentSize: vi.fn(async () => ({ ok: true })),
       getVisibility: vi.fn(async () => ({ visible: true })),
       onVisibility: vi.fn(() => () => undefined),
     },

--- a/tests/renderer-widget-host.test.tsx
+++ b/tests/renderer-widget-host.test.tsx
@@ -30,8 +30,10 @@ function installBabyMenuApi(widgets: BabyMenuApi["widgets"]) {
     },
     widgets,
     background: { onUpdate: vi.fn(() => () => undefined) },
+    layout: { get: vi.fn(async () => null) },
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
+      setContentSize: vi.fn(async () => ({ ok: true })),
       getVisibility: vi.fn(async () => ({ visible: true })),
       onVisibility: vi.fn(() => () => undefined),
     },

--- a/tests/settings-view.test.tsx
+++ b/tests/settings-view.test.tsx
@@ -26,8 +26,10 @@ function installBabyMenuApi(settings?: Partial<BabyMenuSettings>): BabyMenuApi {
     },
     widgets: { list: vi.fn(async () => []) },
     background: { onUpdate: vi.fn(() => () => undefined) },
+    layout: { get: vi.fn(async () => null) },
     popover: {
       setContentHeight: vi.fn(async () => ({ ok: true })),
+      setContentSize: vi.fn(async () => ({ ok: true })),
       getVisibility: vi.fn(async () => ({ visible: true })),
       onVisibility: vi.fn(() => () => undefined),
     },

--- a/tests/widget-canvas.test.tsx
+++ b/tests/widget-canvas.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WidgetHost, layoutFromModule, loadRuntimeLayout } from "../src/renderer/menu/WidgetHost";
+import type { BabyMenuLayout, RefreshableBabyMenuWidget } from "../src/shared/contracts";
+
+afterEach(() => {
+  cleanup();
+  delete window.babyMenu;
+});
+
+const widgetA: RefreshableBabyMenuWidget = { id: "a", title: "ALPHA", render: () => <span>alpha-body</span> };
+const widgetB: RefreshableBabyMenuWidget = { id: "b", title: "BRAVO", render: () => <span>bravo-body</span> };
+
+describe("WidgetHost layout", () => {
+  it("renders widgets without a host-drawn title header so the extension owns its area", () => {
+    const { container } = render(<WidgetHost widgets={[widgetA]} layout={null} />);
+
+    expect(screen.getByText("alpha-body")).toBeTruthy();
+    // The old per-widget title chrome is gone.
+    expect(container.querySelector(".w-head")).toBeNull();
+    expect(screen.queryByText("ALPHA")).toBeNull();
+  });
+
+  it("uses the built-in column when there is no custom layout", () => {
+    const { container } = render(<WidgetHost widgets={[widgetA, widgetB]} layout={null} />);
+
+    expect(container.querySelector(".widget-host")).toBeTruthy();
+    expect(container.querySelector("[data-bm-canvas]")).toBeNull();
+  });
+
+  it("renders an agent-authored layout that arranges widgets by id", () => {
+    const layout: BabyMenuLayout = ({ widgets, renderWidget }) => (
+      <div data-testid="canvas-grid">
+        {widgets.map((w) => (
+          <section key={w.id} data-col={w.id}>
+            {renderWidget(w.id)}
+          </section>
+        ))}
+      </div>
+    );
+
+    const { container } = render(<WidgetHost widgets={[widgetA, widgetB]} layout={layout} />);
+
+    expect(container.querySelector("[data-bm-canvas]")).toBeTruthy();
+    expect(screen.getByTestId("canvas-grid")).toBeTruthy();
+    expect(screen.getByText("alpha-body")).toBeTruthy();
+    expect(screen.getByText("bravo-body")).toBeTruthy();
+  });
+
+  it("falls back to the built-in column when the custom layout throws", () => {
+    const Boom: BabyMenuLayout = () => {
+      throw new Error("layout blew up");
+    };
+
+    const { container } = render(<WidgetHost widgets={[widgetA]} layout={Boom} />);
+
+    // The popover never blanks: the column renders the widget content instead.
+    expect(container.querySelector(".widget-host")).toBeTruthy();
+    expect(screen.getByText("alpha-body")).toBeTruthy();
+  });
+});
+
+describe("loadRuntimeLayout", () => {
+  it("loads the default-export component from the discovered module", async () => {
+    const Layout: BabyMenuLayout = () => null;
+    window.babyMenu = {
+      layout: { get: vi.fn(async () => ({ moduleUrl: "/@fs/x/layout.tsx" })) },
+    } as unknown as typeof window.babyMenu;
+
+    const loaded = await loadRuntimeLayout(async () => ({ default: Layout }));
+    expect(loaded).toBe(Layout);
+  });
+
+  it("returns null when there is no layout module", async () => {
+    window.babyMenu = { layout: { get: vi.fn(async () => null) } } as unknown as typeof window.babyMenu;
+    expect(await loadRuntimeLayout(async () => ({}))).toBeNull();
+  });
+
+  it("degrades to null (built-in column) when the host bridge lacks layout.get", async () => {
+    window.babyMenu = {} as unknown as typeof window.babyMenu;
+    await expect(loadRuntimeLayout(async () => ({}))).resolves.toBeNull();
+  });
+
+  it("degrades to null when importing the module throws", async () => {
+    window.babyMenu = {
+      layout: { get: vi.fn(async () => ({ moduleUrl: "/@fs/x/layout.tsx" })) },
+    } as unknown as typeof window.babyMenu;
+    await expect(
+      loadRuntimeLayout(async () => {
+        throw new Error("boom");
+      }),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("layoutFromModule", () => {
+  it("extracts a default-export function component", () => {
+    const Layout: BabyMenuLayout = () => null;
+    expect(layoutFromModule({ default: Layout })).toBe(Layout);
+  });
+
+  it("returns null when there is no default export function", () => {
+    expect(layoutFromModule({})).toBeNull();
+    expect(layoutFromModule({ default: 42 })).toBeNull();
+    expect(layoutFromModule(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Intent

The developer wanted the popover menu to move beyond a fixed stacked-column layout by allowing an agent-authored root layout component to control the popover canvas size and arrange active extensions freely, while keeping older app versions and existing extensions working. They specifically preferred a React layout file at the root of the extensions directory that loads and positions active extension widgets. They required the popover to adapt in both width and height, remove host-rendered widget titles, and update extension authoring guidance so agents know widgets may need their own non-mandatory affordance to communicate what they show. After testing dev mode, they wanted the deeper runtime issue diagnosed because a valid layout.tsx was authored but not picked up by the live popover despite starting the app after the initial changes.

## What Changed

- Adds root `layout.tsx` discovery/loading so extensions can provide a custom React popover layout that renders active widgets through the host renderer.
- Extends the bridge, contracts, renderer host, and popover sizing path so custom layouts can drive both popover width and height while packaged builds allow the same renderer imports as widgets.
- Updates extension authoring docs and coverage for custom layout registration, adaptive sizing, renderer behavior, IPC/preload contracts, and packaged module compilation.

## Risk Assessment

⚠️ Medium: The current diff has no substantiated merge-blocking findings, but it touches the renderer layout path, IPC sizing, main-process window bounds, and packaged module compilation, so residual integration risk is broader than a cosmetic change.

## Testing

Focused Vitest coverage for layout discovery, renderer fallback, bridge wiring, compilation, sizing, and authoring guidance passed; a browser-rendered harness then demonstrated a root `layout.tsx` arranging two widgets, no host widget titles, and content-driven popover sizing to `880x282`, with screenshot evidence captured.

- Evidence: Custom root layout rendered in Baby Menu popover (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/custom-layout-render.png</code>)
<details>
<summary>Evidence: Rendered layout verification data</summary>

```text
{"popoverSize":"880x282","shellWidth":518,"canvasWidth":880,"hostTitles":0,"layoutTextPresent":true}
```
</details>
<details>
<summary>Evidence: Temporary renderer harness</summary>

Source: [Temporary renderer harness](http://127.0.0.1:5374/@fs/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/custom-layout-harness.html)

```text
<!doctype html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Baby Menu Custom Layout Evidence</title>
    <script type="module" src="/@fs/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/harness-boot.ts"></script>
  </head>
  <body>
    <div id="root"></div>
  </body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `src/main/extension-module-compiler.ts:254` - Packaged custom layouts that import allowed renderer dependencies such as `react` hooks or `@babymenu/ui` are rejected during module graph collection because `assertSupportedExternalImport` still whitelists those imports only for `kind === &#34;widget&#34;`; `discoverLayoutModule` then catches the compile failure and returns null, so valid `layout.tsx` files silently fall back to the built-in column in packaged builds.

🔧 Fix: Allow packaged layout renderer imports
2 issues (1 error, 1 warning) still open:
- 🚨 `src/renderer/popover-content-height.ts:39` - Custom layout width reports only the `[data-bm-canvas]` scrollWidth, but that canvas is rendered inside `.pop-body` with 14px horizontal padding plus the shell border. A documented `w-[840px]` layout therefore requests an 840px BrowserWindow whose content box is about 810px wide, clipping the right side instead of fitting the canvas. Include the surrounding shell/body horizontal chrome in the reported width or measure the shell scroll width after the canvas is present.
- ⚠️ `src/main/popover.ts:59` - When the hidden renderer reports a custom layout size before `latestTrayBounds` is set during first popover creation, `responsivePopoverSize` uses an infinite max width, so an oversized layout can store an uncapped `latestPopoverSize` before the first `setBounds`. Cap width to a safe display/work-area size before opening, or set tray bounds before loading the renderer.

🔧 Fix: Fix adaptive popover layout sizing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm vitest run tests/layout-module-registry.test.ts tests/widget-canvas.test.tsx tests/popover-content-height.test.ts tests/popover-position.test.ts tests/extension-layout.test.ts tests/ipc-capabilities.test.ts`
- `pnpm vitest run tests/preload-capabilities.test.ts tests/extension-module-compiler.test.ts tests/renderer-layout.test.ts`
- <code>Created temporary evidence harness files under `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG` with mocked `window.babyMenu.layout.get`, `widgets.list`, and `popover.setContentSize`.</code>
- `pnpm exec vite --config "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/vite.config.mjs" --host 127.0.0.1 --port 5374`
- `chrome-devtools-axi open "http://127.0.0.1:5374/@fs/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/custom-layout-harness.html"`
- `chrome-devtools-axi eval "() => ({ popoverSize: document.documentElement.dataset.lastPopoverSize, shellWidth: document.querySelector('.app-shell')?.scrollWidth, canvasWidth: document.querySelector('[data-bm-canvas]')?.scrollWidth, hostTitles: document.querySelectorAll('.w-head').length, layoutTextPresent: document.body.innerText.includes('agent-authored layout.tsx') })"`
- `chrome-devtools-axi screenshot "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSTYG7HQ98TTN4F5AQCW1KZG/custom-layout-render.png"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
