### PR TITLE
test(adapters): make cancellation tests deterministic

### DIFF
--- a/tests/adapter-claude-driver.test.ts
+++ b/tests/adapter-claude-driver.test.ts
@@ -1,11 +1,21 @@
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, afterEach } from "vitest";
 import { ClaudeDriver } from "../src/adapters/claude/driver";
 import type * as schema from "@agentclientprotocol/sdk";
 
 const FAKE = join(__dirname, "fixtures", "fake-clis", "fake-claude.mjs");
+
+// A SLOW_CANCEL fake stays alive after SIGTERM until this sentinel file appears,
+// so the test - not the wall clock - decides when the child exits. Returns the
+// prompt to send and a `release()` that lets the child finish.
+async function slowCancelGate(): Promise<{ prompt: string; release: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "claude-driver-"));
+  const sentinel = join(dir, "release-exit");
+  return { prompt: `SLOW_CANCEL:${sentinel}`, release: () => writeFile(sentinel, "") };
+}
 
 describe("ClaudeDriver (against a fake claude CLI)", () => {
   let driver: ClaudeDriver | null = null;
@@ -64,13 +74,14 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
   it("waits for the child process to exit before resolving cancellation", async () => {
     const d = makeDriver();
     await d.start(tmpdir());
+    const gate = await slowCancelGate();
     const ac = new AbortController();
     let ready!: () => void;
     const readyPromise = new Promise<void>((resolve) => {
       ready = resolve;
     });
     const prompt = d.prompt(
-      "SLOW_CANCEL",
+      gate.prompt,
       (u) => {
         if (u.sessionUpdate === "agent_message_chunk") ready();
       },
@@ -79,20 +90,29 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
     await readyPromise;
     ac.abort();
 
-    const early = await Promise.race([prompt, delay(20).then(() => "still-running")]);
-    expect(early).toBe("still-running");
+    // The child cannot exit until we release the sentinel, so the prompt must
+    // stay pending regardless of scheduling - this assertion is not a race.
+    let settled = false;
+    void prompt.then(() => {
+      settled = true;
+    });
+    await delay(20);
+    expect(settled).toBe(false);
+
+    await gate.release();
     expect(await prompt).toBe("cancelled");
   });
 
   it("waits for the child process to exit before resolving disposal", async () => {
     const d = makeDriver();
     await d.start(tmpdir());
+    const gate = await slowCancelGate();
     let ready!: () => void;
     const readyPromise = new Promise<void>((resolve) => {
       ready = resolve;
     });
     const prompt = d.prompt(
-      "SLOW_CANCEL",
+      gate.prompt,
       (u) => {
         if (u.sessionUpdate === "agent_message_chunk") ready();
       },
@@ -101,9 +121,18 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
     await readyPromise;
 
     const disposal = d.dispose();
-    const early = await Promise.race([disposal.then(() => "disposed"), delay(20).then(() => "still-running")]);
-    expect(early).toBe("still-running");
+    // Disposal awaits the child's exit, which the sentinel gates, so it stays
+    // pending until we release it - deterministic, no wall-clock window.
+    let disposed = false;
+    void disposal.then(() => {
+      disposed = true;
+    });
+    await delay(20);
+    expect(disposed).toBe(false);
+
+    await gate.release();
     await disposal;
+    expect(disposed).toBe(true);
     expect(await prompt).toBe("cancelled");
   });
 
@@ -123,9 +152,11 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
     );
     await readyPromise;
 
-    const disposal = d.dispose();
-    const result = await Promise.race([disposal.then(() => "disposed"), delay(1500).then(() => "still-running")]);
-    expect(result).toBe("disposed");
+    // The child swallows SIGTERM, so disposal can only resolve once the driver's
+    // SIGKILL after TERMINATION_GRACE_MS terminates it. Awaiting disposal is a
+    // deterministic proof of force-kill: if it never fired, this would hang and
+    // fail via the test timeout instead of flaking on a race window.
+    await d.dispose();
     expect(await prompt).toBe("cancelled");
   });
 });

