### PR TITLE
test: stabilize Grok refresh termination coverage

### DIFF
--- a/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/focused-process-group-regression.log
+++ b/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/focused-process-group-regression.log
@@ -1,0 +1,710 @@
+focused regression run 1/10
+Already up to date
+Done in 162ms using pnpm v11.1.1
+Already up to date
+Done in 160ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 775ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:58:53
+   Duration  1.12s (transform 112ms, setup 0ms, import 276ms, tests 776ms, environment 0ms)
+
+focused regression run 2/10
+Already up to date
+Done in 162ms using pnpm v11.1.1
+Already up to date
+Done in 163ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 784ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:58:55
+   Duration  1.13s (transform 116ms, setup 0ms, import 280ms, tests 785ms, environment 0ms)
+
+focused regression run 3/10
+Already up to date
+Done in 165ms using pnpm v11.1.1
+Already up to date
+Done in 168ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 789ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:58:57
+   Duration  1.16s (transform 118ms, setup 0ms, import 297ms, tests 790ms, environment 0ms)
+
+focused regression run 4/10
+Already up to date
+Done in 169ms using pnpm v11.1.1
+Already up to date
+Done in 194ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 808ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:58:59
+   Duration  1.19s (transform 127ms, setup 0ms, import 310ms, tests 809ms, environment 0ms)
+
+focused regression run 5/10
+Already up to date
+Done in 182ms using pnpm v11.1.1
+Already up to date
+Done in 179ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 797ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:01
+   Duration  1.19s (transform 132ms, setup 0ms, import 318ms, tests 797ms, environment 0ms)
+
+focused regression run 6/10
+Already up to date
+Done in 178ms using pnpm v11.1.1
+Already up to date
+Done in 181ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 798ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:03
+   Duration  1.18s (transform 126ms, setup 0ms, import 311ms, tests 799ms, environment 0ms)
+
+focused regression run 7/10
+Already up to date
+Done in 180ms using pnpm v11.1.1
+Already up to date
+Done in 182ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 800ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:05
+   Duration  1.19s (transform 130ms, setup 0ms, import 312ms, tests 801ms, environment 0ms)
+
+focused regression run 8/10
+Already up to date
+Done in 180ms using pnpm v11.1.1
+Already up to date
+Done in 178ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 798ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:07
+   Duration  1.18s (transform 123ms, setup 0ms, import 307ms, tests 799ms, environment 0ms)
+
+focused regression run 9/10
+Already up to date
+Done in 174ms using pnpm v11.1.1
+Already up to date
+Done in 175ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 795ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:09
+   Duration  1.17s (transform 125ms, setup 0ms, import 299ms, tests 795ms, environment 0ms)
+
+focused regression run 10/10
+Already up to date
+Done in 180ms using pnpm v11.1.1
+Already up to date
+Done in 178ms using pnpm v11.1.1
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > calls the exact bounded consumer gRPC-web operation without mutation headers or account data
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes a locally expired OIDC bearer once, rereads auth, and calls gRPC with the refreshed bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one provider request after local-expiry refresh even when it fails transiently
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one HTTP 401, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one gRPC unauthenticated, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refreshes after one credential-classified gRPC permission failure, rereads auth, and retries gRPC exactly once
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses one post-refresh transport attempt while ordinary transient acquisition retains one retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never runs the conditional refresh for a healthy successful bearer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not refresh a healthy bearer after HTTP 403
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > contains no direct OAuth, browser-cookie, proxy, or client-mode runtime path
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > prefers a current OIDC principal and falls back from a partial OIDC entry to legacy
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses ambiguous winning-class principals before any provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > refuses a refreshed principal change before a gRPC retry
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good cache when conditional official refresh fails
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > bounds refresh termination when a descendant keeps inherited stdio open
+ ✓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > does not rethrow macOS EPERM when refresh termination double-signals a dead process group 797ms
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > uses currentPeriod.end and never the monetary billing period reset
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > never turns monetary monthly spend into a quota percentage
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > accepts the bounded raw protobuf form and retries one transient response only
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 9 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > classifies non-credential gRPC status 7 without refreshing, retrying, or exposing the message
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the header
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects malformed or out-of-range gRPC status in the trailer
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects compressed frames and non-credential gRPC header errors before protobuf parsing
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > enforces one whole-request timeout without a second provider call
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > reports exact source unavailable instead of falling back to CLI billing or monetary math
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during connectivity failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during parser failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during rate limit failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects and clears the fabricated legacy row during service failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces the fabricated legacy row only after exact-source success
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unversioned cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a legacy version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a future version cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong source cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a wrong operation cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a different principal cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing percentage provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a percentage field mismatch cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a unknown reset provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a reset field without reset value cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a missing credits provenance cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a duplicate product provenance index cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > fails closed for a gapped product provenance indexes cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > renders fresh unbound data but never writes or reuses a persistent cache row
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves a trusted current-schema row byte-for-byte during a transient failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > writes schema 2 with exact operation, period, global, product, reset, and credit provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > applies protobuf scalar zero semantics only on the exact consumer operation
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > decodes an omitted product enum as UNSPECIFIED with indexed cache provenance
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > replaces an old reported snapshot when the exact source later reports proto3 zero
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > preserves same-principal last-good bytes during a transient transport failure
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > rejects a response above 64 KiB without exposing or parsing its body
+ ↓ tests/grok-quota-generated-install.test.ts > clean generated Grok quota installation > single-flights repeated manual and startup-equivalent refresh calls
+
+ Test Files  1 passed (1)
+      Tests  1 passed | 56 skipped (57)
+   Start at  15:59:11
+   Duration  1.18s (transform 124ms, setup 0ms, import 304ms, tests 798ms, environment 0ms)
+

