### PR TITLE
fix(main): survive a non-directory extension workspace on startup

### DIFF
--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -154,7 +154,15 @@ export async function startBabyMenuApp(): Promise<void> {
 
   const sourceRoot = getRepoRoot();
   const paths = resolveBabyMenuRuntimePaths(sourceRoot);
-  await seedExtensionWorkspace({ extensionsDir: paths.extensionsDir, templateDir: paths.bundledExtensionTemplateDir });
+  // Seeding the bundled defaults is best-effort: it touches a user-owned
+  // workspace that can be a read-only or managed (home-manager / Nix) symlink,
+  // and the embedded agent self-heals it later anyway. A failure here must never
+  // prevent the tray from appearing, so it is contained rather than fatal.
+  try {
+    await seedExtensionWorkspace({ extensionsDir: paths.extensionsDir, templateDir: paths.bundledExtensionTemplateDir });
+  } catch (error) {
+    console.error("[baby-menu] extension workspace seeding failed; continuing startup", error);
+  }
   registerBabyMenuProtocolHandlers({ widgetCacheDir: paths.widgetCacheDir });
 
   if (process.platform === "darwin") {
@@ -314,5 +322,9 @@ export async function startBabyMenuApp(): Promise<void> {
 }
 
 if (!process.env.VITEST) {
-  void startBabyMenuApp();
+  // Last-resort guard: an unhandled rejection here would otherwise leave a dead
+  // app with a lingering dock icon and no tray, with no diagnostic in the logs.
+  startBabyMenuApp().catch((error) => {
+    console.error("[baby-menu] fatal startup error", error);
+  });
 }

--- a/src/main/extension-seeder.ts
+++ b/src/main/extension-seeder.ts
@@ -1,4 +1,5 @@
-import { cp, mkdir, stat } from "node:fs/promises";
+import { cp, lstat, mkdir, stat } from "node:fs/promises";
+import type { Stats } from "node:fs";
 
 export type SeedExtensionWorkspaceOptions = {
   extensionsDir: string;
@@ -9,14 +10,59 @@ export async function seedExtensionWorkspace(options: SeedExtensionWorkspaceOpti
   if (!options.templateDir) return false;
   if (!(await pathExists(options.templateDir))) return false;
 
-  await mkdir(options.extensionsDir, { recursive: true });
-  // Self-heal the bundled defaults: every file the template ships (AGENTS.md,
-  // babymenu-env.d.ts, recipes, starter extensions) is force-copied so a stale
-  // or edited managed file is restored on launch. cp only writes paths present
-  // in the template, so user-created extensions the template does not ship are
-  // left untouched and are never deleted.
-  await cp(options.templateDir, options.extensionsDir, { recursive: true, force: true });
-  return true;
+  // The workspace must be a real directory baby-menu owns and can write to: the
+  // seeder force-copies bundled defaults here on every launch and the embedded
+  // agent edits it at runtime. If the path already exists as a symlink or any
+  // other non-directory (e.g. a read-only home-manager / Nix-store managed
+  // symlink), fs.cp throws ERR_FS_CP_DIR_TO_NON_DIR. Seeding is best-effort and
+  // must never abort app startup, so skip with a clear warning instead of
+  // throwing, and never clobber a user-owned node.
+  const existing = await lstatOrNull(options.extensionsDir);
+  if (existing && !existing.isDirectory()) {
+    console.warn(
+      `[baby-menu] Skipping extension workspace seeding: ${options.extensionsDir} is ${describeNode(existing)}, ` +
+        `not a writable directory. Baby Menu must own this path; if it is a managed symlink ` +
+        `(e.g. home-manager / Nix), remove that management so Baby Menu can create a real directory.`,
+    );
+    return false;
+  }
+
+  try {
+    await mkdir(options.extensionsDir, { recursive: true });
+    // Self-heal the bundled defaults: every file the template ships (AGENTS.md,
+    // babymenu-env.d.ts, recipes, starter extensions) is force-copied so a stale
+    // or edited managed file is restored on launch. cp only writes paths present
+    // in the template, so user-created extensions the template does not ship are
+    // left untouched and are never deleted.
+    await cp(options.templateDir, options.extensionsDir, { recursive: true, force: true });
+    return true;
+  } catch (error) {
+    // A failed seed (permissions, read-only volume, race) must not prevent the
+    // app from launching its tray. Log and continue with whatever workspace
+    // contents already exist.
+    console.warn(
+      `[baby-menu] Failed to seed extension workspace at ${options.extensionsDir}; continuing with existing contents: ${describeError(error)}`,
+    );
+    return false;
+  }
+}
+
+function describeNode(stats: Stats): string {
+  if (stats.isSymbolicLink()) return "a symlink";
+  if (stats.isFile()) return "a file";
+  return "a non-directory";
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function lstatOrNull(filePath: string): Promise<Stats | null> {
+  try {
+    return await lstat(filePath);
+  } catch {
+    return null;
+  }
 }
 
 async function pathExists(filePath: string): Promise<boolean> {

--- a/tests/app-lifecycle.test.ts
+++ b/tests/app-lifecycle.test.ts
@@ -171,6 +171,19 @@ describe("startBabyMenuApp", () => {
     expect(appModule.getActiveBabyMenuTray?.()).toBe(trayInstance);
   });
 
+  it("still creates the tray when extension workspace seeding fails", async () => {
+    const { seedExtensionWorkspace } = await import("../src/main/extension-seeder");
+    (seedExtensionWorkspace as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("EISDIR: symlinked workspace"));
+    const appModule = await import("../src/main/app");
+
+    await expect(appModule.startBabyMenuApp()).resolves.toBeUndefined();
+
+    expect(createBabyMenuTray).toHaveBeenCalledWith(expect.any(Function), {
+      iconPath: "/repo/assets/tray/baby_menuTemplate.png",
+    });
+    expect(appModule.getActiveBabyMenuTray()).toBe(trayInstance);
+  });
+
   it("creates the popover with the CommonJS preload bridge", async () => {
     const appModule = await import("../src/main/app");
 

--- a/tests/extension-seeder.test.ts
+++ b/tests/extension-seeder.test.ts
@@ -1,0 +1,89 @@
+import { chmod, lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { seedExtensionWorkspace } from "../src/main/extension-seeder";
+
+describe("seedExtensionWorkspace", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    const { rm } = await import("node:fs/promises");
+    // Restore perms first so read-only-target test dirs can be removed.
+    await Promise.all(
+      tempDirs.splice(0).map(async (dir) => {
+        await chmod(dir, 0o755).catch(() => undefined);
+        await rm(dir, { recursive: true, force: true });
+      }),
+    );
+  });
+
+  async function makeTemplate(): Promise<string> {
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-seeder-"));
+    tempDirs.push(rootDir);
+    const templateDir = join(rootDir, "template");
+    await mkdir(join(templateDir, "recipes"), { recursive: true });
+    await writeFile(join(templateDir, "AGENTS.md"), "template rules\n");
+    await writeFile(join(templateDir, "recipes", "starter.html"), "<title>Starter</title>\n");
+    return templateDir;
+  }
+
+  it("returns false when no template is configured", async () => {
+    await expect(seedExtensionWorkspace({ extensionsDir: "/anything", templateDir: null })).resolves.toBe(false);
+  });
+
+  it("force-copies the template into a real workspace directory", async () => {
+    const templateDir = await makeTemplate();
+    const extensionsDir = join(templateDir, "..", "extensions");
+
+    const seeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(seeded).toBe(true);
+    await expect(readFile(join(extensionsDir, "AGENTS.md"), "utf8")).resolves.toBe("template rules\n");
+  });
+
+  it("skips seeding without throwing when the workspace path is a symlink", async () => {
+    // Reproduces a home-manager / Nix-store managed workspace: ~/.baby-menu/extensions
+    // is a symlink into a read-only store. fs.cp would throw ERR_FS_CP_DIR_TO_NON_DIR
+    // and abort app startup before the tray is ever created.
+    const templateDir = await makeTemplate();
+    const linkTarget = join(templateDir, "..", "managed-store");
+    const extensionsDir = join(templateDir, "..", "extensions");
+    await mkdir(linkTarget, { recursive: true });
+    await writeFile(join(linkTarget, "existing.txt"), "managed\n");
+    await symlink(linkTarget, extensionsDir);
+
+    const seeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(seeded).toBe(false);
+    // The user-owned symlink is preserved, not clobbered or followed-and-overwritten.
+    await expect(lstat(extensionsDir).then((s) => s.isSymbolicLink())).resolves.toBe(true);
+    // Bundled defaults were not force-copied into the managed target.
+    await expect(readFile(join(linkTarget, "AGENTS.md"), "utf8")).rejects.toThrow();
+  });
+
+  it("skips seeding without throwing when the workspace path is a regular file", async () => {
+    const templateDir = await makeTemplate();
+    const extensionsDir = join(templateDir, "..", "extensions");
+    await writeFile(extensionsDir, "not a directory\n");
+
+    const seeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(seeded).toBe(false);
+    await expect(readFile(extensionsDir, "utf8")).resolves.toBe("not a directory\n");
+  });
+
+  it("returns false instead of throwing when the copy fails", async () => {
+    const templateDir = await makeTemplate();
+    const extensionsDir = join(templateDir, "..", "extensions");
+    await mkdir(extensionsDir, { recursive: true });
+    // Read-only directory: the destination is a real directory (passes the
+    // non-directory guard) but fs.cp cannot write into it.
+    await chmod(extensionsDir, 0o500);
+    tempDirs.push(extensionsDir);
+
+    const seeded = await seedExtensionWorkspace({ extensionsDir, templateDir });
+
+    expect(seeded).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The production app (0.1.13) launches into a dead state on machines where `~/.baby-menu/extensions` is a symlink: the dock icon lingers, the tray never appears, and there is no error in the UI.

Root cause: on every launch the seeder force-copies the bundled template into the workspace with `fs.cp(template, extensionsDir, { recursive: true, force: true })`. When `extensionsDir` is a symlink or other non-directory (e.g. a read-only home-manager / Nix-store managed symlink), `fs.cp` throws `ERR_FS_CP_DIR_TO_NON_DIR`. That throw is an unhandled rejection in `startBabyMenuApp`, raised **before** `app.dock.hide()` and tray creation, so startup aborts silently.

Verified against a real symlinked workspace:

```
OLD: cp THREW -> ERR_FS_CP_DIR_TO_NON_DIR (this is the startup crash)
NEW: detected symlink -> skip seeding, return false, NO throw
```

## Fix

Harden the whole class of startup workspace failures:

- **`extension-seeder.ts`** - `lstat` the target first and skip with a clear warning when it is not a real directory, never clobbering a user-owned symlink. Wrap the copy so any failure (permissions, read-only volume) returns `false` instead of throwing.
- **`app.ts`** - contain seeding in a `try/catch` so it can never abort tray creation, and add a top-level `.catch` on the entry point so a fatal startup error is logged rather than silently leaving a tray-less app.

## Tests (TDD)

- `tests/extension-seeder.test.ts` (new): symlinked target, regular-file target, and read-only-copy-failure all return `false` without throwing; symlink is preserved; happy path still force-copies.
- `tests/app-lifecycle.test.ts`: tray is still created when seeding rejects.

`pnpm test`, `pnpm typecheck`, `pnpm lint` all green.

## Note for affected users

This stops the crash so the app launches, but a read-only/managed symlinked workspace still cannot be edited by the embedded agent. Users on home-manager / Nix should stop managing `~/.baby-menu/extensions` and `~/.baby-menu/preferences.json` so Baby Menu can own them.