--- a/tests/adapter-claude-driver.test.ts
+++ b/tests/adapter-claude-driver.test.ts
@@ -25,6 +25,8 @@ function waitForFile(path: string): Promise<void> {
 }
 
 async function slowCancelGate(): Promise<{ prompt: string; terminated: Promise<void>; release: () => Promise<void> }> {
+  // The fake CLI reports SIGTERM through one file and waits on the other before
+  // exiting, which lets the tests assert ordering without wall-clock races.
   const dir = await mkdtemp(join(tmpdir(), "claude-driver-"));
   const sentinel = join(dir, "release-exit");
   const terminated = join(dir, "observed-sigterm");

--- a/tests/adapter-claude-driver.test.ts
+++ b/tests/adapter-claude-driver.test.ts
@@ -1,20 +1,34 @@
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { mkdtemp, writeFile } from "node:fs/promises";
-import { setTimeout as delay } from "node:timers/promises";
+import { existsSync, watch } from "node:fs";
 import { describe, expect, it, afterEach } from "vitest";
 import { ClaudeDriver } from "../src/adapters/claude/driver";
 import type * as schema from "@agentclientprotocol/sdk";
 
 const FAKE = join(__dirname, "fixtures", "fake-clis", "fake-claude.mjs");
 
-// A SLOW_CANCEL fake stays alive after SIGTERM until this sentinel file appears,
-// so the test - not the wall clock - decides when the child exits. Returns the
-// prompt to send and a `release()` that lets the child finish.
-async function slowCancelGate(): Promise<{ prompt: string; release: () => Promise<void> }> {
+function waitForFile(path: string): Promise<void> {
+  if (existsSync(path)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const watcher = watch(dirname(path), (_event, filename) => {
+      if (filename === basename(path) && existsSync(path)) {
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.on("error", (error) => {
+      watcher.close();
+      reject(error);
+    });
+  });
+}
+
+async function slowCancelGate(): Promise<{ prompt: string; terminated: Promise<void>; release: () => Promise<void> }> {
   const dir = await mkdtemp(join(tmpdir(), "claude-driver-"));
   const sentinel = join(dir, "release-exit");
-  return { prompt: `SLOW_CANCEL:${sentinel}`, release: () => writeFile(sentinel, "") };
+  const terminated = join(dir, "observed-sigterm");
+  return { prompt: `SLOW_CANCEL:${sentinel}:${terminated}`, terminated: waitForFile(terminated), release: () => writeFile(sentinel, "") };
 }
 
 describe("ClaudeDriver (against a fake claude CLI)", () => {
@@ -88,19 +102,20 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
       ac.signal,
     );
     await readyPromise;
-    ac.abort();
-
-    // The child cannot exit until we release the sentinel, so the prompt must
-    // stay pending regardless of scheduling - this assertion is not a race.
+    let released = false;
     let settled = false;
-    void prompt.then(() => {
+    const settlement = prompt.then((result) => {
       settled = true;
+      return { result, released };
     });
-    await delay(20);
+    ac.abort();
+    await gate.terminated;
+    await Promise.resolve();
     expect(settled).toBe(false);
 
+    released = true;
     await gate.release();
-    expect(await prompt).toBe("cancelled");
+    expect(await settlement).toEqual({ result: "cancelled", released: true });
   });
 
   it("waits for the child process to exit before resolving disposal", async () => {
@@ -121,17 +136,19 @@ describe("ClaudeDriver (against a fake claude CLI)", () => {
     await readyPromise;
 
     const disposal = d.dispose();
-    // Disposal awaits the child's exit, which the sentinel gates, so it stays
-    // pending until we release it - deterministic, no wall-clock window.
+    let released = false;
     let disposed = false;
-    void disposal.then(() => {
+    const settlement = disposal.then(() => {
       disposed = true;
+      return { released };
     });
-    await delay(20);
+    await gate.terminated;
+    await Promise.resolve();
     expect(disposed).toBe(false);
 
+    released = true;
     await gate.release();
-    await disposal;
+    expect(await settlement).toEqual({ released: true });
     expect(disposed).toBe(true);
     expect(await prompt).toBe("cancelled");
   });

--- a/tests/adapter-codex-driver.test.ts
+++ b/tests/adapter-codex-driver.test.ts
@@ -25,6 +25,8 @@ function waitForFile(path: string): Promise<void> {
 }
 
 async function slowCancelGate(): Promise<{ prompt: string; terminated: Promise<void>; release: () => Promise<void> }> {
+  // The fake CLI reports SIGTERM through one file and waits on the other before
+  // exiting, which lets the tests assert ordering without wall-clock races.
   const dir = await mkdtemp(join(tmpdir(), "codex-driver-"));
   const sentinel = join(dir, "release-exit");
   const terminated = join(dir, "observed-sigterm");

--- a/tests/adapter-codex-driver.test.ts
+++ b/tests/adapter-codex-driver.test.ts
@@ -1,11 +1,21 @@
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it, afterEach } from "vitest";
 import { CodexDriver } from "../src/adapters/codex/driver";
 import type * as schema from "@agentclientprotocol/sdk";
 
 const FAKE = join(__dirname, "fixtures", "fake-clis", "fake-codex.mjs");
+
+// A SLOW_CANCEL fake stays alive after SIGTERM until this sentinel file appears,
+// so the test - not the wall clock - decides when the child exits. Returns the
+// prompt to send and a `release()` that lets the child finish.
+async function slowCancelGate(): Promise<{ prompt: string; release: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), "codex-driver-"));
+  const sentinel = join(dir, "release-exit");
+  return { prompt: `SLOW_CANCEL:${sentinel}`, release: () => writeFile(sentinel, "") };
+}
 
 describe("CodexDriver (against a fake codex CLI)", () => {
   let driver: CodexDriver | null = null;
@@ -81,13 +91,14 @@ describe("CodexDriver (against a fake codex CLI)", () => {
   it("waits for the child process to exit before resolving cancellation", async () => {
     const d = makeDriver();
     await d.start(tmpdir());
+    const gate = await slowCancelGate();
     const ac = new AbortController();
     let ready!: () => void;
     const readyPromise = new Promise<void>((resolve) => {
       ready = resolve;
     });
     const prompt = d.prompt(
-      "SLOW_CANCEL",
+      gate.prompt,
       (u) => {
         if (u.sessionUpdate === "agent_message_chunk") ready();
       },
@@ -96,20 +107,29 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     await readyPromise;
     ac.abort();
 
-    const early = await Promise.race([prompt, delay(20).then(() => "still-running")]);
-    expect(early).toBe("still-running");
+    // The child cannot exit until we release the sentinel, so the prompt must
+    // stay pending regardless of scheduling - this assertion is not a race.
+    let settled = false;
+    void prompt.then(() => {
+      settled = true;
+    });
+    await delay(20);
+    expect(settled).toBe(false);
+
+    await gate.release();
     expect(await prompt).toBe("cancelled");
   });
 
   it("waits for the child process to exit before resolving disposal", async () => {
     const d = makeDriver();
     await d.start(tmpdir());
+    const gate = await slowCancelGate();
     let ready!: () => void;
     const readyPromise = new Promise<void>((resolve) => {
       ready = resolve;
     });
     const prompt = d.prompt(
-      "SLOW_CANCEL",
+      gate.prompt,
       (u) => {
         if (u.sessionUpdate === "agent_message_chunk") ready();
       },
@@ -118,9 +138,18 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     await readyPromise;
 
     const disposal = d.dispose();
-    const early = await Promise.race([disposal.then(() => "disposed"), delay(20).then(() => "still-running")]);
-    expect(early).toBe("still-running");
+    // Disposal awaits the child's exit, which the sentinel gates, so it stays
+    // pending until we release it - deterministic, no wall-clock window.
+    let disposed = false;
+    void disposal.then(() => {
+      disposed = true;
+    });
+    await delay(20);
+    expect(disposed).toBe(false);
+
+    await gate.release();
     await disposal;
+    expect(disposed).toBe(true);
     expect(await prompt).toBe("cancelled");
   });
 
@@ -140,9 +169,11 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     );
     await readyPromise;
 
-    const disposal = d.dispose();
-    const result = await Promise.race([disposal.then(() => "disposed"), delay(1500).then(() => "still-running")]);
-    expect(result).toBe("disposed");
+    // The child swallows SIGTERM, so disposal can only resolve once the driver's
+    // SIGKILL after TERMINATION_GRACE_MS terminates it. Awaiting disposal is a
+    // deterministic proof of force-kill: if it never fired, this would hang and
+    // fail via the test timeout instead of flaking on a race window.
+    await d.dispose();
     expect(await prompt).toBe("cancelled");
   });
 });

--- a/tests/adapter-codex-driver.test.ts
+++ b/tests/adapter-codex-driver.test.ts
@@ -1,20 +1,34 @@
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { mkdtemp, writeFile } from "node:fs/promises";
-import { setTimeout as delay } from "node:timers/promises";
+import { existsSync, watch } from "node:fs";
 import { describe, expect, it, afterEach } from "vitest";
 import { CodexDriver } from "../src/adapters/codex/driver";
 import type * as schema from "@agentclientprotocol/sdk";
 
 const FAKE = join(__dirname, "fixtures", "fake-clis", "fake-codex.mjs");
 
-// A SLOW_CANCEL fake stays alive after SIGTERM until this sentinel file appears,
-// so the test - not the wall clock - decides when the child exits. Returns the
-// prompt to send and a `release()` that lets the child finish.
-async function slowCancelGate(): Promise<{ prompt: string; release: () => Promise<void> }> {
+function waitForFile(path: string): Promise<void> {
+  if (existsSync(path)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const watcher = watch(dirname(path), (_event, filename) => {
+      if (filename === basename(path) && existsSync(path)) {
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.on("error", (error) => {
+      watcher.close();
+      reject(error);
+    });
+  });
+}
+
+async function slowCancelGate(): Promise<{ prompt: string; terminated: Promise<void>; release: () => Promise<void> }> {
   const dir = await mkdtemp(join(tmpdir(), "codex-driver-"));
   const sentinel = join(dir, "release-exit");
-  return { prompt: `SLOW_CANCEL:${sentinel}`, release: () => writeFile(sentinel, "") };
+  const terminated = join(dir, "observed-sigterm");
+  return { prompt: `SLOW_CANCEL:${sentinel}:${terminated}`, terminated: waitForFile(terminated), release: () => writeFile(sentinel, "") };
 }
 
 describe("CodexDriver (against a fake codex CLI)", () => {
@@ -105,19 +119,20 @@ describe("CodexDriver (against a fake codex CLI)", () => {
       ac.signal,
     );
     await readyPromise;
-    ac.abort();
-
-    // The child cannot exit until we release the sentinel, so the prompt must
-    // stay pending regardless of scheduling - this assertion is not a race.
+    let released = false;
     let settled = false;
-    void prompt.then(() => {
+    const settlement = prompt.then((result) => {
       settled = true;
+      return { result, released };
     });
-    await delay(20);
+    ac.abort();
+    await gate.terminated;
+    await Promise.resolve();
     expect(settled).toBe(false);
 
+    released = true;
     await gate.release();
-    expect(await prompt).toBe("cancelled");
+    expect(await settlement).toEqual({ result: "cancelled", released: true });
   });
 
   it("waits for the child process to exit before resolving disposal", async () => {
@@ -138,17 +153,19 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     await readyPromise;
 
     const disposal = d.dispose();
-    // Disposal awaits the child's exit, which the sentinel gates, so it stays
-    // pending until we release it - deterministic, no wall-clock window.
+    let released = false;
     let disposed = false;
-    void disposal.then(() => {
+    const settlement = disposal.then(() => {
       disposed = true;
+      return { released };
     });
-    await delay(20);
+    await gate.terminated;
+    await Promise.resolve();
     expect(disposed).toBe(false);
 
+    released = true;
     await gate.release();
-    await disposal;
+    expect(await settlement).toEqual({ released: true });
     expect(disposed).toBe(true);
     expect(await prompt).toBe("cancelled");
   });

--- a/tests/fixtures/fake-clis/fake-claude.mjs
+++ b/tests/fixtures/fake-clis/fake-claude.mjs
@@ -4,7 +4,7 @@
 // runs one process per turn). Echoes whether it was resumed so the driver's
 // session threading can be asserted. Kept in sync with
 // tests/fixtures/protocols/claude/*.jsonl.
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
 
@@ -20,13 +20,14 @@ if (prompt.includes("SLOW_CANCEL")) {
   // process is still mid-script; registering after the emit left a window where
   // SIGTERM hit Node's default action (immediate termination) and the child
   // died early. Once terminated, exit only when the test creates the sentinel
-  // file encoded in the prompt (SLOW_CANCEL:<path>), so the driver's disposal
+  // release file encoded in the prompt, so the driver's disposal
   // and cancellation promises stay pending until the test releases us - no
   // wall-clock race decides the outcome.
-  const releaseFile = prompt.match(/SLOW_CANCEL:(\S+)/)?.[1] ?? null;
+  const [, releaseFile = null, terminatedFile = null] = prompt.match(/SLOW_CANCEL:(\S+):(\S+)/) ?? [];
   let terminating = false;
   process.on("SIGTERM", () => {
     terminating = true;
+    if (terminatedFile) writeFileSync(terminatedFile, "");
   });
   emit({ type: "system", subtype: "init", session_id: "fake-session", model: "fake", cwd: process.cwd() });
   emit({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "ready" }] } });

--- a/tests/fixtures/fake-clis/fake-claude.mjs
+++ b/tests/fixtures/fake-clis/fake-claude.mjs
@@ -4,6 +4,8 @@
 // runs one process per turn). Echoes whether it was resumed so the driver's
 // session threading can be asserted. Kept in sync with
 // tests/fixtures/protocols/claude/*.jsonl.
+// Special SLOW_* prompts are test controls for cancellation and child-process
+// termination behavior rather than captured protocol fixtures.
 import { existsSync, writeFileSync } from "node:fs";
 
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");

--- a/tests/fixtures/fake-clis/fake-claude.mjs
+++ b/tests/fixtures/fake-clis/fake-claude.mjs
@@ -4,6 +4,8 @@
 // runs one process per turn). Echoes whether it was resumed so the driver's
 // session threading can be asserted. Kept in sync with
 // tests/fixtures/protocols/claude/*.jsonl.
+import { existsSync } from "node:fs";
+
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
 
 const argv = process.argv.slice(2);
@@ -13,17 +15,35 @@ const isResume = resumeIdx >= 0;
 const prompt = argv[argv.length - 1] ?? "";
 
 if (prompt.includes("SLOW_CANCEL")) {
+  // Register the SIGTERM handler BEFORE announcing readiness. The parent reads
+  // "ready" the instant the bytes hit the pipe and may fire SIGTERM while this
+  // process is still mid-script; registering after the emit left a window where
+  // SIGTERM hit Node's default action (immediate termination) and the child
+  // died early. Once terminated, exit only when the test creates the sentinel
+  // file encoded in the prompt (SLOW_CANCEL:<path>), so the driver's disposal
+  // and cancellation promises stay pending until the test releases us - no
+  // wall-clock race decides the outcome.
+  const releaseFile = prompt.match(/SLOW_CANCEL:(\S+)/)?.[1] ?? null;
+  let terminating = false;
+  process.on("SIGTERM", () => {
+    terminating = true;
+  });
   emit({ type: "system", subtype: "init", session_id: "fake-session", model: "fake", cwd: process.cwd() });
   emit({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "ready" }] } });
-  process.on("SIGTERM", () => setTimeout(() => process.exit(0), 100));
-  setInterval(() => {}, 1000);
+  setInterval(() => {
+    if (terminating && (!releaseFile || existsSync(releaseFile))) process.exit(0);
+  }, 5);
   await new Promise(() => {});
 }
 
 if (prompt.includes("SLOW_FORCE_KILL")) {
+  // Swallow SIGTERM entirely so only the driver's SIGKILL after the termination
+  // grace period can stop us. The test proves force-kill happened simply by
+  // observing that disposal completes at all. Registered before "ready" for the
+  // same reason as SLOW_CANCEL above.
+  process.on("SIGTERM", () => {});
   emit({ type: "system", subtype: "init", session_id: "fake-session", model: "fake", cwd: process.cwd() });
   emit({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "ready" }] } });
-  process.on("SIGTERM", () => setTimeout(() => process.exit(0), 2000));
   setInterval(() => {}, 1000);
   await new Promise(() => {});
 }

--- a/tests/fixtures/fake-clis/fake-codex.mjs
+++ b/tests/fixtures/fake-clis/fake-codex.mjs
@@ -3,6 +3,8 @@
 // JSONL mirroring the real flat shape, then exits (exec is one-shot per turn).
 // Captures resume to prove the driver threads the thread id across turns.
 // Kept in sync with tests/fixtures/protocols/codex/exec-*.jsonl.
+import { existsSync } from "node:fs";
+
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
 
 const argv = process.argv.slice(2);
@@ -19,19 +21,37 @@ if (isResume && argv.includes("--color")) {
 }
 
 if (prompt.includes("SLOW_CANCEL")) {
+  // Register the SIGTERM handler BEFORE announcing readiness. The parent reads
+  // "ready" the instant the bytes hit the pipe and may fire SIGTERM while this
+  // process is still mid-script; registering after the emit left a window where
+  // SIGTERM hit Node's default action (immediate termination) and the child
+  // died early. Once terminated, exit only when the test creates the sentinel
+  // file encoded in the prompt (SLOW_CANCEL:<path>), so the driver's disposal
+  // and cancellation promises stay pending until the test releases us - no
+  // wall-clock race decides the outcome.
+  const releaseFile = prompt.match(/SLOW_CANCEL:(\S+)/)?.[1] ?? null;
+  let terminating = false;
+  process.on("SIGTERM", () => {
+    terminating = true;
+  });
   emit({ type: "thread.started", thread_id: "fake-thread" });
   emit({ type: "turn.started" });
   emit({ type: "item.completed", item: { id: "item_1", type: "agent_message", text: "ready" } });
-  process.on("SIGTERM", () => setTimeout(() => process.exit(0), 100));
-  setInterval(() => {}, 1000);
+  setInterval(() => {
+    if (terminating && (!releaseFile || existsSync(releaseFile))) process.exit(0);
+  }, 5);
   await new Promise(() => {});
 }
 
 if (prompt.includes("SLOW_FORCE_KILL")) {
+  // Swallow SIGTERM entirely so only the driver's SIGKILL after the termination
+  // grace period can stop us. The test proves force-kill happened simply by
+  // observing that disposal completes at all. Registered before "ready" for the
+  // same reason as SLOW_CANCEL above.
+  process.on("SIGTERM", () => {});
   emit({ type: "thread.started", thread_id: "fake-thread" });
   emit({ type: "turn.started" });
   emit({ type: "item.completed", item: { id: "item_1", type: "agent_message", text: "ready" } });
-  process.on("SIGTERM", () => setTimeout(() => process.exit(0), 2000));
   setInterval(() => {}, 1000);
   await new Promise(() => {});
 }

--- a/tests/fixtures/fake-clis/fake-codex.mjs
+++ b/tests/fixtures/fake-clis/fake-codex.mjs
@@ -3,7 +3,7 @@
 // JSONL mirroring the real flat shape, then exits (exec is one-shot per turn).
 // Captures resume to prove the driver threads the thread id across turns.
 // Kept in sync with tests/fixtures/protocols/codex/exec-*.jsonl.
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
 
@@ -26,13 +26,14 @@ if (prompt.includes("SLOW_CANCEL")) {
   // process is still mid-script; registering after the emit left a window where
   // SIGTERM hit Node's default action (immediate termination) and the child
   // died early. Once terminated, exit only when the test creates the sentinel
-  // file encoded in the prompt (SLOW_CANCEL:<path>), so the driver's disposal
+  // release file encoded in the prompt, so the driver's disposal
   // and cancellation promises stay pending until the test releases us - no
   // wall-clock race decides the outcome.
-  const releaseFile = prompt.match(/SLOW_CANCEL:(\S+)/)?.[1] ?? null;
+  const [, releaseFile = null, terminatedFile = null] = prompt.match(/SLOW_CANCEL:(\S+):(\S+)/) ?? [];
   let terminating = false;
   process.on("SIGTERM", () => {
     terminating = true;
+    if (terminatedFile) writeFileSync(terminatedFile, "");
   });
   emit({ type: "thread.started", thread_id: "fake-thread" });
   emit({ type: "turn.started" });

--- a/tests/fixtures/fake-clis/fake-codex.mjs
+++ b/tests/fixtures/fake-clis/fake-codex.mjs
@@ -3,6 +3,8 @@
 // JSONL mirroring the real flat shape, then exits (exec is one-shot per turn).
 // Captures resume to prove the driver threads the thread id across turns.
 // Kept in sync with tests/fixtures/protocols/codex/exec-*.jsonl.
+// Special SLOW_* prompts are test controls for cancellation and child-process
+// termination behavior rather than captured protocol fixtures.
 import { existsSync, writeFileSync } from "node:fs";
 
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");


### PR DESCRIPTION
## Intent

The developer wanted to diagnose a failed GitHub Actions run for baby-menu and then implement a real fix rather than simply rerunning CI. After learning the failure was a flaky timing-sensitive Codex driver test, they explicitly required making the test deterministic and non-flaky. The scope included fixing the underlying fixture/test race around process disposal behavior, with attention to the shared Claude driver pattern as well.

## What Changed

- Replaced timing-based Claude and Codex adapter cancellation assertions with file-backed handshakes that prove prompts and disposal remain pending until the fake CLI is released.
- Updated fake Claude and Codex CLIs to register SIGTERM handlers before emitting readiness, report observed termination through sentinel files, and keep slow-cancel exits under explicit test control.
- Simplified force-kill coverage to await disposal directly, relying on the test timeout instead of fixed sleep races.

## Risk Assessment

✅ Low: The change is limited to deterministic adapter cancellation tests and fake CLI fixtures, with no production behavior changes and no material risks found.

## Testing

After inspecting the changed adapter fixtures and tests, I ran the full relevant Claude/Codex driver suites and then stress-ran the deterministic cancellation, disposal, and force-kill selectors 10 times; all runs passed, with evidence logs captured under the requested temp directory.

<details>
<summary>Evidence: Adapter driver verbose test log</summary>

`Shows both fake-CLI adapter suites passing, including cancellation-before-spawn, wait-for-child-exit cancellation/disposal, and force-kill behavior for Claude and Codex.`

```text
Already up to date
Done in 186ms using pnpm v11.1.1
Already up to date
Done in 194ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn 37ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn 37ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory) 74ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2) 72ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory) 77ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update 33ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning 1ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update 38ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning 2ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 69ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 74ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 61ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 66ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1031ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1029ms

 Test Files  2 passed (2)
      Tests  15 passed (15)
   Start at  16:26:47
   Duration  1.55s (transform 122ms, setup 0ms, import 152ms, tests 2.70s, environment 0ms)
```
</details>
<details>
<summary>Evidence: Adapter cancellation stress log</summary>

`Shows 10 consecutive runs of the historically flaky cancellation/disposal/force-kill paths for both ClaudeDriver and CodexDriver.`

```text
stress iteration 1
Already up to date
Done in 177ms using pnpm v11.1.1
Already up to date
Done in 183ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 61ms
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 64ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 62ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 60ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1033ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1035ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:03
   Duration  1.30s (transform 101ms, setup 0ms, import 128ms, tests 2.32s, environment 0ms)

stress iteration 2
Already up to date
Done in 171ms using pnpm v11.1.1
Already up to date
Done in 165ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 62ms
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 62ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 67ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 67ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1028ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1028ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:05
   Duration  1.27s (transform 58ms, setup 0ms, import 77ms, tests 2.32s, environment 0ms)

stress iteration 3
Already up to date
Done in 173ms using pnpm v11.1.1
Already up to date
Done in 173ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 67ms
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 68ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 64ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 64ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1032ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1032ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:07
   Duration  1.27s (transform 54ms, setup 0ms, import 70ms, tests 2.33s, environment 0ms)

stress iteration 4
Already up to date
Done in 158ms using pnpm v11.1.1
Already up to date
Done in 163ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries me

... [9309 bytes truncated] ...

 tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1027ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1027ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:15
   Duration  1.26s (transform 58ms, setup 0ms, import 76ms, tests 2.31s, environment 0ms)

stress iteration 8
Already up to date
Done in 170ms using pnpm v11.1.1
Already up to date
Done in 173ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 68ms
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 68ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 60ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 59ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1030ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1030ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:18
   Duration  1.27s (transform 59ms, setup 0ms, import 78ms, tests 2.32s, environment 0ms)

stress iteration 9
Already up to date
Done in 175ms using pnpm v11.1.1
Already up to date
Done in 168ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 66ms
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 70ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 61ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 60ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1026ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1023ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:20
   Duration  1.26s (transform 56ms, setup 0ms, import 72ms, tests 2.31s, environment 0ms)

stress iteration 10
Already up to date
Done in 167ms using pnpm v11.1.1
Already up to date
Done in 163ms using pnpm v11.1.1

 RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/982f317a9221/01KSV0M36ZJJFQTNMMJBKC9G63

 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > surfaces a tool_call and tool_call_update
 ↓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving cancellation 68ms
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > streams an assistant chunk and resolves end_turn
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resumes the session on the second prompt (carries memory)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > does not pass --color to `exec resume` (codex rejects it with exit 2)
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > surfaces a command tool_call and tool_call_update
 ↓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > resolves cancelled when the signal aborts before spawning
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving cancellation 67ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > waits for the child process to exit before resolving disposal 63ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > waits for the child process to exit before resolving disposal 65ms
 ✓ tests/adapter-claude-driver.test.ts > ClaudeDriver (against a fake claude CLI) > force-kills a child that outlives the termination grace period 1029ms
 ✓ tests/adapter-codex-driver.test.ts > CodexDriver (against a fake codex CLI) > force-kills a child that outlives the termination grace period 1029ms

 Test Files  2 passed (2)
      Tests  6 passed | 9 skipped (15)
   Start at  16:27:22
   Duration  1.27s (transform 54ms, setup 0ms, import 71ms, tests 2.32s, environment 0ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/adapter-claude-driver.test.ts:99` - The cancellation test still uses a fixed 20ms sleep to decide that the prompt stayed pending; a regression that resolves after that window but before the sentinel release would still pass, so the test is not fully deterministic. Have the fake CLI signal when SIGTERM has been handled, then assert the prompt remains unsettled after that deterministic point and before creating the release file.
- ⚠️ `tests/adapter-codex-driver.test.ts:116` - The Codex cancellation test has the same fixed 20ms pending check; a delayed-but-still-premature cancellation resolution can pass if it happens after the sleep and before the sentinel release. Use an explicit SIGTERM-observed handshake from the fake CLI before checking non-settlement.

🔧 Fix: Make adapter cancellation tests deterministic
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected target diff from `9ad8894335495e818692ef0872666a4277a69a75..49ed6cdc1fd5c06d56517d304f6c1ef4619c8d8e` to confirm the intent was deterministic fake-CLI cancellation/disposal behavior for Claude and Codex drivers.</code>
- `pnpm vitest run tests/adapter-codex-driver.test.ts tests/adapter-claude-driver.test.ts --reporter=verbose`
- `for i in {1..10}; do pnpm vitest run tests/adapter-codex-driver.test.ts tests/adapter-claude-driver.test.ts -t "waits for the child process to exit before resolving|force-kills a child" --reporter=verbose; done`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