--- a/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite-stress-runs-2-through-5.log
+++ b/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite-stress-runs-2-through-5.log
@@ -1,0 +1,60 @@
+full concurrent suite run 2/5
+Already up to date
+Done in 164ms using pnpm v11.1.1
+$ vitest run tests
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+[test-adapter] prompt failed AUTHENTICATION_FAILED Codex is not authenticated. Run `codex login` and try again.
+[test-adapter] prompt failed ADAPTER_FAILED The embedded agent failed while processing the request.
+
+ Test Files  68 passed | 1 skipped (69)
+      Tests  538 passed | 2 skipped (540)
+   Start at  15:59:51
+   Duration  14.13s (transform 7.51s, setup 0ms, import 20.02s, tests 42.61s, environment 17.83s)
+
+full concurrent suite run 3/5
+Already up to date
+Done in 176ms using pnpm v11.1.1
+$ vitest run tests
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+[test-adapter] prompt failed AUTHENTICATION_FAILED Codex is not authenticated. Run `codex login` and try again.
+[test-adapter] prompt failed ADAPTER_FAILED The embedded agent failed while processing the request.
+
+ Test Files  68 passed | 1 skipped (69)
+      Tests  538 passed | 2 skipped (540)
+   Start at  16:00:05
+   Duration  14.25s (transform 7.29s, setup 0ms, import 22.30s, tests 44.33s, environment 20.07s)
+
+full concurrent suite run 4/5
+Already up to date
+Done in 182ms using pnpm v11.1.1
+$ vitest run tests
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+[test-adapter] prompt failed AUTHENTICATION_FAILED Codex is not authenticated. Run `codex login` and try again.
+[test-adapter] prompt failed ADAPTER_FAILED The embedded agent failed while processing the request.
+
+ Test Files  68 passed | 1 skipped (69)
+      Tests  538 passed | 2 skipped (540)
+   Start at  16:00:20
+   Duration  14.06s (transform 6.93s, setup 0ms, import 22.66s, tests 45.17s, environment 19.20s)
+
+full concurrent suite run 5/5
+Already up to date
+Done in 165ms using pnpm v11.1.1
+$ vitest run tests
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+[test-adapter] prompt failed AUTHENTICATION_FAILED Codex is not authenticated. Run `codex login` and try again.
+[test-adapter] prompt failed ADAPTER_FAILED The embedded agent failed while processing the request.
+
+ Test Files  68 passed | 1 skipped (69)
+      Tests  538 passed | 2 skipped (540)
+   Start at  16:00:35
+   Duration  14.55s (transform 9.36s, setup 0ms, import 24.78s, tests 46.21s, environment 19.89s)
+

--- a/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite.log
+++ b/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite.log
@@ -1,0 +1,14 @@
+Already up to date
+Done in 172ms using pnpm v11.1.1
+$ vitest run tests
+
+ RUN  v4.1.6 /Users/kunchen/.no-mistakes/worktrees/dfc47b02954f/01KY0VPMRYSTQ11GPDSC40TRYT
+
+[test-adapter] prompt failed AUTHENTICATION_FAILED Codex is not authenticated. Run `codex login` and try again.
+[test-adapter] prompt failed ADAPTER_FAILED The embedded agent failed while processing the request.
+
+ Test Files  68 passed | 1 skipped (69)
+      Tests  538 passed | 2 skipped (540)
+   Start at  15:59:22
+   Duration  14.13s (transform 6.13s, setup 0ms, import 20.69s, tests 46.81s, environment 20.16s)
+

--- a/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/verification-summary.log
+++ b/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/verification-summary.log
@@ -1,0 +1,4 @@
+Focused regression passes: 10
+Full-suite successful summaries: 5
+Full-suite EPERM/unhandled-error scan: none
+Post-test hanging Grok fixture processes: none

--- a/extensions/recipes/grok-quota.html
+++ b/extensions/recipes/grok-quota.html
@@ -64,6 +64,7 @@
         <p>HTTP 403 remains a rejected credential or permission outcome but does not trigger refresh.</p>
         <p>Never invoke it before every acquisition, after permission or team-scope failures, or after the one post-refresh retry.</p>
         <p>Spawn the discovered executable with argument array <code>["models"]</code>, <code>shell: false</code>, ignored stdin, the complete inherited environment, a 20-second timeout, and 128 KiB bounded stdout and stderr held only in memory.</p>
+        <p>On timeout, terminate the detached non-Windows process group with <code>SIGTERM</code>, allow a one-second grace period, then issue at most one process-group <code>SIGKILL</code>. Suppress <code>ESRCH</code>; suppress <code>EPERM</code> only when a process-table check confirms that no live, same-uid, non-zombie member remains in the owned group. Otherwise propagate the signaling failure.</p>
         <p>Discover <code>$GROK_CLI_PATH</code>, <code>$GROK_HOME/bin/grok</code>, current <code>PATH</code>, home-local Grok locations, then Homebrew locations without a shell.</p>
         <p>After exit zero, reread the same resolved auth source, apply deterministic OIDC-over-legacy selection again, and require the new stable account binding to equal the pre-refresh binding.</p>
         <p>Return <code>auth_principal_changed</code> without a gRPC retry when the principal changes, and return <code>auth_expired</code> when official refresh leaves the selected bearer expired.</p>
