### PR TITLE
docs: split README into focused docs/ guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,48 +44,15 @@ Click the tray icon, then ask for a widget in the composer such as:
 add a CPU usage widget that shows current load in %
 ```
 
-Baby Menu writes changes under `~/.baby-menu/extensions`, mounts updated widgets or layouts live, and shows Keep / Undo controls only when files actually changed.
-The Keep / Undo bar labels the actual workspace diff, such as `Added the cpu extension` or `Updated the layout`; use Keep to keep it, or Undo to throw it away.
-Extensions can keep local state in Baby Menu's shared SQLite store, contribute settings sections, and register background tasks for work that must continue while the popover is closed.
-The packaged app opens at login by default.
-Use the popover header to open settings, fully quit the app, or install an available update.
-Settings opens as an overlay so the menu, widgets, and composer keep their state while you configure the app.
-It lets you turn `launch at system start` off or back on, choose the embedded agent, add/edit/remove custom ACP agents, and see unavailable built-in agents with install hints.
-Switching agents resets the current conversation after confirmation.
+Baby Menu writes changes under `~/.baby-menu/extensions`, mounts updated widgets or layouts live, and shows a Keep / Undo bar only when files actually changed.
+The bar labels the real diff (`Added the cpu extension`, `Updated the layout`) so you can keep or throw away each turn.
+
+Open the popover header to reach Settings (an overlay that preserves your menu state), quit, or install an update.
+Settings lets you toggle launch-at-login, pick the embedded agent, and manage custom ACP agents.
 
 ## Install Details
 
-The packaged app stores mutable extensions, the local extension database, caches, agent sessions, custom agent catalog, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets and extension state.
-On launch, packaged Baby Menu refreshes bundled default extension files such as `AGENTS.md`, `babymenu-env.d.ts`, recipes, and starter extensions from the app template while preserving user-created extension directories.
-Packaged release builds send anonymous, best-effort usage telemetry to a self-hosted Umami instance.
-Telemetry records app startup, popover opens as `/popover` page views plus named events, agent turn outcomes, and agent switches; it does not include a user or device id, prompts, file contents, generated code, extension data, or local paths, and network failures are ignored.
-Set `BABY_MENU_TELEMETRY=0` in the launch environment to opt out.
-If an agent send fails, the composer notice surfaces the underlying failure message instead of only showing a generic unavailable hint.
-Baby Menu detects supported agents from the catalog in order: Claude Code (`claude`), then Codex (`codex`).
-Those built-ins run through bundled clean-room ACP adapters that drive the authenticated local CLIs without inheriting user-level agent settings, skills, MCP servers, or extra rules.
-The Codex adapter makes one exception: it reads only the top-level `model` from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` and passes it as `--model`, because the adapter otherwise runs Codex with `--ignore-user-config`.
-Use Settings to persist an agent choice across launches.
-Set `BABY_MENU_AGENT=<name>` in the launch environment to override auto-detection before a preference is saved.
-Add `~/.baby-menu/agents.json` to override or append catalog entries manually; source mode reads `agents.json` from the repo root.
-Each entry is an object with `name`, optional `label`, optional `command`, optional `installHint`, and optional `launchCommand`.
-Agents with `launchCommand` are registered as custom [`acpx`](https://github.com/openclaw/acpx) overrides and are shown as available.
-
-`launchCommand` is any Agent Client Protocol (ACP) server command - `acpx` (the ACP client Baby Menu runs agents through) supports a wide range of coding agents, so you can point an entry at the same command `acpx` uses for one of them.
-For example: `npx pi-acp` (Pi), `cursor-agent acp` (Cursor), `copilot --acp --stdio` (GitHub Copilot), `qwen --acp` (Qwen Code), or `npx -y opencode-ai acp` (OpenCode).
-The underlying CLI must be installed and authenticated.
-
-```json
-[
-  {
-    "name": "pi",
-    "label": "Pi",
-    "launchCommand": "npx pi-acp"
-  }
-]
-```
-
-You can also add, edit, and remove custom agents directly from Settings by entering an id, optional label, and ACP launch command.
-Settings-added agents are saved to the same `agents.json`, apply immediately, and are editable/removable; built-in Claude Code and Codex entries remain read-only.
+The packaged app stores extensions, the local database, caches, agent sessions, and preferences under `~/.baby-menu`, so upgrades preserve generated widgets and extension state.
 
 Update with Homebrew:
 
@@ -94,24 +61,9 @@ brew update
 brew upgrade --cask baby-menu
 ```
 
-When a newer GitHub Release is available, Baby Menu shows an update indicator in the popover header.
-The indicator opens a small dialog with the same Homebrew upgrade command and a link to the release notes.
-If Baby Menu is running during a Homebrew Cask upgrade, the cask quits the old app and relaunches the newly installed app after replacement.
-Fresh installs and upgrades while Baby Menu is closed do not launch the app automatically.
+When a newer release exists, Baby Menu shows an update indicator in the popover header.
 
-## From Source
-
-Use source mode when developing Baby Menu itself.
-End users should install the Homebrew Cask above.
-
-```sh
-git clone https://github.com/kunchenguid/baby-menu.git
-cd baby-menu
-pnpm install
-pnpm dev
-```
-
-Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
+For agent selection, custom ACP agents, telemetry, and environment flags, see [docs/configuration.md](docs/configuration.md).
 
 ## How It Works
 
@@ -145,101 +97,19 @@ Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
    └─────────────────────┘
 ```
 
-- **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem.
-  Everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
-- **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability, data sources, fallback behavior, and acceptance criteria.
-  The agent reads the matching recipe before implementing.
-- **Bundled ACP adapters** - the built-in Claude Code and Codex entries launch `out/adapters/<name>/index.mjs`, which wraps the local authenticated CLI and keeps Baby Menu's embedded agent isolated from user-level agent configuration.
-  Codex still reuses only the top-level configured model from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` so `--ignore-user-config` does not force an unsupported CLI default.
-  If a restart leaves behind a persisted ACP session that an adapter cannot resume, Baby Menu records the failed attempt, deletes that stale session record, and retries once with a fresh session.
-- **Live custom agent catalog** - Settings-owned custom ACP agents are persisted to `agents.json`, registered as `acpx` overrides immediately, and kept separate from read-only built-ins.
-- **Settings overlay** - Settings covers the default menu without unmounting it, so chat composer, widget, and run state survive opening and closing Settings.
-- **Release update indicator** - the main process checks the latest GitHub Release at most every four hours, keeps failures silent, and shows a header indicator with `brew update && brew upgrade --cask baby-menu` only when a newer packaged release exists.
-  Source/dev mode simulates an available update so the UI can be exercised locally.
-  The released Homebrew Cask relaunches Baby Menu after an upgrade only when the old app was running before uninstall started.
-- **Custom popover layouts** - an extension workspace may include a root `layout.tsx` default export that receives active widgets and `renderWidget(id)`, arranges the popover canvas, and lets the window adapt to both the canvas width plus host chrome and the rendered height.
-  Workspaces without `layout.tsx` keep the built-in stacked column.
-- **Extension settings sections** - extensions may export `BabyMenuSettingsSection` from `widget.tsx`; the Settings page discovers those renderer-only sections through the same module pipeline as widgets and renders the host-owned frame around each body.
-- **Extension server actions** - privileged work (shell, network, credentials) lives in `<extension-id>/server.ts` and is invoked from widgets and settings sections via `window.babyMenu.capabilities.invoke(extensionId, action, input)`.
-  No per-widget IPC channels.
-  Baby Menu keeps an unchanged `server.ts` module instance alive across invokes and background ticks, so module-scope values are only an ephemeral cache and reset after code edits or app restarts.
-- **Local extension storage** - extensions share a local SQLite store exposed as `context.db` in server actions and background tasks, and as `window.babyMenu.db` in widgets and settings sections.
-  Use this store for settings, history, rate baselines, and anything else that must survive reloads.
-- **Background tasks vs view refresh** - `refreshView` / `viewRefreshIntervalMs` keeps a visible widget current and pauses while the popover is hidden; `export const background` in `server.ts` runs on a host-owned timer, clamped to a 60-second minimum, for work that must continue while the popover is closed.
-- **Runtime-specific extension roots** - `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with internal snapshot save/rollback.
-  Tracked `extensions/` remain the source templates for dev and packaged extension workspaces, including the generated `@babymenu/contracts` declaration in `extensions/babymenu-env.d.ts`.
-- **Diff-derived change prompts** - the Keep / Undo bar is driven by the actual git or snapshot diff, not by agent wording.
-  It names created, updated, or removed extensions, reports root `layout.tsx` edits as layout changes, and clears the pending session automatically when the agent made no on-disk change.
-- **Stable extension contracts** - extension code imports public host types with type-only `import ... from "@babymenu/contracts"`; the generated declaration is shipped into each extension workspace so extensions never need to reach back into `src/shared/contracts.ts`.
-- **Anonymous telemetry** - packaged release builds fire best-effort Umami events for app start, popover open, agent turn status (`success`, `error`, `timeout`, or `blocked_dirty`), and agent switching, and also record each popover open as the `/popover` page view.
-  Built-in agent names are reported as `claude` or `codex`; custom agent names are reported only as `custom`.
+- **Three processes, one bridge** - the renderer never touches git, the agent, or the filesystem; everything goes through `window.babyMenu`.
+- **Recipes are specs, not prompts** - HTML files under `extensions/recipes/` describe a widget's capability and data sources; the agent reads the matching recipe before implementing.
+- **Bundled ACP adapters** - built-in Claude Code and Codex run through clean-room adapters isolated from user-level agent configuration.
+- **Diff-derived Keep / Undo** - the change bar reflects the actual git or snapshot diff, not agent wording, and clears itself when nothing changed on disk.
+- **Extensions own their capabilities** - widgets, layouts, settings sections, server actions, background tasks, and a shared SQLite store, all behind the stable bridge.
 
-## Layout
+For the full design notes and repository layout, see [docs/architecture.md](docs/architecture.md).
 
-| Path                        | What lives here                                                                        |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| `src/adapters/`             | Bundled clean-room ACP adapters for built-in Claude Code and Codex agents              |
-| `src/main/`                 | Electron lifecycle, tray, popover, IPC, git, agent runtime, update checks              |
-| `src/preload/index.ts`      | The stable `window.babyMenu` bridge                                                    |
-| `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, custom layouts, settings, updates, app controls   |
-| `src/ui/`                   | Shared `@babymenu/ui` design system for shell and extension renderer surfaces          |
-| `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `BabyMenuSettingsSection`, `GitSessionSnapshot`, etc. |
-| `src/shared/extension-contract-names.ts` | Public type names exported through `@babymenu/contracts`                  |
-| `extensions/babymenu-env.d.ts` | Generated `@babymenu/contracts` declarations copied into extension workspaces       |
-| `extensions/layout.tsx`     | Optional root popover layout component for arranging active widgets                     |
-| `extensions/<id>/`          | Tracked extensions (`widget.tsx` descriptors, `components.tsx` views, `server.ts`)      |
-| `extensions/recipes/*.html` | Self-contained widget specs the agent reads                                            |
-| `extensions-dev/`           | Gitignored dev workspace prepared by `scripts/dev.mjs`                                 |
-| `marketing-video/`          | HyperFrames source plus committed MP4/GIF assets for the README hero video             |
-| `~/.baby-menu/extensions/`  | Packaged app extension workspace                                                       |
-| `~/.baby-menu/baby-menu.db` | Packaged app's shared local SQLite store for extensions                                |
-| `~/.baby-menu/cache/`       | Packaged widget, server-action, snapshot, and agent caches                             |
-| `tests/`                    | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)                                     |
+## Docs
 
