### PR TITLE
fix(adapters): preserve configured Codex model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ The extension-facing slice of that contract is a generated public surface, treat
 `src/adapters/` contains the bundled clean-room ACP adapters for built-in agents.
 Claude Code and Codex are exposed to `acpx/runtime` as local adapter processes, while the adapters drive the real authenticated `claude` and `codex` CLIs in the active extension workspace.
 The adapters intentionally run lean: they do not inherit user-level agent settings, skills, MCP servers, or extra rules.
+The Codex adapter makes one narrow exception: because `--ignore-user-config` also discards the configured default model, it reads only the top-level `model` from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` and passes that value back as `--model`.
 
 `src/renderer/` extension loading modules:
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Set `BABY_MENU_TELEMETRY=0` in the launch environment to opt out.
 If an agent send fails, the composer notice surfaces the underlying failure message instead of only showing a generic unavailable hint.
 Baby Menu detects supported agents from the catalog in order: Claude Code (`claude`), then Codex (`codex`).
 Those built-ins run through bundled clean-room ACP adapters that drive the authenticated local CLIs without inheriting user-level agent settings, skills, MCP servers, or extra rules.
+The Codex adapter makes one exception: it reads only the top-level `model` from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` and passes it as `--model`, because the adapter otherwise runs Codex with `--ignore-user-config`.
 Use Settings to persist an agent choice across launches.
 Set `BABY_MENU_AGENT=<name>` in the launch environment to override auto-detection before a preference is saved.
 Add `~/.baby-menu/agents.json` to override or append catalog entries manually; source mode reads `agents.json` from the repo root.
@@ -149,6 +150,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 - **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria.
   The agent reads the matching recipe before implementing.
 - **Bundled ACP adapters** - the built-in Claude Code and Codex entries launch `out/adapters/<name>/index.mjs`, which wraps the local authenticated CLI and keeps Baby Menu's embedded agent isolated from user-level agent configuration.