@@ -300,7 +301,7 @@ type GrokQuotaResult =
         <ul>
           <li>The server sends the exact gRPC-web POST, headers, and five-byte body with no client-mode header, cookie, proxy, or ACP path.</li>
           <li>OIDC selection, legacy fallback, expiry, ambiguity, and unbound identity behavior are deterministic.</li>
-          <li>Local expiry and one credential-classified response run one bounded fake-CLI-tested official refresh, reread auth, verify principal continuity, and issue exactly one gRPC retry.</li>
+          <li>Local expiry and one credential-classified response run one bounded fake-CLI-tested official refresh, reread auth, verify principal continuity, and issue exactly one gRPC retry. Timeout coverage proves one owned-group hard kill, descendant cleanup, and narrow dead-group <code>EPERM</code> handling.</li>
           <li>A healthy successful bearer never launches the CLI, and deterministic tests never execute a real Grok binary.</li>
           <li>The bounded typed decoder covers framed and raw payloads, global and product percentages, current period, prepaid balance, proto3 zero, trailers, malformed data, and the response cap.</li>
           <li>Exact used values remain unrounded in state and cache, remaining is derived, and rounding occurs only in visible copy.</li>

--- a/tests/fixtures/grok-quota-generated/server.ts.fixture
+++ b/tests/fixtures/grok-quota-generated/server.ts.fixture
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { accessSync, constants, existsSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
@@ -187,6 +187,67 @@ function safeAuthRequiredMarker(text) {
         normalized.includes("run `grok login`");
 }
 
+/**
+ * True when this uid still owns a non-zombie member of pgid.
+ * Used only after kill(-pgid) returns EPERM so we never signal a recycled pid
+ * and never treat a still-running owned child as cleaned up.
+ */
+function hasLiveOwnedProcessGroupMember(pgid) {
+    if (typeof process.getuid !== "function")
+        return true;
+    const result = spawnSync("/bin/ps", ["-axo", "pgid=,uid=,state="], { encoding: "utf8" });
+    if (result.error || result.status !== 0)
+        return true;
+    const uid = process.getuid();
+    return result.stdout.split("\n").some((line) => {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 3)
+            return false;
+        const [rawPgid, rawUid, state] = parts;
+        if (Number(rawPgid) !== pgid || Number(rawUid) !== uid)
+            return false;
+        // Zombies cannot receive signals. On macOS, kill(-pgid) often returns
+        // EPERM (not ESRCH) while only zombies remain mid-reap.
+        return !String(state).startsWith("Z");
+    });
+}
+
+/**
+ * Signal a detached CLI process group once per hard-kill. Redundant SIGKILLs race
+ * the force-kill timer with the child "close" handler: after the first successful
+ * group kill, macOS may return EPERM for kill(-pgid) while zombies linger or the
+ * pgid is recycled, and rethrowing that from a timer/close handler aborts Vitest.
+ */
+function signalRefreshProcessGroup(pid, signal, state) {
+    if (!pid)
+        return;
+    if (signal === "SIGKILL" && state.groupKillIssued)
+        return;
+    try {
+        if (process.platform !== "win32")
+            process.kill(-pid, signal);
+        else
+            process.kill(pid, signal);
+        if (signal === "SIGKILL")
+            state.groupKillIssued = true;
+    }
+    catch (error) {
+        if (error?.code === "ESRCH") {
+            if (signal === "SIGKILL")
+                state.groupKillIssued = true;
+            return;
+        }
+        if (error?.code === "EPERM" &&
+            process.platform !== "win32" &&
+            !hasLiveOwnedProcessGroupMember(pid)) {
+            if (signal === "SIGKILL")
+                state.groupKillIssued = true;
+            return;
+        }
+        throw error;
+    }
+}
+
 async function runOfficialRefresh() {
     const executable = resolveGrokExecutable();
     if (!executable)
@@ -203,16 +264,18 @@ async function runOfficialRefresh() {
         let settled = false;
         let timeoutFailure;
         let forceKillTimer;
+        const killState = { groupKillIssued: false };
         const signalChild = (signal) => {
-            try {
-                if (child.pid && process.platform !== "win32")
-                    process.kill(-child.pid, signal);
-                else
+            if (child.pid && process.platform !== "win32")
+                signalRefreshProcessGroup(child.pid, signal, killState);
+            else {
+                try {
                     child.kill(signal);
-            }
-            catch (error) {
-                if (error?.code !== "ESRCH")
-                    throw error;
+                }
+                catch (error) {
+                    if (error?.code !== "ESRCH")
+                        throw error;
+                }
             }
         };
         const appendBounded = (current, chunk) => Buffer.concat([current, chunk])

--- a/tests/grok-quota-generated-install.test.ts
+++ b/tests/grok-quota-generated-install.test.ts
@@ -752,14 +752,218 @@ describe("clean generated Grok quota installation", () => {
     expect(descendantPidPath).toBeTruthy();
     if (!descendantPidPath) return;
     const descendantPid = Number(await readFile(descendantPidPath, "utf8"));
+    // Harness-only liveness probe: ESRCH means gone; EPERM means the pid was
+    // recycled to an unowned process (our descendant is still gone). Do not
+    // treat either as a production signal path.
     await expect.poll(() => {
       try {
         process.kill(descendantPid, 0);
         return false;
       } catch (error) {
-        return (error as NodeJS.ErrnoException).code === "ESRCH";
+        const code = (error as NodeJS.ErrnoException).code;
+        return code === "ESRCH" || code === "EPERM";
       }
     }).toBe(true);
+  });
+
+  it("does not rethrow macOS EPERM when refresh termination double-signals a dead process group", async () => {
+    // Fixture contract: one hard group-kill, and EPERM only suppressed when no
+    // live owned member remains (never a blanket permission swallow).
+    const source = await readFile(fixtureUrl, "utf8");
+    expect(source).toContain("function hasLiveOwnedProcessGroupMember");
+    expect(source).toContain("function signalRefreshProcessGroup");
+    expect(source).toContain("groupKillIssued");
+    expect(source).toContain("hasLiveOwnedProcessGroupMember(pid)");
+    expect(source).toMatch(/error\?\.code === "EPERM"/);
+    const helper = source.slice(
+      source.indexOf("function signalRefreshProcessGroup"),
+      source.indexOf("async function runOfficialRefresh"),
+    );
+    expect(helper).toContain('if (signal === "SIGKILL" && state.groupKillIssued)');
+    expect(helper).toContain('error?.code === "EPERM"');
+    expect(helper).toContain("hasLiveOwnedProcessGroupMember(pid)");
+
+    if (process.platform === "win32") return;
+
+    const { spawn, spawnSync } = await import("node:child_process");
+
+    function hasLiveOwnedProcessGroupMember(pgid: number): boolean {
+      if (typeof process.getuid !== "function") return true;
+      const result = spawnSync("/bin/ps", ["-axo", "pgid=,uid=,state="], { encoding: "utf8" });
+      if (result.error || result.status !== 0) return true;
+      const uid = process.getuid();
+      return result.stdout.split("\n").some((line) => {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 3) return false;
+        const [rawPgid, rawUid, state] = parts;
+        if (Number(rawPgid) !== pgid || Number(rawUid) !== uid) return false;
+        return !String(state).startsWith("Z");
+      });
+    }
+
+    type KillState = { groupKillIssued: boolean; successfulHardKillPgids: number[] };
+    function signalRefreshProcessGroup(
+      pid: number,
+      signal: NodeJS.Signals,
+      state: KillState,
+      liveOwned: (pgid: number) => boolean = hasLiveOwnedProcessGroupMember,
+    ): void {
+      if (signal === "SIGKILL" && state.groupKillIssued) return;
+      try {
+        process.kill(-pid, signal);
+        if (signal === "SIGKILL") {
+          state.groupKillIssued = true;
+          state.successfulHardKillPgids.push(pid);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+          if (signal === "SIGKILL") state.groupKillIssued = true;
+          return;
+        }
+        if ((error as NodeJS.ErrnoException).code === "EPERM" && !liveOwned(pid)) {
+          if (signal === "SIGKILL") state.groupKillIssued = true;
+          return;
+        }
+        throw error;
+      }
+    }
+
+    // Pre-fix helper: only ESRCH is swallowed, so macOS EPERM escapes timers/close.
+    function signalChildLegacy(pid: number, signal: NodeJS.Signals): void {
+      try {
+        process.kill(-pid, signal);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+      }
+    }
+
+    // Deterministic contract: when kill(-pgid) yields EPERM and the group has no
+    // live owned member, legacy rethrows (suite-killing) and the fix does not.
+    // Still-live owned groups must keep throwing so we never mask real EPERM.
+    const fakePgid = 424242;
+    const originalKill = process.kill.bind(process);
+    const eperm = Object.assign(new Error("kill EPERM"), { code: "EPERM" }) as NodeJS.ErrnoException;
+    (process as NodeJS.Process).kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === -fakePgid) throw eperm;
+      return originalKill(pid, signal as NodeJS.Signals);
+    }) as typeof process.kill;
+    try {
+      expect(() => signalChildLegacy(fakePgid, "SIGKILL")).toThrow(
+        expect.objectContaining({ code: "EPERM" }),
+      );
+      const deadGroupState: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
+      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState, () => false)).not.toThrow();
+      expect(deadGroupState.groupKillIssued).toBe(true);
+      expect(deadGroupState.successfulHardKillPgids).toEqual([]);
+      // Second hard kill is a no-op: never touches a recycled pgid.
+      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState, () => false)).not.toThrow();
+
+      const liveGroupState: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
+      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", liveGroupState, () => true)).toThrow(
+        expect.objectContaining({ code: "EPERM" }),
+      );
+      expect(liveGroupState.groupKillIssued).toBe(false);
+    } finally {
+      process.kill = originalKill;
+    }
+
+    async function spawnHangingGroup(script: string, descendantPidPath: string) {
+      const child = spawn(script, [], {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"] as const,
+        shell: false,
+      });
+      const leaderPid = child.pid;
+      expect(leaderPid).toBeTypeOf("number");
+      if (!leaderPid) throw new Error("missing leader pid");
+      let descendantPid = 0;
+      await expect.poll(async () => {
+        try {
+          descendantPid = Number(await readFile(descendantPidPath, "utf8"));
+          return Number.isFinite(descendantPid) && descendantPid > 0;
+        } catch {
+          return false;
+        }
+      }).toBe(true);
+      return { child, leaderPid, descendantPid };
+    }
+
+    function expectProcessGone(pid: number) {
+      return expect.poll(() => {
+        try {
+          process.kill(pid, 0);
+          return false;
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          return code === "ESRCH" || code === "EPERM";
+        }
+      }).toBe(true);
+    }
+
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-grok-kill-race-"));
+    tempDirs.push(rootDir);
+    const script = join(rootDir, "hanging-cli.sh");
+    const descendantPidPath = join(rootDir, "descendant.pid");
+    await writeFile(
+      script,
+      `#!/bin/sh
+trap "" TERM
+(trap "" TERM; while :; do sleep 1; done) &
+printf "%s" "$!" > "${descendantPidPath}"
+wait
+`,
+    );
+    await chmod(script, 0o755);
+
+    // Real process groups: fixed helper bounds leaders + descendants without
+    // signaling any pgid other than the one it started.
+    const ownedLeaders: number[] = [];
+    const ownedDescendants: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      const { child, leaderPid, descendantPid } = await spawnHangingGroup(script, descendantPidPath);
+      ownedLeaders.push(leaderPid);
+      ownedDescendants.push(descendantPid);
+
+      const state: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
+      expect(() => {
+        signalRefreshProcessGroup(leaderPid, "SIGTERM", state);
+        signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
+        signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
+      }).not.toThrow();
+
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      await Promise.race([
+        new Promise<void>((resolve) => child.once("close", () => resolve())),
+        new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
+      ]);
+      expect(() => signalRefreshProcessGroup(leaderPid, "SIGKILL", state)).not.toThrow();
+
+      expect(state.groupKillIssued).toBe(true);
+      // At most one successful hard kill, and only against this test's leader.
+      expect(state.successfulHardKillPgids.length).toBeLessThanOrEqual(1);
+      expect(state.successfulHardKillPgids.every((pgid) => pgid === leaderPid)).toBe(true);
+      await expectProcessGone(leaderPid);
+      await expectProcessGone(descendantPid);
+    }
+
+    for (const leaderPid of ownedLeaders) {
+      const result = spawnSync("/bin/ps", ["-axo", "pid=,pgid=,uid=,state="], { encoding: "utf8" });
+      expect(result.status).toBe(0);
+      const uid = process.getuid?.();
+      const live = result.stdout.split("\n").filter((line) => {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 4) return false;
+        const [, rawPgid, rawUid, state] = parts;
+        if (Number(rawPgid) !== leaderPid) return false;
+        if (uid !== undefined && Number(rawUid) !== uid) return false;
+        return !String(state).startsWith("Z");
+      });
+      expect(live).toEqual([]);
+    }
+    expect(ownedDescendants).toHaveLength(ownedLeaders.length);
+    // Every hard kill targeted an owned leader from this test, never an outsider.
+    expect(new Set(ownedLeaders).size).toBe(ownedLeaders.length);
   });
 
   it("uses currentPeriod.end and never the monetary billing period reset", async () => {

--- a/tests/grok-quota-generated-install.test.ts
+++ b/tests/grok-quota-generated-install.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createExtensionDatabase, type ExtensionDatabase } from "../src/main/extension-database";
 import { createServerActionRegistry, type ServerActionRegistry } from "../src/main/server-action-registry";
@@ -767,68 +768,23 @@ describe("clean generated Grok quota installation", () => {
   });
 
   it("does not rethrow macOS EPERM when refresh termination double-signals a dead process group", async () => {
-    // Fixture contract: one hard group-kill, and EPERM only suppressed when no
-    // live owned member remains (never a blanket permission swallow).
     const source = await readFile(fixtureUrl, "utf8");
-    expect(source).toContain("function hasLiveOwnedProcessGroupMember");
-    expect(source).toContain("function signalRefreshProcessGroup");
-    expect(source).toContain("groupKillIssued");
-    expect(source).toContain("hasLiveOwnedProcessGroupMember(pid)");
-    expect(source).toMatch(/error\?\.code === "EPERM"/);
-    const helper = source.slice(
-      source.indexOf("function signalRefreshProcessGroup"),
-      source.indexOf("async function runOfficialRefresh"),
-    );
-    expect(helper).toContain('if (signal === "SIGKILL" && state.groupKillIssued)');
-    expect(helper).toContain('error?.code === "EPERM"');
-    expect(helper).toContain("hasLiveOwnedProcessGroupMember(pid)");
-
     if (process.platform === "win32") return;
 
     const { spawn, spawnSync } = await import("node:child_process");
+    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-grok-kill-race-"));
+    tempDirs.push(rootDir);
+    const executableFixture = join(rootDir, "server.mjs");
+    await writeFile(executableFixture, `${source}\nexport { signalRefreshProcessGroup };\n`);
+    const fixtureModule = await import(pathToFileURL(executableFixture).href) as {
+      signalRefreshProcessGroup: (
+        pid: number,
+        signal: NodeJS.Signals,
+        state: { groupKillIssued: boolean },
+      ) => void;
+    };
+    const { signalRefreshProcessGroup } = fixtureModule;
 
-    function hasLiveOwnedProcessGroupMember(pgid: number): boolean {
-      if (typeof process.getuid !== "function") return true;
-      const result = spawnSync("/bin/ps", ["-axo", "pgid=,uid=,state="], { encoding: "utf8" });
-      if (result.error || result.status !== 0) return true;
-      const uid = process.getuid();
-      return result.stdout.split("\n").some((line) => {
-        const parts = line.trim().split(/\s+/);
-        if (parts.length < 3) return false;
-        const [rawPgid, rawUid, state] = parts;
-        if (Number(rawPgid) !== pgid || Number(rawUid) !== uid) return false;
-        return !String(state).startsWith("Z");
-      });
-    }
-
-    type KillState = { groupKillIssued: boolean; successfulHardKillPgids: number[] };
-    function signalRefreshProcessGroup(
-      pid: number,
-      signal: NodeJS.Signals,
-      state: KillState,
-      liveOwned: (pgid: number) => boolean = hasLiveOwnedProcessGroupMember,
-    ): void {
-      if (signal === "SIGKILL" && state.groupKillIssued) return;
-      try {
-        process.kill(-pid, signal);
-        if (signal === "SIGKILL") {
-          state.groupKillIssued = true;
-          state.successfulHardKillPgids.push(pid);
-        }
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-          if (signal === "SIGKILL") state.groupKillIssued = true;
-          return;
-        }
-        if ((error as NodeJS.ErrnoException).code === "EPERM" && !liveOwned(pid)) {
-          if (signal === "SIGKILL") state.groupKillIssued = true;
-          return;
-        }
-        throw error;
-      }
-    }
-
-    // Pre-fix helper: only ESRCH is swallowed, so macOS EPERM escapes timers/close.
     function signalChildLegacy(pid: number, signal: NodeJS.Signals): void {
       try {
         process.kill(-pid, signal);
@@ -837,45 +793,44 @@ describe("clean generated Grok quota installation", () => {
       }
     }
 
-    // Deterministic contract: when kill(-pgid) yields EPERM and the group has no
-    // live owned member, legacy rethrows (suite-killing) and the fix does not.
-    // Still-live owned groups must keep throwing so we never mask real EPERM.
     const fakePgid = 424242;
-    const originalKill = process.kill.bind(process);
+    const originalKill = process.kill;
     const eperm = Object.assign(new Error("kill EPERM"), { code: "EPERM" }) as NodeJS.ErrnoException;
     (process as NodeJS.Process).kill = ((pid: number, signal?: NodeJS.Signals | number) => {
       if (pid === -fakePgid) throw eperm;
-      return originalKill(pid, signal as NodeJS.Signals);
+      return originalKill.call(process, pid, signal as NodeJS.Signals);
     }) as typeof process.kill;
     try {
       expect(() => signalChildLegacy(fakePgid, "SIGKILL")).toThrow(
         expect.objectContaining({ code: "EPERM" }),
       );
-      const deadGroupState: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
-      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState, () => false)).not.toThrow();
+      const deadGroupState = { groupKillIssued: false };
+      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState)).not.toThrow();
       expect(deadGroupState.groupKillIssued).toBe(true);
-      expect(deadGroupState.successfulHardKillPgids).toEqual([]);
-      // Second hard kill is a no-op: never touches a recycled pgid.
-      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState, () => false)).not.toThrow();
-
-      const liveGroupState: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
-      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", liveGroupState, () => true)).toThrow(
-        expect.objectContaining({ code: "EPERM" }),
-      );
-      expect(liveGroupState.groupKillIssued).toBe(false);
+      expect(() => signalRefreshProcessGroup(fakePgid, "SIGKILL", deadGroupState)).not.toThrow();
     } finally {
       process.kill = originalKill;
     }
 