-## Environment Flags
-
-| Var                               | Effect                                                                                                                                                                                                            |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BABY_MENU_KEEP_POPOVER_OPEN=1`   | Disables blur-to-hide so devtools / external windows stay up                                                                                                                                                      |
-| `BABY_MENU_AGENT=<name>`          | Overrides agent auto-detection when no saved Settings choice exists                                                                                                                                               |
-| `BABY_MENU_AGENT_TIMEOUT_MS=<ms>` | Overrides the embedded-agent request timeout                                                                                                                                                                      |
-| `BABY_MENU_EXTENSIONS_DIR=<dir>`  | Overrides the active extension workspace in source/dev runs. Dev Tailwind scans only `extensions/` and `extensions-dev/`, so overrides outside those paths need matching `@source` coverage for widget utilities. |
-| `CODEX_HOME=<dir>`                | When Codex is the selected built-in agent, points the adapter at `<dir>/config.toml` for the top-level `model`; other Codex user config is still ignored.                                                         |
-| `BABY_MENU_TELEMETRY=0`           | Disables packaged-release telemetry; `false` and `off` are also accepted                                                                                                                                          |
-| `BABY_MENU_UMAMI_HOST=<url>`      | Overrides the self-hosted Umami endpoint used by telemetry. Source/dev/test builds are no-op unless a website id is also configured.                                                                               |
-| `BABY_MENU_UMAMI_WEBSITE_ID=<id>` | Overrides or supplies the Umami website id used by telemetry. The release workflow reads this from the GitHub Actions `vars.*` context, not a secret.                                                             |
-
-## Development
-
-```sh
-pnpm dev          # run Electron + renderer dev server with a gitignored extensions-dev/ sandbox
-pnpm dev:reset    # wipe extensions-dev/ and agent session cache, then start fresh
-pnpm build        # build main + preload + renderer + bundled adapters into out/
-pnpm generate:contracts # regenerate extensions/babymenu-env.d.ts from src/shared/contracts.ts
-pnpm package:mac  # clean release/ and create an ad-hoc-signed Baby Menu Dev.app
-pnpm dist:mac     # build Baby Menu Dev.app and create a universal DMG in release/
-pnpm test         # run all Vitest tests
-pnpm test:e2e     # only e2e tests (including acpx/runtime plus bundled adapter coverage)
-pnpm typecheck    # tsc --noEmit
-pnpm lint         # tsc --noEmit (same as typecheck)
-```
-
-Use `pnpm dev` for source iteration in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
-Use `pnpm dev:reset` when recipe or extension guidance changes; it also clears `.cache/baby-menu/acp-sessions` so the embedded agent re-reads the fresh copied specs instead of continuing from prior conversation state.
-Run `pnpm generate:contracts` after changing extension-facing types in `src/shared/contracts.ts` or the public name list in `src/shared/extension-contract-names.ts`; CI fails if the committed `extensions/babymenu-env.d.ts` is stale.
-Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
-Use `pnpm package:mac` when you want to test the actual packaged app from `release/mac-universal/Baby Menu Dev.app`.
-Local packaging uses the `Baby Menu Dev` product name and `com.kunchenguid.baby-menu.dev` bundle id so local builds do not shadow the released `/Applications/Baby Menu.app` in macOS LaunchServices.
-The universal package is expected to run on both Intel and Apple Silicon Macs, so macOS native prebuilt dependencies must stay installed for `x64` and `arm64` and must stay covered by `electron-builder.yml` `x64ArchFiles` when new native packages are added.
-Keep `electron-builder` at `26.8.2` or newer so pnpm-deduped dependencies are included correctly in packaged builds.
-
-The README hero animation is committed from `marketing-video/baby-menu-marketing-square.gif`.
-Use the HyperFrames project in `marketing-video/` when revising that asset: `pnpm --dir marketing-video check` validates the composition, and `pnpm --dir marketing-video render` renders the MP4 before regenerating the 960x960 GIF.
-
-Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.
-
-TDD is required for bug fixes and new features.
-Tests live in `tests/` at the repo root, not co-located.
+- [docs/configuration.md](docs/configuration.md) - agent selection, custom ACP agents, telemetry, environment flags
+- [docs/architecture.md](docs/architecture.md) - runtime design notes and repository layout
+- [docs/development.md](docs/development.md) - building, testing, and packaging Baby Menu itself
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+How Baby Menu fits together at runtime.
+For the at-a-glance picture, see the "How It Works" diagram in the [README](../README.md#how-it-works).
+
+## Process model
+
+- **Three processes, one bridge.**
+  The renderer never touches git, the agent, or the filesystem - everything goes through `window.babyMenu` exposed in `src/preload/index.ts`.
+- **Settings overlay.**
+  Settings covers the menu without unmounting it, so composer, widget, and run state survive opening and closing it.
+
+## Extensions
+
+| Concept | What it is |
+| --- | --- |
+| Recipes | HTML specs under `extensions/recipes/` describing a widget's capability, data sources, fallbacks, and acceptance criteria. The agent reads the matching recipe before implementing. |
+| Custom layouts | An optional root `layout.tsx` arranges the popover canvas. Without it, widgets stack in a column. |
+| Settings sections | Extensions export `BabyMenuSettingsSection` from `widget.tsx`; the host frames each body. |
+| Server actions | Privileged work (shell, network, credentials) lives in `<extension-id>/server.ts`, called via `window.babyMenu.capabilities.invoke(...)`. No per-widget IPC. |
+| Local storage | A shared SQLite store: `context.db` server-side, `window.babyMenu.db` in the renderer. Use it for anything that must survive reloads. |
+| Stable contracts | Extensions import host types with type-only `import ... from "@babymenu/contracts"`, shipped into each workspace. |
+
+**Background vs view refresh.**
+`refreshView` / `viewRefreshIntervalMs` keeps a visible widget current and pauses while the popover is hidden.
+`export const background` in `server.ts` runs on a host-owned timer (60-second minimum) for work that must continue while the popover is closed.
+
+**Module lifetime.**
+An unchanged `server.ts` module instance stays alive across invokes and background ticks, so module-scope values are only an ephemeral cache - they reset on code edits or app restarts.
+
+## Agent runtime
+
+- **Bundled ACP adapters.**
+  Built-in Claude Code and Codex launch `out/adapters/<name>/index.mjs`, wrapping the local authenticated CLI in isolation from user-level agent config.
+  Codex still reuses only the top-level `model` from `$CODEX_HOME/config.toml` (or `~/.codex/config.toml`) so `--ignore-user-config` does not force an unsupported default.
+- **Stale session recovery.**
+  If a restart leaves a persisted ACP session an adapter cannot resume, Baby Menu records the failed attempt, deletes the stale record, and retries once with a fresh session.
+- **Live custom agent catalog.**
+  Settings-owned custom ACP agents persist to `agents.json` and register as `acpx` overrides immediately, kept separate from read-only built-ins.
+
+## Change tracking
+
+- **Runtime-specific roots.**
+  `pnpm dev` edits gitignored `extensions-dev/`; packaged builds seed and edit `~/.baby-menu/extensions` with snapshot save/rollback.
+  Tracked `extensions/` stay the source templates, including the generated `@babymenu/contracts` declaration.
+- **Diff-derived Keep / Undo.**
+  The bar reflects the actual git or snapshot diff, not agent wording - it names created, updated, or removed extensions, reports `layout.tsx` edits as layout changes, and clears itself when nothing changed on disk.
+
+## Updates and telemetry
+
+- **Release indicator.**
+  The main process checks the latest GitHub Release at most every four hours, stays silent on failure, and shows the upgrade command only when a newer release exists.
+  The Homebrew Cask relaunches Baby Menu after an upgrade only when it was already running.
+- **Anonymous telemetry.**
+  Packaged builds fire best-effort Umami events for app start, popover open (also a `/popover` page view), agent turn status, and agent switches.
+  Built-in agents report as `claude` or `codex`; custom agents report only as `custom`.
+
+## Repository layout
+
+| Path                        | What lives here                                                                        |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `src/adapters/`             | Bundled clean-room ACP adapters for built-in Claude Code and Codex agents              |
+| `src/main/`                 | Electron lifecycle, tray, popover, IPC, git, agent runtime, update checks              |
+| `src/preload/index.ts`      | The stable `window.babyMenu` bridge                                                    |
+| `src/renderer/`             | React UI: `AgentChat`, `WidgetHost`, custom layouts, settings, updates, app controls   |
+| `src/ui/`                   | Shared `@babymenu/ui` design system for shell and extension renderer surfaces          |
+| `src/shared/contracts.ts`   | `BabyMenuApi`, `BabyMenuWidget`, `BabyMenuSettingsSection`, `GitSessionSnapshot`, etc. |
+| `src/shared/extension-contract-names.ts` | Public type names exported through `@babymenu/contracts`                  |
+| `extensions/babymenu-env.d.ts` | Generated `@babymenu/contracts` declarations copied into extension workspaces       |
+| `extensions/layout.tsx`     | Optional root popover layout component for arranging active widgets                     |
+| `extensions/<id>/`          | Tracked extensions (`widget.tsx` descriptors, `components.tsx` views, `server.ts`)      |
+| `extensions/recipes/*.html` | Self-contained widget specs the agent reads                                            |
+| `extensions-dev/`           | Gitignored dev workspace prepared by `scripts/dev.mjs`                                 |
+| `marketing-video/`          | HyperFrames source plus committed MP4/GIF assets for the README hero video             |
+| `~/.baby-menu/extensions/`  | Packaged app extension workspace                                                       |
+| `~/.baby-menu/baby-menu.db` | Packaged app's shared local SQLite store for extensions                                |
+| `~/.baby-menu/cache/`       | Packaged widget, server-action, snapshot, and agent caches                             |
+| `tests/`                    | Vitest tests (e2e specs are `tests/e2e-*.test.ts`)                                     |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,94 @@
+# Configuration
+
+How a running Baby Menu install stores state, picks an agent, and can be tuned.
+
+## Where state lives
+
+The packaged app keeps everything mutable under `~/.baby-menu`: extensions, the local SQLite database, caches, agent sessions, the custom agent catalog, and preferences.
+Upgrades preserve this directory, so generated widgets and extension state survive.
+
+On launch, packaged Baby Menu refreshes bundled defaults (`AGENTS.md`, `babymenu-env.d.ts`, recipes, starter extensions) from the app template while leaving your own extension directories untouched.
+
+## Choosing an agent
+
+Baby Menu detects supported agents in order: Claude Code (`claude`), then Codex (`codex`).
+Both run through bundled clean-room ACP adapters that drive the authenticated local CLI without inheriting user-level settings, skills, MCP servers, or extra rules.
+
+| Mechanism | Effect |
+| --- | --- |
+| Settings | Persist an agent choice across launches; add, edit, or remove custom agents. |
+| `BABY_MENU_AGENT=<name>` | Override auto-detection before a preference is saved. |
+| `agents.json` | Override or append catalog entries manually. |
+
+If a send fails, the composer surfaces the underlying error message rather than a generic unavailable hint.
+
+### Codex model exception
+
+The Codex adapter reads only the top-level `model` from `$CODEX_HOME/config.toml` or `~/.codex/config.toml` and passes it as `--model`, because it otherwise runs Codex with `--ignore-user-config`.
+
+## Custom ACP agents
+
+Add agents from Settings (id, optional label, ACP launch command) or by editing `agents.json` directly.
+Packaged mode reads `~/.baby-menu/agents.json`; source mode reads `agents.json` at the repo root.
+Settings-added agents are editable and removable; built-in Claude Code and Codex stay read-only.
+
+Each entry is an object with `name`, optional `label`, `command`, `installHint`, and `launchCommand`.
+Entries with `launchCommand` register as custom [`acpx`](https://github.com/openclaw/acpx) overrides and show as available.
+
+```json
+[
+  {
+    "name": "pi",
+    "label": "Pi",
+    "launchCommand": "npx pi-acp"
+  }
+]
+```
+
+`launchCommand` is any Agent Client Protocol (ACP) server command.
+The underlying CLI must be installed and authenticated.
+Examples:
+
+| Agent | `launchCommand` |
+| --- | --- |
+| Pi | `npx pi-acp` |
+| Cursor | `cursor-agent acp` |
+| GitHub Copilot | `copilot --acp --stdio` |
+| Qwen Code | `qwen --acp` |
+| OpenCode | `npx -y opencode-ai acp` |
+
+## Updates
+
+Update with Homebrew:
+
+```sh
+brew update
+brew upgrade --cask baby-menu
+```
+
+When a newer GitHub Release exists, Baby Menu shows an indicator in the popover header that opens a dialog with the same command and a link to the release notes.
+If Baby Menu is running during a Cask upgrade, the cask quits the old app and relaunches the new one after replacement.
+Fresh installs and upgrades while Baby Menu is closed do not launch the app automatically.
+
+## Telemetry
+
+Packaged release builds send anonymous, best-effort usage telemetry to a self-hosted Umami instance.
+
+- **Records:** app startup, popover opens (`/popover` page views plus named events), agent turn outcomes, agent switches.
+- **Never includes:** user/device id, prompts, file contents, generated code, extension data, or local paths.
+- Network failures are ignored.
+
+Set `BABY_MENU_TELEMETRY=0` in the launch environment to opt out.
+
+## Environment flags
+
+| Var                               | Effect                                                                                                                                                                                                            |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BABY_MENU_KEEP_POPOVER_OPEN=1`   | Disables blur-to-hide so devtools / external windows stay up                                                                                                                                                      |
+| `BABY_MENU_AGENT=<name>`          | Overrides agent auto-detection when no saved Settings choice exists                                                                                                                                               |
+| `BABY_MENU_AGENT_TIMEOUT_MS=<ms>` | Overrides the embedded-agent request timeout                                                                                                                                                                      |
+| `BABY_MENU_EXTENSIONS_DIR=<dir>`  | Overrides the active extension workspace in source/dev runs. Dev Tailwind scans only `extensions/` and `extensions-dev/`, so overrides outside those paths need matching `@source` coverage for widget utilities. |
+| `CODEX_HOME=<dir>`                | When Codex is the selected built-in agent, points the adapter at `<dir>/config.toml` for the top-level `model`; other Codex user config is still ignored.                                                         |
+| `BABY_MENU_TELEMETRY=0`           | Disables packaged-release telemetry; `false` and `off` are also accepted                                                                                                                                          |
+| `BABY_MENU_UMAMI_HOST=<url>`      | Overrides the self-hosted Umami endpoint used by telemetry. Source/dev/test builds are no-op unless a website id is also configured.                                                                               |
+| `BABY_MENU_UMAMI_WEBSITE_ID=<id>` | Overrides or supplies the Umami website id used by telemetry. The release workflow reads this from the GitHub Actions `vars.*` context, not a secret.                                                             |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,61 @@
+# Development
+
+Working on Baby Menu itself.
+End users should install the Homebrew Cask (see the [README](../README.md#quick-start)).
+
+## Setup
+
+```sh
+git clone https://github.com/kunchenguid/baby-menu.git
+cd baby-menu
+pnpm install
+pnpm dev
+```
+
+Requires Node `>=22.12` and `pnpm@11.1.1` (declared in `packageManager`).
+
+## Commands
+
+| Command | What it does |
+| --- | --- |
+| `pnpm dev` | Electron + renderer dev server with a gitignored `extensions-dev/` sandbox |
+| `pnpm dev:reset` | Wipe `extensions-dev/` and the agent session cache, then start fresh |
+| `pnpm build` | Build main + preload + renderer + bundled adapters into `out/` |
+| `pnpm generate:contracts` | Regenerate `extensions/babymenu-env.d.ts` from `src/shared/contracts.ts` |
+| `pnpm package:mac` | Clean `release/` and create an ad-hoc-signed `Baby Menu Dev.app` |
+| `pnpm dist:mac` | Build `Baby Menu Dev.app` and create a universal DMG in `release/` |
+| `pnpm test` | Run all Vitest tests |
+| `pnpm test:e2e` | Only e2e tests (including `acpx/runtime` plus bundled adapter coverage) |
+| `pnpm typecheck` | `tsc --noEmit` |
+| `pnpm lint` | `tsc --noEmit` (same as typecheck) |
+
+Single test: `pnpm vitest run tests/<name>.test.ts` or `pnpm vitest run -t "<pattern>"`.
+
+## Dev workflow
+
+- `pnpm dev` iterates in a throwaway sandbox - the agent edits the gitignored `extensions-dev/` copy and your tracked tree stays clean.
+- `pnpm dev:reset` when recipe or extension guidance changes; it also clears `.cache/baby-menu/acp-sessions` so the agent re-reads fresh specs instead of continuing prior conversation state.
+- `pnpm generate:contracts` after changing extension-facing types in `src/shared/contracts.ts` or the public name list in `src/shared/extension-contract-names.ts`; CI fails if the committed `extensions/babymenu-env.d.ts` is stale.
+- Source/dev mode never touches macOS login items, including Electron's `setLoginItemSettings` API.
+
+## Packaging
+
+- `pnpm package:mac` tests the actual packaged app from `release/mac-universal/Baby Menu Dev.app`.
+- Local packaging uses the `Baby Menu Dev` product name and `com.kunchenguid.baby-menu.dev` bundle id so local builds do not shadow the released `/Applications/Baby Menu.app` in macOS LaunchServices.
+- The universal package must run on both Intel and Apple Silicon Macs, so macOS native prebuilt dependencies must stay installed for `x64` and `arm64` and stay covered by `electron-builder.yml` `x64ArchFiles` when new native packages are added.
+- Keep `electron-builder` at `26.8.2` or newer so pnpm-deduped dependencies are included correctly in packaged builds.
+
+## Hero video
+
+The README hero animation is committed from `marketing-video/baby-menu-marketing-square.gif`.
+Use the HyperFrames project in `marketing-video/` to revise it:
+
+```sh
+pnpm --dir marketing-video check    # validate the composition
+pnpm --dir marketing-video render   # render the MP4 before regenerating the 960x960 GIF
+```
+
+## Conventions
+
+- TDD is required for bug fixes and new features.
+- Tests live in `tests/` at the repo root, not co-located.


### PR DESCRIPTION
## Intent

The developer wanted to slim down their project README, which had grown to roughly 247 lines with several long walls of reference text that distracted from its role as a landing page. They asked the agent to propose how to extract detailed sections into separate files, then approved a plan to move install/configuration details, the architecture deep-dive bullets, the layout table, environment flags, and development/packaging notes into three new docs under the existing docs/ directory. They explicitly decided to keep the ASCII architecture diagram in the README and confirmed that docs/ was the right home for the extracted content. The goal was to reduce the README to a concise landing page linking to the reference docs without losing any information, restructuring the relocated content into scannable subsections and tables rather than just copying the prose.

## What Changed

- Trimmed `README.md` from a long reference document down to a concise landing page, keeping the ASCII architecture diagram and Quick Start while linking out to the new reference docs.
- Extracted the relocated content into three new files under `docs/`: `architecture.md` (deep-dive bullets, repository layout table), `configuration.md` (environment flags table and config details), and `development.md` (build/packaging notes).
- Restructured the moved prose into scannable subsections and tables rather than copying it verbatim; the environment-flags and repository-layout tables were preserved in full.

## Risk Assessment

✅ Low: A documentation-only refactor that relocates README content into three new docs/ guides with all cross-reference links and anchors verified to resolve and no information lost.

## Testing

This is a docs-only restructure, so I demonstrated intent by rendering the actual reader-facing surface rather than relying on unit tests. I rendered README.md and the three new docs/ guides to GitHub-faithful HTML and captured full-page screenshots: the README is now a concise landing page that retains the ASCII \"How It Works\" diagram and adds a Docs section linking the guides, while configuration/architecture/development render with the new scannable tables and subsections. I confirmed all cross-links resolve, the two large reference tables (env flags, repository layout) are byte-for-byte preserved, and a spread of distinctive facts survived the move; the single README-mirroring test passes. Two minor details (the telemetry status enum values and the \"opens at login by default\" note) did not carry over - reported as informational since they're author judgment calls, not failures.

- Evidence: README rendered as concise landing page (hero, Quick Start, kept ASCII diagram, new Docs links) (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KT5XSPDH2QFKD6H9HVBABJ42/readme-rendered.png</code>)
- Evidence: docs/configuration.md rendered (agent table, ACP launch-command table, telemetry, full env-flags table) (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KT5XSPDH2QFKD6H9HVBABJ42/configuration-rendered.png</code>)
- Evidence: docs/architecture.md rendered (extensions table, grouped subsections, preserved repository-layout table) (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KT5XSPDH2QFKD6H9HVBABJ42/architecture-rendered.png</code>)
- Evidence: docs/development.md rendered (Setup, commands table, Packaging, Hero video, Conventions) (local file: <code>/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KT5XSPDH2QFKD6H9HVBABJ42/development-rendered.png</code>)
<details>
<summary>Evidence: Link + table-preservation checks</summary>

```text
README->docs links: configuration.md, architecture.md, development.md all exist
docs->README anchors: #how-it-works (## How It Works), #quick-start (## Quick Start) both exist
ALL ENV VARS PRESERVED (9 vars diff clean)
ALL LAYOUT PATHS PRESERVED (repository-layout table diff clean)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (4m4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `docs/architecture.md:55` - Two small facts from the original README were not carried into the split docs. (1) The agent-turn telemetry status enum `success`, `error`, `timeout`, `blocked_dirty` is now summarized as just &#34;agent turn status&#34;/&#34;agent turn outcomes&#34; in docs/architecture.md and docs/configuration.md - the specific values are gone. (2) The original Quick Start stated &#34;The packaged app opens at login by default&#34;; the new README only says Settings &#34;lets you toggle launch-at-login&#34;, dropping the default-on detail. Both are minor and may be intentional summarization, but they&#39;re worth a glance given the explicit &#34;without losing any information&#34; goal.
- <code>Rendered README.md + docs/{configuration,architecture,development}.md to GitHub-faithful HTML via `gh api -X POST /markdown` and captured full-page screenshots with chrome-devtools-axi</code>
- <code>Verified README-&gt;docs links target existing files and docs-&gt;README anchors (`#how-it-works`, `#quick-start`) exist</code>
- `Diffed env-flags vars and repository-layout paths between old README and new docs - both tables fully preserved`
- `Checked distinctive facts (every-four-hours update check, 60-second background min, electron-builder 26.8.2, x64ArchFiles, Node >=22.12, Codex --ignore-user-config) survived the move`
- `pnpm vitest run tests/agent-catalog.test.ts -t "documented custom agent example"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