+  Codex still reuses only the top-level configured model from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` so `--ignore-user-config` does not force an unsupported CLI default.
   If a restart leaves behind a persisted ACP session that an adapter cannot resume, Baby Menu records the failed attempt, deletes that stale session record, and retries once with a fresh session.
 - **Live custom agent catalog** - Settings-owned custom ACP agents are persisted to `agents.json`, registered as `acpx` overrides immediately, and kept separate from read-only built-ins.
 - **Settings overlay** - Settings covers the default menu without unmounting it, so chat composer, widget, and run state survive opening and closing Settings.
@@ -200,6 +202,7 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
 | `BABY_MENU_AGENT=<name>`          | Overrides agent auto-detection when no saved Settings choice exists                                                                                                                                               |
 | `BABY_MENU_AGENT_TIMEOUT_MS=<ms>` | Overrides the embedded-agent request timeout                                                                                                                                                                      |
 | `BABY_MENU_EXTENSIONS_DIR=<dir>`  | Overrides the active extension workspace in source/dev runs. Dev Tailwind scans only `extensions/` and `extensions-dev/`, so overrides outside those paths need matching `@source` coverage for widget utilities. |
+| `CODEX_HOME=<dir>`                | When Codex is the selected built-in agent, points the adapter at `<dir>/config.toml` for the top-level `model`; other Codex user config is still ignored.                                                         |
 | `BABY_MENU_TELEMETRY=0`           | Disables packaged-release telemetry; `false` and `off` are also accepted                                                                                                                                          |
 | `BABY_MENU_UMAMI_HOST=<url>`      | Overrides the self-hosted Umami endpoint used by telemetry. Source/dev/test builds are no-op unless a website id is also configured.                                                                               |
 | `BABY_MENU_UMAMI_WEBSITE_ID=<id>` | Overrides or supplies the Umami website id used by telemetry. The release workflow reads this from the GitHub Actions `vars.*` context, not a secret.                                                             |

--- a/src/adapters/codex/config.ts
+++ b/src/adapters/codex/config.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolves codex's config/auth home, matching the CLI: $CODEX_HOME if set,
+ * otherwise ~/.codex. Auth already resolves via CODEX_HOME (see driver.ts), and
+ * the model lives next to it in config.toml.
+ */
+export function codexHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_HOME ?? join(homedir(), ".codex");
+}
+
+/**
+ * Extracts the top-level `model` from a codex config.toml.
+ *
+ * Only the top-level key counts: in TOML, top-level keys appear before the first
+ * table header, so we stop at the first `[...]`. A `model` under `[profiles.*]`
+ * (or any other table) is a different setting and must not be mistaken for the
+ * active default. Handles single- and double-quoted strings and skips comments.
+ */
+export function parseCodexModel(toml: string): string | null {
+  for (const line of toml.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith("[")) break; // entered a table; top-level keys are above it
+    const match = trimmed.match(/^model\s*=\s*["']([^"']+)["']/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Reads the configured codex model from <home>/config.toml, or null if the file
+ * is missing or has no top-level model. The adapter runs codex with
+ * `--ignore-user-config` to stay lean, which also discards this model line, so
+ * the driver re-injects it explicitly as `--model`.
+ */
+export function readCodexModel(home: string = codexHome()): string | null {
+  let raw: string;
+  try {
+    raw = readFileSync(join(home, "config.toml"), "utf8");
+  } catch {
+    return null;
+  }
+  return parseCodexModel(raw);
+}

--- a/src/adapters/codex/driver.ts
+++ b/src/adapters/codex/driver.ts
@@ -12,6 +12,13 @@ const TERMINATION_GRACE_MS = 1000;
 export type CodexDriverOptions = {
   /** Override the codex binary (tests inject a fake). Defaults to "codex". */
   command?: string;
+  /**
+   * Model to pass as `--model`. `--ignore-user-config` (below) discards the
+   * `model` line from ~/.codex/config.toml, so without this codex falls back to
+   * a built-in default that is unsupported on ChatGPT-account logins. When
+   * undefined, no `--model` is passed and codex picks its own default.
+   */
+  model?: string;
 };
 
 /**
@@ -28,6 +35,7 @@ export type CodexDriverOptions = {
  */
 export class CodexDriver implements SessionDriver {
   private readonly command: string;
+  private readonly model: string | null;
   private cwd: string | null = null;
   private threadId: string | null = null;
   private child: ChildProcessWithoutNullStreams | null = null;
@@ -36,6 +44,7 @@ export class CodexDriver implements SessionDriver {
 
   constructor(options: CodexDriverOptions = {}) {
     this.command = options.command ?? "codex";
+    this.model = options.model ?? null;
   }
 
   async start(cwd: string): Promise<void> {
@@ -58,6 +67,10 @@ export class CodexDriver implements SessionDriver {
       // context comes from the cwd (the workspace) and its AGENTS.md.
       "--ignore-user-config",
       "--ignore-rules",
+      // Re-inject the model that --ignore-user-config just discarded. `--model`
+      // is a CLI flag, so it survives both the ignore and the resume subcommand
+      // (unlike --color), and it points codex at a model the account supports.
+      ...(this.model ? ["--model", this.model] : []),
     ];
     // `--color` is valid on `codex exec` but the `resume` subcommand rejects it
     // (clap exits 2), so it stays off the resume path. Output is `--json`

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,5 +1,10 @@
 import { runAdapter } from "../shared/acp-agent.js";
 import { CodexDriver } from "./driver.js";
+import { readCodexModel } from "./config.js";
 
 // Entry point: acpx spawns `node <this> ...` and speaks ACP over stdio.
-runAdapter(new CodexDriver(), "codex-adapter");
+// We run codex with --ignore-user-config to stay lean, which also discards the
+// user's configured model, so read just that one setting back and pass it as
+// --model. Without it, codex defaults to a model unsupported on ChatGPT-account
+// logins and every turn dies with a 400.
+runAdapter(new CodexDriver({ model: readCodexModel() ?? undefined }), "codex-adapter");

--- a/tests/adapter-codex-config.test.ts
+++ b/tests/adapter-codex-config.test.ts
@@ -1,0 +1,53 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parseCodexModel, readCodexModel, codexHome } from "../src/adapters/codex/config";
+
+describe("parseCodexModel", () => {
+  it("reads a top-level double-quoted model", () => {
+    expect(parseCodexModel('model = "gpt-5.5"\n')).toBe("gpt-5.5");
+  });
+
+  it("reads a top-level single-quoted model", () => {
+    expect(parseCodexModel("model = 'gpt-5.5'\n")).toBe("gpt-5.5");
+  });
+
+  it("ignores commented-out model lines", () => {
+    expect(parseCodexModel('# model = "gpt-5.3-codex"\nmodel = "gpt-5.5"\n')).toBe("gpt-5.5");
+  });
+
+  it("ignores model keys nested inside a table (profiles, etc.)", () => {
+    // Only the top-level model applies; a model under [profiles.foo] is a
+    // different setting and must not be mistaken for the active default.
+    const toml = ['[profiles.fast]', 'model = "gpt-5.3-codex"', ""].join("\n");
+    expect(parseCodexModel(toml)).toBeNull();
+  });
+
+  it("returns null when no model key is present", () => {
+    expect(parseCodexModel('approval_policy = "never"\n')).toBeNull();
+  });
+});
+
+describe("readCodexModel", () => {
+  it("reads model from <home>/config.toml", async () => {
+    const home = await mkdtemp(join(tmpdir(), "codex-home-"));
+    await writeFile(join(home, "config.toml"), 'model = "gpt-5.5"\n');
+    expect(readCodexModel(home)).toBe("gpt-5.5");
+  });
+
+  it("returns null when config.toml is missing", async () => {
+    const home = await mkdtemp(join(tmpdir(), "codex-home-"));
+    expect(readCodexModel(home)).toBeNull();
+  });
+});
+
+describe("codexHome", () => {
+  it("honors CODEX_HOME when set", () => {
+    expect(codexHome({ CODEX_HOME: "/custom/codex" } as NodeJS.ProcessEnv)).toBe("/custom/codex");
+  });
+
+  it("falls back to ~/.codex when CODEX_HOME is unset", () => {
+    expect(codexHome({} as NodeJS.ProcessEnv).endsWith("/.codex")).toBe(true);
+  });
+});

--- a/tests/adapter-codex-driver.test.ts
+++ b/tests/adapter-codex-driver.test.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
 import { existsSync, watch } from "node:fs";
 import { describe, expect, it, afterEach } from "vitest";
 import { CodexDriver } from "../src/adapters/codex/driver";
@@ -85,6 +85,50 @@ describe("CodexDriver (against a fake codex CLI)", () => {
     expect(updates.find((u) => u.sessionUpdate === "agent_message_chunk")).toMatchObject({
       content: { type: "text", text: "resumed:second" },
     });
+  });
+
+  it("passes --model on both first and resume turns when a model is configured", async () => {
+    // Regression: --ignore-user-config strips ~/.codex/config.toml's `model`
+    // line, so codex falls back to a built-in default that is unsupported on
+    // ChatGPT-account logins (400 invalid_request_error). The driver must inject
+    // the configured model explicitly on every turn so codex talks to a model
+    // the account can actually use.
+    const dir = await mkdtemp(join(tmpdir(), "codex-args-"));
+    const argsFile = join(dir, "args.json");
+    process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+    try {
+      driver = new CodexDriver({ command: FAKE, model: "gpt-5.5" });
+      await driver.start(tmpdir());
+      const s = new AbortController().signal;
+      await driver.prompt("first", () => {}, s);
+      const firstArgs = JSON.parse(await readFile(argsFile, "utf8")) as string[];
+      expect(firstArgs).toContain("--model");
+      expect(firstArgs[firstArgs.indexOf("--model") + 1]).toBe("gpt-5.5");
+
+      await driver.prompt("second", () => {}, s);
+      const resumeArgs = JSON.parse(await readFile(argsFile, "utf8")) as string[];
+      expect(resumeArgs[0]).toBe("exec");
+      expect(resumeArgs[1]).toBe("resume");
+      expect(resumeArgs).toContain("--model");
+      expect(resumeArgs[resumeArgs.indexOf("--model") + 1]).toBe("gpt-5.5");
+    } finally {
+      delete process.env.FAKE_CODEX_ARGS_FILE;
+    }
+  });
+
+  it("omits --model when no model is configured", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "codex-args-"));
+    const argsFile = join(dir, "args.json");
+    process.env.FAKE_CODEX_ARGS_FILE = argsFile;
+    try {
+      const d = makeDriver();
+      await d.start(tmpdir());
+      await d.prompt("first", () => {}, new AbortController().signal);
+      const args = JSON.parse(await readFile(argsFile, "utf8")) as string[];
+      expect(args).not.toContain("--model");
+    } finally {
+      delete process.env.FAKE_CODEX_ARGS_FILE;
+    }
   });
 
   it("surfaces a command tool_call and tool_call_update", async () => {

--- a/tests/fixtures/fake-clis/fake-codex.mjs
+++ b/tests/fixtures/fake-clis/fake-codex.mjs
@@ -10,6 +10,11 @@ import { existsSync, writeFileSync } from "node:fs";
 const emit = (obj) => process.stdout.write(JSON.stringify(obj) + "\n");
 
 const argv = process.argv.slice(2);
+// Optional arg capture so driver tests can assert which flags were passed
+// (e.g. --model). Overwritten on every invocation, so the last turn wins.
+if (process.env.FAKE_CODEX_ARGS_FILE) {
+  writeFileSync(process.env.FAKE_CODEX_ARGS_FILE, JSON.stringify(argv));
+}
 const isResume = argv[0] === "exec" && argv[1] === "resume";
 // The prompt is the final positional arg.
 const prompt = argv[argv.length - 1] ?? "";


### PR DESCRIPTION
## Intent

The developer wanted to fix Baby Menu's embedded Codex adapter so it could use the same supported model as the user's normal terminal Codex while still ignoring the rest of the user's Codex configuration. They needed the adapter to preserve the intentional lean behavior from --ignore-user-config, especially avoiding inherited MCP servers and rules, but re-inject only the top-level model from CODEX_HOME or ~/.codex/config.toml. They wanted this implemented with TDD, including parser tests for config handling and driver tests proving --model is passed on both initial and resumed Codex exec calls and omitted when no model is configured. They also expected verification through targeted tests, typecheck, and the broader test suite, with awareness that real codex exec resume might reject --model even though the fake CLI test accepts it.

## What Changed
- Read the top-level Codex `model` from `CODEX_HOME` or `~/.codex/config.toml` while continuing to launch Codex with `--ignore-user-config`.
- Pass the configured model through to Codex adapter first-turn and resumed-turn `codex exec` calls, and omit `--model` when no model is configured.
- Added adapter config and driver coverage with a fake Codex CLI, plus documentation for the intentionally narrow model passthrough.

## Risk Assessment

✅ Low: The change is narrowly scoped to reading a single Codex config value and passing an advertised CLI flag, with targeted coverage for parsing and driver argument construction.

## Testing

Targeted parser and Codex driver tests passed, the generated evidence artifact shows lean ignore flags plus `--model gpt-5.5` on initial and resumed calls and no `--model` when unconfigured, the full Vitest suite passed, and no tracked files were modified; typecheck was not run because the prompt explicitly prohibited static-analysis tools.

<details>
<summary>Evidence: Codex adapter argument evidence</summary>

<code>Shows first turn args include `--ignore-user-config`, `--ignore-rules`, and `--model gpt-5.5`; resumed args use `exec resume` with `--model gpt-5.5` and no `--color`; no-model args omit `--model`.</code>

```text
{
  "purpose": "Demonstrate Codex adapter argument contract for configured model while keeping lean ignore flags",
  "firstTurn": {
    "args": [
      "exec",
      "--json",
      "--dangerously-bypass-approvals-and-sandbox",
      "--skip-git-repo-check",
      "--ignore-user-config",
      "--ignore-rules",
      "--model",
      "gpt-5.5",
      "--color",
      "never",
      "first"
    ],
    "reply": "echo:first"
  },
  "resumedTurn": {
    "args": [
      "exec",
      "resume",
      "fake-thread",
      "--json",
      "--dangerously-bypass-approvals-and-sandbox",
      "--skip-git-repo-check",
      "--ignore-user-config",
      "--ignore-rules",
      "--model",
      "gpt-5.5",
      "second"
    ],
    "reply": "resumed:second"
  },
  "noConfiguredModel": {
    "args": [
      "exec",
      "--json",
      "--dangerously-bypass-approvals-and-sandbox",
      "--skip-git-repo-check",
      "--ignore-user-config",
      "--ignore-rules",
      "--color",
      "never",
      "first"
    ],
    "hasModelFlag": false
  },
  "checks": {
    "firstHasIgnoreUserConfig": true,
    "firstHasIgnoreRules": true,
    "firstModel": "gpt-5.5",
    "resumeUsesSubcommand": "exec resume",
    "resumeHasModel": true,
    "resumeHasColor": false,
    "noModelHasModel": false
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm vitest run tests/adapter-codex-config.test.ts tests/adapter-codex-driver.test.ts`
- <code>Evidence step: `node --input-type=module -e ...` drove the fake Codex CLI through first-turn, resumed-turn, and no-model argument shapes and wrote `codex-adapter-args-evidence.json`</code>
- `pnpm test`
- <code>`git status --short` to confirm no tracked files were modified by verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