-    async function spawnHangingGroup(script: string, descendantPidPath: string) {
+    type HangingGroup = {
+      child: ReturnType<typeof spawn>;
+      leaderPid: number;
+      descendantPid?: number;
+    };
+    const groups: HangingGroup[] = [];
+
+    async function spawnHangingGroup(script: string, descendantPidPath: string): Promise<HangingGroup> {
       const child = spawn(script, [], {
         detached: true,
+        env: { ...process.env, GROK_TEST_DESCENDANT_PID: descendantPidPath },
         stdio: ["ignore", "pipe", "pipe"] as const,
         shell: false,
       });
       const leaderPid = child.pid;
       expect(leaderPid).toBeTypeOf("number");
       if (!leaderPid) throw new Error("missing leader pid");
+      const group: HangingGroup = { child, leaderPid };
+      groups.push(group);
       let descendantPid = 0;
       await expect.poll(async () => {
         try {
@@ -885,7 +840,8 @@ describe("clean generated Grok quota installation", () => {
           return false;
         }
       }).toBe(true);
-      return { child, leaderPid, descendantPid };
+      group.descendantPid = descendantPid;
+      return group;
     }
 
     function expectProcessGone(pid: number) {
@@ -900,51 +856,81 @@ describe("clean generated Grok quota installation", () => {
       }).toBe(true);
     }
 
-    const rootDir = await mkdtemp(join(tmpdir(), "baby-menu-grok-kill-race-"));
-    tempDirs.push(rootDir);
     const script = join(rootDir, "hanging-cli.sh");
-    const descendantPidPath = join(rootDir, "descendant.pid");
     await writeFile(
       script,
       `#!/bin/sh
 trap "" TERM
 (trap "" TERM; while :; do sleep 1; done) &
-printf "%s" "$!" > "${descendantPidPath}"
+printf "%s" "$!" > "$GROK_TEST_DESCENDANT_PID"
 wait
 `,
     );
     await chmod(script, 0o755);
 
-    // Real process groups: fixed helper bounds leaders + descendants without
-    // signaling any pgid other than the one it started.
     const ownedLeaders: number[] = [];
     const ownedDescendants: number[] = [];
-    for (let i = 0; i < 8; i++) {
-      const { child, leaderPid, descendantPid } = await spawnHangingGroup(script, descendantPidPath);
-      ownedLeaders.push(leaderPid);
-      ownedDescendants.push(descendantPid);
+    const hardKillTargets: number[] = [];
+    (process as NodeJS.Process).kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid < 0 && signal === "SIGKILL") hardKillTargets.push(-pid);
+      return originalKill.call(process, pid, signal as NodeJS.Signals);
+    }) as typeof process.kill;
+    try {
+      const liveGroup = await spawnHangingGroup(script, join(rootDir, "live-descendant.pid"));
+      const liveEpermKill = process.kill;
+      process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+        if (pid === -liveGroup.leaderPid) throw eperm;
+        return liveEpermKill.call(process, pid, signal as NodeJS.Signals);
+      }) as typeof process.kill;
+      const liveState = { groupKillIssued: false };
+      expect(() => signalRefreshProcessGroup(liveGroup.leaderPid, "SIGKILL", liveState)).toThrow(
+        expect.objectContaining({ code: "EPERM" }),
+      );
+      expect(liveState.groupKillIssued).toBe(false);
+      process.kill = liveEpermKill;
 
-      const state: KillState = { groupKillIssued: false, successfulHardKillPgids: [] };
-      expect(() => {
-        signalRefreshProcessGroup(leaderPid, "SIGTERM", state);
-        signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
-        signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
-      }).not.toThrow();
+      for (let i = 0; i < 8; i++) {
+        const descendantPidPath = join(rootDir, `descendant-${i}.pid`);
+        const { child, leaderPid, descendantPid } = await spawnHangingGroup(script, descendantPidPath);
+        if (!descendantPid) throw new Error("missing descendant pid");
+        ownedLeaders.push(leaderPid);
+        ownedDescendants.push(descendantPid);
 
-      child.stdout?.destroy();
-      child.stderr?.destroy();
-      await Promise.race([
-        new Promise<void>((resolve) => child.once("close", () => resolve())),
-        new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
-      ]);
-      expect(() => signalRefreshProcessGroup(leaderPid, "SIGKILL", state)).not.toThrow();
+        const state = { groupKillIssued: false };
+        expect(() => {
+          signalRefreshProcessGroup(leaderPid, "SIGTERM", state);
+          signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
+          signalRefreshProcessGroup(leaderPid, "SIGKILL", state);
+        }).not.toThrow();
 
-      expect(state.groupKillIssued).toBe(true);
-      // At most one successful hard kill, and only against this test's leader.
-      expect(state.successfulHardKillPgids.length).toBeLessThanOrEqual(1);
-      expect(state.successfulHardKillPgids.every((pgid) => pgid === leaderPid)).toBe(true);
-      await expectProcessGone(leaderPid);
-      await expectProcessGone(descendantPid);
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+        await Promise.race([
+          new Promise<void>((resolve) => child.once("close", () => resolve())),
+          new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
+        ]);
+        expect(() => signalRefreshProcessGroup(leaderPid, "SIGKILL", state)).not.toThrow();
+        expect(state.groupKillIssued).toBe(true);
+        expect(hardKillTargets.filter((pgid) => pgid === leaderPid)).toHaveLength(1);
+        await expectProcessGone(leaderPid);
+        await expectProcessGone(descendantPid);
+      }
+
+      expect(hardKillTargets.every((pgid) => ownedLeaders.includes(pgid))).toBe(true);
+      expect(new Set(ownedLeaders).size).toBe(ownedLeaders.length);
+      expect(ownedDescendants).toHaveLength(ownedLeaders.length);
+    } finally {
+      process.kill = originalKill;
+      for (const { child, leaderPid } of groups) {
+        try {
+          originalKill.call(process, -leaderPid, "SIGKILL");
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          if (code !== "ESRCH" && code !== "EPERM") throw error;
+        }
+        child.stdout?.destroy();
+        child.stderr?.destroy();
+      }
     }
 
     for (const leaderPid of ownedLeaders) {
@@ -961,9 +947,6 @@ wait
       });
       expect(live).toEqual([]);
     }
-    expect(ownedDescendants).toHaveLength(ownedLeaders.length);
-    // Every hard kill targeted an owned leader from this test, never an outsider.
-    expect(new Set(ownedLeaders).size).toBe(ownedLeaders.length);
   });
 
   it("uses currentPeriod.end and never the monetary billing period reset", async () => {


### PR DESCRIPTION
## Intent

Fix the pre-existing Baby Menu Vitest flake that intermittently aborts the full `pnpm test` suite with an uncaught `process.kill` EPERM in Grok generated-widget refresh termination coverage. The focused test passed alone; full-suite concurrency exposed the race.

Root cause pinned before the fix: on macOS, after a successful process.kill(-pgid, SIGKILL), a redundant second group kill (force-kill timer racing the child close handler) often returns EPERM instead of ESRCH while zombies linger mid-reap or the pgid is recycled. The fixture only swallowed ESRCH and rethrew EPERM from timer/close handlers, which became an uncaught exception that killed Vitest.

Fix is deliberately narrow (refresh termination helper + test harness only; no Kimi provider, credentials, quota data, or other worker branches):
1. Production fixture: one hard process-group SIGKILL (groupKillIssued), and EPERM is suppressed only when no live owned non-zombie group member remains - not a blanket permission swallow.
2. Deterministic regression: legacy helper rethrows stubbed EPERM; fixed helper does not for a dead group, still throws for a live owned group; real hanging CLI groups prove only owned leader pids are hard-killed and leaders+descendants are cleaned up.
3. Harness liveness probe treats EPERM as "our pid is gone" (recycled), separate from production signaling.

Do not weaken descendant-termination assertions, add sleeps, disable concurrency, or globally swallow EPERM. Ship a PR; do not merge.

## What Changed

- Harden the generated Grok quota fixture to issue only one process-group `SIGKILL` and suppress `EPERM` only after confirming no live owned group members remain.
- Add deterministic and real-process regressions covering dead-group races, live-group failures, owned leader targeting, and descendant cleanup.
- Document the refresh termination safeguards and capture repeated focused and full-suite verification evidence.

## Risk Assessment

✅ Low: The follow-up directly exercises the production fixture helper, uses unique descendant PID files, restores the global kill function exactly, and reliably cleans every spawned process group while preserving the narrow EPERM behavior and descendant assertions.

## Testing

The real-process regression passed 10 consecutive runs and the complete concurrent suite passed five consecutive runs without EPERM, uncaught errors, suite aborts, weakened descendant cleanup, or leaked fixture processes. No screenshot was produced because this is process-termination test-harness behavior with no rendered user interface; reviewer-visible command transcripts are the direct evidence.

- Evidence: [Focused process-group regression, 10 runs](https://github.com/kunchenguid/baby-menu/blob/d27fd8141cdeea6a4bb0d5b94a8fed988cbf4aa3/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/focused-process-group-regression.log)
- Evidence: [Initial full concurrent suite](https://github.com/kunchenguid/baby-menu/blob/d27fd8141cdeea6a4bb0d5b94a8fed988cbf4aa3/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite.log)
- Evidence: [Full concurrent suite stress runs 2 through 5](https://github.com/kunchenguid/baby-menu/blob/d27fd8141cdeea6a4bb0d5b94a8fed988cbf4aa3/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/full-suite-stress-runs-2-through-5.log)
<details>
<summary>Evidence: Verification summary</summary>

Source: [Verification summary](https://github.com/kunchenguid/baby-menu/blob/d27fd8141cdeea6a4bb0d5b94a8fed988cbf4aa3/.no-mistakes/evidence/fm/baby-menu-grok-refresh-termination-flake-f1/verification-summary.log)

```text
Focused regression passes: 10
Full-suite successful summaries: 5
Full-suite EPERM/unhandled-error scan: none
Post-test hanging Grok fixture processes: none
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/grok-quota-generated-install.test.ts:805` - The deterministic EPERM assertions exercise a test-local copy of `signalRefreshProcessGroup`; the production fixture is only checked for matching strings. A behavioral regression in the fixture can therefore pass this test if those tokens remain. Exercise the installed fixture&#39;s helper directly or extract the helper into shared importable code.
- ⚠️ `tests/grok-quota-generated-install.test.ts:923` - Every iteration reuses `descendant.pid` without removing it. After the first iteration, polling can immediately read the previous dead descendant before the new script updates the file, weakening the repeated descendant-cleanup proof. Use a unique PID path per group or remove the file before spawning and verify the reported PID belongs to the new group.
- ⚠️ `tests/grok-quota-generated-install.test.ts:870` - The hanging process group is not registered for cleanup until after setup and assertions succeed. If PID polling times out or an assertion throws before SIGKILL, the TERM-ignoring leader and descendant can survive the test and destabilize later runs. Track spawned leaders immediately and hard-kill outstanding groups in `finally` or `afterEach`.

🔧 Fix: Exercise production kill helper with reliable process cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff --unified=80 34df1ee5b8a21f91ac34ef4c6582ca983f628b22..f309ac271f880b2e032aa42bc1322f365dbd1281` to verify scope and acceptance coverage.</code>
- <code>Ran the focused process-group EPERM regression 10 consecutive times with `pnpm vitest run tests/grok-quota-generated-install.test.ts -t &#34;does not rethrow macOS EPERM when refresh termination double-signals a dead process group&#34; --reporter=verbose`.</code>
- <code>Ran `pnpm test` five consecutive times under default Vitest full-suite concurrency.</code>
- `Scanned all full-suite transcripts for EPERM and unhandled errors.`
- `Inspected the live process table for leaked Grok hanging-CLI fixture leaders or descendants after testing.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
