### PR TITLE
fix(main): close Kimi quota responses on every terminal path

### DIFF
--- a/.no-mistakes/evidence/fm/baby-menu-kimi-response-cancel-f1/kimi-response-lifecycle.md
+++ b/.no-mistakes/evidence/fm/baby-menu-kimi-response-cancel-f1/kimi-response-lifecycle.md
@@ -1,0 +1,76 @@
+# Kimi response lifecycle validation
+
+Validated target `2aef344ada45583a293aa663deac6c167a1c838b` against base `9c0a970dca92b86e1275add9213aeb20eeda1780` using the broker's real fetch boundary and a controlled loopback HTTP server. No live Kimi credential or provider request was used.
+
+## End-user boundary exercised
+
+Every request presented to the broker remained the production fixed operation:
+
+```text
+GET https://api.kimi.com/coding/v1/usages
+```
+
+The injected transport routed that operation to a loopback server which deliberately kept response bodies open. At the exact moment `broker.acquire()` completed, the tests inspected both the server-side active response set and live TCP socket set.
+
+## Target result
+
+All tested terminal paths returned their normalized broker result with zero active responses and zero live sockets:
+
+| Response path | Normalized result | Resource state at completion |
+| --- | --- | --- |
+| 301, 302, 307, 308 | `redirect_rejected` | 0 active responses, 0 live sockets |
+| 401, 403 | `provider_auth_rejected` | 0 active responses, 0 live sockets |
+| 408 | `provider_timeout` | 0 active responses, 0 live sockets |
+| 429 | `provider_rate_limited` | 0 active responses, 0 live sockets |
+| 418, 422 | `provider_request_rejected` | 0 active responses, 0 live sockets |
+| 500, 503 | `provider_unavailable` | 0 active responses, 0 live sockets |
+| Wrong content type | `unexpected_content_type` | 0 active responses, 0 live sockets |
+| Declared or streamed oversized body | `response_too_large` | 0 active responses, 0 live sockets |
+| Malformed bounded JSON | `malformed_json` | 0 active responses, 0 live sockets, deadline cleared |
+| Valid bounded JSON | `fresh` API snapshot | 0 active responses, 0 live sockets, deadline cleared |
+| Indefinitely streaming success body | `request_timeout` | 0 active responses, 0 live sockets, deadline cleared |
+
+Command:
+
+```sh
+pnpm vitest run tests/kimi-quota-broker.test.ts --reporter=verbose
+```
+
+Relevant runner output:
+
+```text
+PASS closes an indefinitely streaming HTTP 301/302/307/308 response before acquire completes
+PASS closes an indefinitely streaming HTTP 401/403/408/429 response before acquire completes
+PASS closes an indefinitely streaming HTTP 418/422/500/503 response before acquire completes
+PASS closes the socket for an unexpected content type before acquire completes
+PASS closes the socket for declared and streamed oversized bodies before acquire completes
+PASS finishes bounded malformed and valid JSON with no live body, socket, or deadline timer
+PASS closes an indefinitely streaming success body and clears its timer when the deadline expires
+```
+
+## Base negative control
+
+The target regression test file was run unchanged against the base broker implementation in an isolated, transient fixture. It failed 14 cleanup cases. The base returned the correct normalized result but still had one active response at the moment the broker completed:
+
+```text
+AssertionError: expected 1 to be +0
+
+- Expected
++ Received
+
+- 0
++ 1
+
+tests/kimi-quota-broker.test.ts:371
+expect(transport.activeResponsesAtCompletion).toBe(0)
+```
+
+Affected negative-control cases were all indefinitely streaming 301, 302, 307, 308, 401, 403, 408, 429, 418, 422, 500, and 503 responses, wrong content type, and deadline expiry.
+
+## Compatibility checks
+
+The fake-credential product path from the official CLI resolver through the host broker, extension capability, and widget still passes. Pi-first precedence, cancellation during Pi resolution, fallback rules, and secret confinement checks also pass. These checks use synthetic credentials only.
+
+```sh
+pnpm vitest run tests/e2e-kimi-cli-quota.test.ts tests/kimi-code-cli-credential-resolver.test.ts --reporter=verbose
+```

--- a/src/main/kimi-quota-broker.ts
+++ b/src/main/kimi-quota-broker.ts
@@ -146,10 +146,15 @@ export function createKimiQuotaBroker(options: CreateKimiQuotaBrokerOptions): Ki
       timeout.unref?.();
     });
 
+    const attemptPromise = attempt(controller.signal);
     let result: KimiQuotaResult;
     try {
-      result = await Promise.race([attempt(controller.signal), deadline]);
+      result = await Promise.race([attemptPromise, deadline]);
     } catch (error) {
+      // Abort and drain the attempt so response-body cleanup always finishes before
+      // acquire is considered complete, even when the deadline wins the race first.
+      if (!controller.signal.aborted) controller.abort();
+      await attemptPromise.catch(() => undefined);
       const failure = error instanceof KimiAcquisitionFailure
         ? error
         : new KimiAcquisitionFailure(deadlineReached || error instanceof KimiDeadlineError ? "request_timeout" : classifyTransportError(error));
@@ -164,9 +169,15 @@ export function createKimiQuotaBroker(options: CreateKimiQuotaBrokerOptions): Ki
   const attempt = async (signal: AbortSignal): Promise<KimiQuotaResult> => {
     let credential: KimiCredentialResolution;
     try {
-      credential = await options.credentialResolver.resolveCredential(signal);
-    } catch {
+      // Race against abort so a hung resolver that ignores AbortSignal cannot pin
+      // acquire after the deadline (and so body-drain on timeout always completes).
+      credential = await Promise.race([
+        options.credentialResolver.resolveCredential(signal),
+        abortRejection(signal),
+      ]);
+    } catch (error) {
       throwIfAborted(signal);
+      if (error instanceof KimiAcquisitionFailure) throw error;
       throw new KimiAcquisitionFailure("credential_resolution_failed");
     }
     throwIfAborted(signal);
@@ -203,67 +214,13 @@ export function createKimiQuotaBroker(options: CreateKimiQuotaBrokerOptions): Ki
       throw failure(classifyTransportError(error));
     }
 
-    emit({ event: "request_completed", httpStatus: response.status });
-    if (response.status >= 300 && response.status < 400) {
-      throw failure("redirect_rejected", response.status);
-    }
-    if (response.status === 401 || response.status === 403) {
-      throw failure("provider_auth_rejected", response.status);
-    }
-    if (response.status === 408) throw failure("provider_timeout", response.status);
-    if (response.status === 429) {
-      throw failure("provider_rate_limited", response.status, parseRetryAfter(response.headers.get("retry-after"), now()));
-    }
-    if (response.status >= 500 && response.status <= 599) {
-      throw failure("provider_unavailable", response.status);
-    }
-    if (response.status >= 400 && response.status <= 499) {
-      throw failure("provider_request_rejected", response.status);
-    }
-    if (response.status !== 200) throw failure("provider_request_rejected", response.status);
-
-    const mediaType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
-    if (mediaType !== "application/json") throw failure("unexpected_content_type", response.status);
-    const declaredLength = response.headers.get("content-length");
-    if (declaredLength && /^\d+$/.test(declaredLength.trim()) && Number(declaredLength) > RESPONSE_LIMIT_BYTES) {
+    // One lifecycle rule: every terminal path cancels/closes the response body so a
+    // malicious or broken endpoint cannot keep streaming after the broker settles.
+    try {
+      return await consumeQuotaResponse(response, signal, credentialSource, failure, emit, now);
+    } finally {
       await cancelBody(response);
-      throw failure("response_too_large", response.status);
     }
-
-    let body: Uint8Array;
-    try {
-      body = await readBoundedBody(response, signal);
-    } catch (error) {
-      if (error instanceof KimiAcquisitionFailure) {
-        throw failure(error.code, error.httpStatus, error.retryAt);
-      }
-      if (signal.aborted) throw failure("request_timeout");
-      throw failure(classifyTransportError(error));
-    }
-
-    let text: string;
-    try {
-      text = new TextDecoder("utf-8", { fatal: true }).decode(body);
-    } catch {
-      throw failure("response_invalid_utf8", response.status);
-    }
-
-    let payload: unknown;
-    try {
-      payload = JSON.parse(text);
-    } catch {
-      throw failure("malformed_json", response.status);
-    }
-
-    let snapshot: KimiQuotaSnapshot;
-    try {
-      snapshot = normalizeKimiUsage(payload, new Date(now()).toISOString(), credentialSource);
-    } catch (error) {
-      emit({ event: "normalization_failed", code: error instanceof KimiQuotaParseError ? error.code : "schema_invalid" });
-      throw failure("schema_invalid", response.status);
-    }
-    emit({ event: "normalization_succeeded", windowIds: snapshot.windows.map((window) => window.id) });
-    return freshResult(snapshot, snapshot.refreshedAt);
   };
 
   return {
@@ -272,11 +229,99 @@ export function createKimiQuotaBroker(options: CreateKimiQuotaBrokerOptions): Ki
   };
 }
 
+type KimiFailureFactory = (code: KimiQuotaErrorCode, httpStatus?: number, retryAt?: string) => KimiAcquisitionFailure;
+
+async function consumeQuotaResponse(
+  response: Response,
+  signal: AbortSignal,
+  credentialSource: KimiCredentialSource,
+  failure: KimiFailureFactory,
+  emit: (event: KimiQuotaLogEvent) => void,
+  now: () => number,
+): Promise<KimiQuotaResult> {
+  emit({ event: "request_completed", httpStatus: response.status });
+  if (response.status >= 300 && response.status < 400) {
+    throw failure("redirect_rejected", response.status);
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw failure("provider_auth_rejected", response.status);
+  }
+  if (response.status === 408) throw failure("provider_timeout", response.status);
+  if (response.status === 429) {
+    throw failure("provider_rate_limited", response.status, parseRetryAfter(response.headers.get("retry-after"), now()));
+  }
+  if (response.status >= 500 && response.status <= 599) {
+    throw failure("provider_unavailable", response.status);
+  }
+  if (response.status >= 400 && response.status <= 499) {
+    throw failure("provider_request_rejected", response.status);
+  }
+  if (response.status !== 200) throw failure("provider_request_rejected", response.status);
+
+  const mediaType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType !== "application/json") throw failure("unexpected_content_type", response.status);
+  const declaredLength = response.headers.get("content-length");
+  if (declaredLength && /^\d+$/.test(declaredLength.trim()) && Number(declaredLength) > RESPONSE_LIMIT_BYTES) {
+    throw failure("response_too_large", response.status);
+  }
+
+  let body: Uint8Array;
+  try {
+    body = await readBoundedBody(response, signal);
+    // Abort during a hanging read may cancel the stream as an empty body; prefer timeout
+    // over treating that cancelled empty payload as a parse failure.
+    throwIfAborted(signal);
+  } catch (error) {
+    if (error instanceof KimiAcquisitionFailure) {
+      throw failure(error.code, error.httpStatus, error.retryAt);
+    }
+    if (signal.aborted) throw failure("request_timeout");
+    throw failure(classifyTransportError(error));
+  }
+
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw failure("response_invalid_utf8", response.status);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    throw failure("malformed_json", response.status);
+  }
+
+  let snapshot: KimiQuotaSnapshot;
+  try {
+    snapshot = normalizeKimiUsage(payload, new Date(now()).toISOString(), credentialSource);
+  } catch (error) {
+    emit({ event: "normalization_failed", code: error instanceof KimiQuotaParseError ? error.code : "schema_invalid" });
+    throw failure("schema_invalid", response.status);
+  }
+  emit({ event: "normalization_succeeded", windowIds: snapshot.windows.map((window) => window.id) });
+  return freshResult(snapshot, snapshot.refreshedAt);
+}
+
 async function readBoundedBody(response: Response, signal: AbortSignal): Promise<Uint8Array> {
   if (!response.body) return new Uint8Array();
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  // Abort must cancel through the locked reader; response.body.cancel() throws while locked
+  // and a pending reader.read() would otherwise hang past the broker deadline.
+  const onAbort = (): void => {
+    void reader.cancel(signal.reason).catch(() => undefined);
+  };
+  if (signal.aborted) {
+    try {
+      await reader.cancel(signal.reason);
+    } catch {
+      // Already closed.
+    }
+    throw new KimiAcquisitionFailure("request_timeout");
+  }
+  signal.addEventListener("abort", onAbort, { once: true });
   try {
     while (true) {
       throwIfAborted(signal);
@@ -285,13 +330,24 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
       if (!value) continue;
       total += value.byteLength;
       if (total > RESPONSE_LIMIT_BYTES) {
-        await reader.cancel().catch(() => undefined);
         throw new KimiAcquisitionFailure("response_too_large", response.status);
       }
       chunks.push(value);
     }
   } finally {
-    reader.releaseLock();
+    signal.removeEventListener("abort", onAbort);
+    // Cancel through the locked reader so abort/error paths release the socket even when
+    // response.body.cancel() would throw TypeError on a locked stream.
+    try {
+      await reader.cancel();
+    } catch {
+      // Stream may already be closed or released.
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // cancel() may already have released the lock.
+    }
   }
 
   const body = new Uint8Array(total);
@@ -302,15 +358,20 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
   }
   return body;
 }
-
 async function cancelBody(response: Response): Promise<void> {
   try {
-    await response.body?.cancel();
+    const body = response.body;
+    if (!body) return;
+    // Prefer cancelling when unlocked; if a reader still holds the lock, release is
+    // handled by readBoundedBody's finally. Double-cancel after unlock is a no-op.
+    if (!body.locked) {
+      await body.cancel();
+      return;
+    }
   } catch {
-    // Size rejection is authoritative even if cancelling the stream fails.
+    // Terminal result is authoritative even if cancelling the stream fails.
   }
 }
-
 function applyCachePolicy(
   db: ExtensionDatabase,
   current: KimiQuotaResult,
@@ -457,6 +518,21 @@ function throwIfAborted(signal: AbortSignal): void {
   if (signal.aborted) throw new KimiAcquisitionFailure("request_timeout");
 }
 
+function abortRejection(signal: AbortSignal): Promise<never> {
+  return new Promise((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new KimiAcquisitionFailure("request_timeout"));
+      return;
+    }
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(new KimiAcquisitionFailure("request_timeout"));
+      },
+      { once: true },
+    );
+  });
+}
 function normalizeUserAgent(value: string | undefined): string {
   const candidate = value?.trim();
   return candidate && /^[A-Za-z][A-Za-z0-9._-]*\/[A-Za-z0-9._-]+$/.test(candidate) ? candidate : "baby-menu/unknown";

--- a/src/main/kimi-quota-broker.ts
+++ b/src/main/kimi-quota-broker.ts
@@ -308,10 +308,11 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
+  let abortCancellation: Promise<void> | undefined;
   // Abort must cancel through the locked reader; response.body.cancel() throws while locked
   // and a pending reader.read() would otherwise hang past the broker deadline.
   const onAbort = (): void => {
-    void reader.cancel(signal.reason).catch(() => undefined);
+    abortCancellation ??= reader.cancel(signal.reason).catch(() => undefined);
   };
   if (signal.aborted) {
     try {
@@ -339,7 +340,7 @@ async function readBoundedBody(response: Response, signal: AbortSignal): Promise
     // Cancel through the locked reader so abort/error paths release the socket even when
     // response.body.cancel() would throw TypeError on a locked stream.
     try {
-      await reader.cancel();
+      await (abortCancellation ?? reader.cancel());
     } catch {
       // Stream may already be closed or released.
     }

--- a/tests/kimi-quota-broker.test.ts
+++ b/tests/kimi-quota-broker.test.ts
@@ -51,7 +51,7 @@ function allCacheBytes(db: ExtensionDatabase): string {
 type LoopbackResponse = {
   status?: number;
   headers?: Record<string, string>;
-  chunks?: Array<string | Uint8Array>;
+  chunks?: ReadonlyArray<string | Uint8Array>;
   keepOpen?: boolean;
 };
 

--- a/tests/kimi-quota-broker.test.ts
+++ b/tests/kimi-quota-broker.test.ts
@@ -236,6 +236,141 @@ describe("Kimi quota broker transport and privacy", () => {
     expect(JSON.stringify(result)).not.toContain(SYNTHETIC_KEY);
   });
 
+  /**
+   * Negative control: body stays open forever unless the broker cancels it.
+   * Proves early terminal paths release the response body before acquire settles.
+   */
+  function indefinitelyOpenBody() {
+    let live = true;
+    const cancel = vi.fn((_reason?: unknown) => {
+      live = false;
+    });
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // Intentionally never enqueue, close, or error - body stays open until cancel.
+      },
+      cancel(reason) {
+        cancel(reason);
+      },
+    });
+    return {
+      stream,
+      cancel,
+      isLive: () => live,
+    };
+  }
+  it.each([
+    [301, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
+    [302, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
+    [307, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
+    [308, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
+    [401, "provider_auth_rejected", "auth_required", {}],
+    [403, "provider_auth_rejected", "auth_required", {}],
+    [408, "provider_timeout", "error", {}],
+    [429, "provider_rate_limited", "rate_limited", { "retry-after": "12" }],
+    [418, "provider_request_rejected", "error", {}],
+    [422, "provider_request_rejected", "error", {}],
+    [500, "provider_unavailable", "error", {}],
+    [503, "provider_unavailable", "error", {}],
+  ] as const)(
+    "cancels indefinitely open body for HTTP %s before acquire completes",
+    async (httpStatus, code, status, headers) => {
+      const open = indefinitelyOpenBody();
+      const result = await broker({
+        fetch: vi.fn(async () => new Response(open.stream, { status: httpStatus, headers })),
+      }).acquire({ force: true });
+
+      expect(result).toMatchObject({ status, error: { code, httpStatus } });
+      expect(open.cancel).toHaveBeenCalled();
+      expect(open.isLive()).toBe(false);
+    },
+  );
+
+  it("cancels indefinitely open body for unexpected content type", async () => {
+    const open = indefinitelyOpenBody();
+    const result = await broker({
+      fetch: vi.fn(async () => new Response(open.stream, {
+        status: 200,
+        headers: { "content-type": "text/plain" },
+      })),
+    }).acquire({ force: true });
+
+    expect(result).toMatchObject({ status: "error", error: { code: "unexpected_content_type", httpStatus: 200 } });
+    expect(open.cancel).toHaveBeenCalled();
+    expect(open.isLive()).toBe(false);
+  });
+
+  it("cancels indefinitely open body for declared oversized content-length", async () => {
+    const open = indefinitelyOpenBody();
+    const result = await broker({
+      fetch: vi.fn(async () => new Response(open.stream, {
+        status: 200,
+        headers: { "content-type": "application/json", "content-length": "262145" },
+      })),
+    }).acquire({ force: true });
+
+    expect(result).toMatchObject({ status: "error", error: { code: "response_too_large", httpStatus: 200 } });
+    expect(open.cancel).toHaveBeenCalled();
+    expect(open.isLive()).toBe(false);
+  });
+
+  it("cancels body and settles when the deadline expires during an open stream", async () => {
+    const open = indefinitelyOpenBody();
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (signal) {
+        const onAbort = () => {
+          void open.stream.cancel(signal.reason).catch(() => undefined);
+        };
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      }
+      return new Response(open.stream, { status: 200, headers: { "content-type": "application/json" } });
+    });
+
+    const result = await broker({ fetch: fetchMock, timeoutMs: 25 }).acquire({ force: true });
+
+    expect(result).toMatchObject({ status: "error", error: { code: "request_timeout", category: "transport" } });
+    expect(open.cancel).toHaveBeenCalled();
+    expect(open.isLive()).toBe(false);
+  });
+
+  it("releases the body after a successful bounded JSON parse", async () => {
+    const encoder = new TextEncoder();
+    const payload = encoder.encode(JSON.stringify(validPayload()));
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(payload);
+        controller.close();
+      },
+    });
+
+    const result = await broker({
+      fetch: vi.fn(async () => new Response(stream, { status: 200, headers: { "content-type": "application/json" } })),
+    }).acquire({ force: true });
+
+    expect(result).toMatchObject({ status: "fresh", stale: false, source: "api" });
+    // Fully consumed (and lifecycle-cancelled) streams must not remain locked or open for further reads.
+    expect(stream.locked).toBe(false);
+    await expect(stream.getReader().read()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("cancels the body when a streamed success payload exceeds the byte bound", async () => {
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(180_000));
+        controller.enqueue(new Uint8Array(100_000));
+      },
+      cancel,
+    });
+    const result = await broker({
+      fetch: vi.fn(async () => new Response(stream, { headers: { "content-type": "application/json" } })),
+    }).acquire({ force: true });
+    expect(result.error?.code).toBe("response_too_large");
+    expect(cancel).toHaveBeenCalled();
+  });
+
   it.each([
     ["73", "2026-07-19T12:01:13.000Z"],
     ["Sun, 19 Jul 2026 12:04:00 GMT", "2026-07-19T12:04:00.000Z"],

--- a/tests/kimi-quota-broker.test.ts
+++ b/tests/kimi-quota-broker.test.ts
@@ -1,3 +1,6 @@
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Socket } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createKimiCredentialResolverChain } from "../src/main/kimi-code-cli-credential-resolver";
 import { createExtensionDatabase, type ExtensionDatabase } from "../src/main/extension-database";
@@ -43,6 +46,112 @@ function resolver(overrides: Partial<KimiCredentialResolver> = {}): KimiCredenti
 
 function allCacheBytes(db: ExtensionDatabase): string {
   return JSON.stringify(db.query("SELECT key, value, updated_at FROM kimi_quota_cache ORDER BY key"));
+}
+
+type LoopbackResponse = {
+  status?: number;
+  headers?: Record<string, string>;
+  chunks?: Array<string | Uint8Array>;
+  keepOpen?: boolean;
+};
+
+async function throughLoopback<T>(
+  response: LoopbackResponse,
+  run: (fetchImpl: typeof fetch) => Promise<T>,
+): Promise<{
+  value: T;
+  requestedUrl: string;
+  activeResponsesAtCompletion: number;
+  liveSocketsAtCompletion: number;
+}> {
+  const sockets = new Set<Socket>();
+  const activeResponses = new Set<ServerResponse>();
+  const transportClosedWaiters = new Set<() => void>();
+  let requestedUrl = "";
+  const settleTransportClosed = (): void => {
+    if (sockets.size > 0 || activeResponses.size > 0) return;
+    for (const resolve of transportClosedWaiters) resolve();
+    transportClosedWaiters.clear();
+  };
+  const waitForTransportClosed = (): Promise<void> => {
+    if (sockets.size === 0 && activeResponses.size === 0) return Promise.resolve();
+    return new Promise((resolve) => transportClosedWaiters.add(resolve));
+  };
+  const server = createServer((_request, serverResponse) => {
+    activeResponses.add(serverResponse);
+    serverResponse.once("close", () => {
+      activeResponses.delete(serverResponse);
+      settleTransportClosed();
+    });
+    serverResponse.writeHead(response.status ?? 200, {
+      connection: "close",
+      ...response.headers,
+    });
+    serverResponse.flushHeaders();
+    for (const chunk of response.chunks ?? []) serverResponse.write(chunk);
+    if (!response.keepOpen) serverResponse.end();
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => {
+      sockets.delete(socket);
+      settleTransportClosed();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+
+  try {
+    const address = server.address() as AddressInfo;
+    const fetchImpl: typeof fetch = async (input, init) => {
+      requestedUrl = String(input);
+      const { signal: _signal, ...upstreamInit } = init ?? {};
+      const upstream = await fetch(`http://127.0.0.1:${address.port}/coding/v1/usages`, upstreamInit);
+      if (!upstream.body) return upstream;
+      const reader = upstream.body.getReader();
+      const body = new ReadableStream<Uint8Array>({
+        async pull(controller) {
+          const chunk = await reader.read();
+          if (chunk.done) {
+            await waitForTransportClosed();
+            controller.close();
+          } else {
+            controller.enqueue(chunk.value);
+          }
+        },
+        async cancel(reason) {
+          try {
+            await reader.cancel(reason);
+          } finally {
+            await waitForTransportClosed();
+          }
+        },
+      });
+      return new Response(body, {
+        status: upstream.status,
+        statusText: upstream.statusText,
+        headers: upstream.headers,
+      });
+    };
+    let activeResponsesAtCompletion = -1;
+    let liveSocketsAtCompletion = -1;
+    const value = await run(fetchImpl).then((completed) => {
+      activeResponsesAtCompletion = activeResponses.size;
+      liveSocketsAtCompletion = sockets.size;
+      return completed;
+    });
+    return { value, requestedUrl, activeResponsesAtCompletion, liveSocketsAtCompletion };
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
 }
 
 describe("Kimi quota broker transport and privacy", () => {
@@ -236,29 +345,6 @@ describe("Kimi quota broker transport and privacy", () => {
     expect(JSON.stringify(result)).not.toContain(SYNTHETIC_KEY);
   });
 
-  /**
-   * Negative control: body stays open forever unless the broker cancels it.
-   * Proves early terminal paths release the response body before acquire settles.
-   */
-  function indefinitelyOpenBody() {
-    let live = true;
-    const cancel = vi.fn((_reason?: unknown) => {
-      live = false;
-    });
-    const stream = new ReadableStream<Uint8Array>({
-      start() {
-        // Intentionally never enqueue, close, or error - body stays open until cancel.
-      },
-      cancel(reason) {
-        cancel(reason);
-      },
-    });
-    return {
-      stream,
-      cancel,
-      isLive: () => live,
-    };
-  }
   it.each([
     [301, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
     [302, "redirect_rejected", "error", { location: "https://elsewhere.invalid/" }],
@@ -273,102 +359,69 @@ describe("Kimi quota broker transport and privacy", () => {
     [500, "provider_unavailable", "error", {}],
     [503, "provider_unavailable", "error", {}],
   ] as const)(
-    "cancels indefinitely open body for HTTP %s before acquire completes",
+    "closes an indefinitely streaming HTTP %s response before acquire completes",
     async (httpStatus, code, status, headers) => {
-      const open = indefinitelyOpenBody();
-      const result = await broker({
-        fetch: vi.fn(async () => new Response(open.stream, { status: httpStatus, headers })),
-      }).acquire({ force: true });
+      const transport = await throughLoopback(
+        { status: httpStatus, headers, chunks: ["still streaming"], keepOpen: true },
+        (fetchImpl) => broker({ fetch: fetchImpl }).acquire({ force: true }),
+      );
 
-      expect(result).toMatchObject({ status, error: { code, httpStatus } });
-      expect(open.cancel).toHaveBeenCalled();
-      expect(open.isLive()).toBe(false);
+      expect(transport.value).toMatchObject({ status, error: { code, httpStatus } });
+      expect(transport.requestedUrl).toBe("https://api.kimi.com/coding/v1/usages");
+      expect(transport.activeResponsesAtCompletion).toBe(0);
+      expect(transport.liveSocketsAtCompletion).toBe(0);
     },
   );
 
-  it("cancels indefinitely open body for unexpected content type", async () => {
-    const open = indefinitelyOpenBody();
-    const result = await broker({
-      fetch: vi.fn(async () => new Response(open.stream, {
-        status: 200,
-        headers: { "content-type": "text/plain" },
-      })),
-    }).acquire({ force: true });
+  it.each([
+    ["unexpected content type", { headers: { "content-type": "text/plain" }, chunks: ["still streaming"], keepOpen: true }, "unexpected_content_type"],
+    ["declared oversized body", { headers: { "content-type": "application/json", "content-length": "262145" }, keepOpen: true }, "response_too_large"],
+    ["streamed oversized body", { headers: { "content-type": "application/json" }, chunks: [new Uint8Array(262_145)], keepOpen: true }, "response_too_large"],
+  ] as const)("closes the socket for an %s before acquire completes", async (_label, response, code) => {
+    const transport = await throughLoopback(response, (fetchImpl) => broker({ fetch: fetchImpl }).acquire({ force: true }));
 
-    expect(result).toMatchObject({ status: "error", error: { code: "unexpected_content_type", httpStatus: 200 } });
-    expect(open.cancel).toHaveBeenCalled();
-    expect(open.isLive()).toBe(false);
+    expect(transport.value).toMatchObject({ status: "error", error: { code, httpStatus: 200 } });
+    expect(transport.requestedUrl).toBe("https://api.kimi.com/coding/v1/usages");
+    expect(transport.activeResponsesAtCompletion).toBe(0);
+    expect(transport.liveSocketsAtCompletion).toBe(0);
   });
 
-  it("cancels indefinitely open body for declared oversized content-length", async () => {
-    const open = indefinitelyOpenBody();
-    const result = await broker({
-      fetch: vi.fn(async () => new Response(open.stream, {
-        status: 200,
-        headers: { "content-type": "application/json", "content-length": "262145" },
-      })),
-    }).acquire({ force: true });
+  it.each([
+    ["malformed", "{broken", "malformed_json"],
+    ["valid", JSON.stringify(validPayload()), undefined],
+  ] as const)("finishes a bounded %s JSON response with no live body, socket, or deadline timer", async (_label, body, code) => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const transport = await throughLoopback(
+      { headers: { "content-type": "application/json" }, chunks: [body] },
+      (fetchImpl) => broker({ fetch: fetchImpl, timeoutMs: 2_000 }).acquire({ force: true }),
+    );
+    const deadlineCall = setTimeoutSpy.mock.calls.findIndex((call) => call[1] === 2_000);
+    const deadlineTimer = setTimeoutSpy.mock.results[deadlineCall]?.value;
 
-    expect(result).toMatchObject({ status: "error", error: { code: "response_too_large", httpStatus: 200 } });
-    expect(open.cancel).toHaveBeenCalled();
-    expect(open.isLive()).toBe(false);
+    if (code) expect(transport.value).toMatchObject({ status: "error", error: { code, httpStatus: 200 } });
+    else expect(transport.value).toMatchObject({ status: "fresh", stale: false, source: "api" });
+    expect(transport.activeResponsesAtCompletion).toBe(0);
+    expect(transport.liveSocketsAtCompletion).toBe(0);
+    expect(deadlineCall).toBeGreaterThanOrEqual(0);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(deadlineTimer);
   });
 
-  it("cancels body and settles when the deadline expires during an open stream", async () => {
-    const open = indefinitelyOpenBody();
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const signal = init?.signal;
-      if (signal) {
-        const onAbort = () => {
-          void open.stream.cancel(signal.reason).catch(() => undefined);
-        };
-        if (signal.aborted) onAbort();
-        else signal.addEventListener("abort", onAbort, { once: true });
-      }
-      return new Response(open.stream, { status: 200, headers: { "content-type": "application/json" } });
-    });
+  it("closes an indefinitely streaming success body and clears its timer when the deadline expires", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const transport = await throughLoopback(
+      { headers: { "content-type": "application/json" }, chunks: ["{"], keepOpen: true },
+      (fetchImpl) => broker({ fetch: fetchImpl, timeoutMs: 25 }).acquire({ force: true }),
+    );
+    const deadlineCall = setTimeoutSpy.mock.calls.findIndex((call) => call[1] === 25);
+    const deadlineTimer = setTimeoutSpy.mock.results[deadlineCall]?.value;
 
-    const result = await broker({ fetch: fetchMock, timeoutMs: 25 }).acquire({ force: true });
-
-    expect(result).toMatchObject({ status: "error", error: { code: "request_timeout", category: "transport" } });
-    expect(open.cancel).toHaveBeenCalled();
-    expect(open.isLive()).toBe(false);
-  });
-
-  it("releases the body after a successful bounded JSON parse", async () => {
-    const encoder = new TextEncoder();
-    const payload = encoder.encode(JSON.stringify(validPayload()));
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(payload);
-        controller.close();
-      },
-    });
-
-    const result = await broker({
-      fetch: vi.fn(async () => new Response(stream, { status: 200, headers: { "content-type": "application/json" } })),
-    }).acquire({ force: true });
-
-    expect(result).toMatchObject({ status: "fresh", stale: false, source: "api" });
-    // Fully consumed (and lifecycle-cancelled) streams must not remain locked or open for further reads.
-    expect(stream.locked).toBe(false);
-    await expect(stream.getReader().read()).resolves.toEqual({ done: true, value: undefined });
-  });
-
-  it("cancels the body when a streamed success payload exceeds the byte bound", async () => {
-    const cancel = vi.fn();
-    const stream = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(180_000));
-        controller.enqueue(new Uint8Array(100_000));
-      },
-      cancel,
-    });
-    const result = await broker({
-      fetch: vi.fn(async () => new Response(stream, { headers: { "content-type": "application/json" } })),
-    }).acquire({ force: true });
-    expect(result.error?.code).toBe("response_too_large");
-    expect(cancel).toHaveBeenCalled();
+    expect(transport.value).toMatchObject({ status: "error", error: { code: "request_timeout", category: "transport" } });
+    expect(transport.activeResponsesAtCompletion).toBe(0);
+    expect(transport.liveSocketsAtCompletion).toBe(0);
+    expect(deadlineCall).toBeGreaterThanOrEqual(0);
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(deadlineTimer);
   });
 
   it.each([


### PR DESCRIPTION
## Intent

Fix the Baby Menu Kimi quota broker's unbounded response-body/socket lifetime before release. Pre-release audit found that src/main/kimi-quota-broker.ts returns immediately for redirects, 401, 408, 429, other 4xx/5xx statuses, and wrong content types without cancelling the response body; cleanup then clears the 15-second deadline so a malicious or broken endpoint can keep streaming and leave the socket/body alive without a bound. Release PR #81 must remain unmerged until this is corrected.

Reproduce via the real broker boundary with controlled local transport: return each affected status/content-type while keeping the body open indefinitely, and prove the broker result returns while the body/socket remains live (then fix so cleanup happens). Implement one centralized lifecycle rule that closes or cancels every response body on every terminal path without weakening fixed-origin, redirect refusal, byte/time bounds, Pi-first credential precedence, cancellation propagation (PR #86), or secret confinement.

Acceptance: redirects, 401/408/429, other 4xx/5xx, wrong content type, malformed/oversized success bodies, caller cancellation, and deadline expiry all deterministically cancel/close the body before the broker is complete; successful bounded JSON parsing leaves no live body/timer/socket; regression tests fail on the old code and assert normalized result plus resource cleanup including indefinitely streaming body negative control; no live Kimi credentials; keep fixed GET https://api.kimi.com/coding/v1/usages. Keep the diff narrowly focused on response lifecycle correctness. Do not touch or merge release PR #81.

## What Changed

- Centralize Kimi quota response handling so bodies are canceled and transport cleanup completes across HTTP errors, invalid responses, oversized payloads, cancellation, deadlines, and successful parsing.
- Add controlled loopback transport regression coverage that verifies open response bodies and sockets close before acquisition completes, while deadline timers are cleared.

## Risk Assessment

✅ Low: The narrowly scoped change now centralizes response cleanup, awaits abort-owned cancellation work, and adds loopback HTTP coverage proving body, socket, and deadline-timer cleanup while preserving the fixed production request boundary.

## Testing

The full suite passed after focused real-boundary checks covered redirects, provider errors, wrong content type, malformed and oversized bodies, deadline expiry, successful JSON, fixed URL, Pi-first cancellation, fallback, and secret confinement. The base negative control left one response live in 14 cases, while the target reached zero active responses and sockets before completion. A non-TTY pnpm setup attempt for the temporary base fixture was replaced with direct Vitest execution; no live credentials or provider traffic were used.

- Evidence: [Kimi response lifecycle validation report](https://github.com/kunchenguid/baby-menu/blob/36b9fc99da6b82fbe584203609a1c76c58230e5a/.no-mistakes/evidence/fm/baby-menu-kimi-response-cancel-f1/kimi-response-lifecycle.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/kimi-quota-broker.test.ts:243` - The required reproduction says to use the “real broker boundary with controlled local transport” and assert socket/body cleanup. These tests use a mocked fetch returning in-memory ReadableStreams, so no HTTP socket exists; the success case also verifies only stream EOF/unlocking, not timer/socket cleanup, and malformed bodies have no cleanup assertion. Add a controlled local HTTP transport that keeps each affected response open and proves body, socket, and timer cleanup before broker completion.

🔧 Fix: Prove and await Kimi transport cleanup
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 9c0a970dca92b86e1275add9213aeb20eeda1780..2aef344ada45583a293aa663deac6c167a1c838b`</code>
- `pnpm vitest run tests/kimi-quota-broker.test.ts --reporter=verbose`
- <code>Ran the target regression test unchanged against an isolated archive of base commit `9c0a970dca92b86e1275add9213aeb20eeda1780` using `node node_modules/vitest/vitest.mjs run --root .no-mistakes/base-negative-control tests/kimi-quota-broker.test.ts --reporter=verbose`</code>
- `pnpm vitest run tests/e2e-kimi-cli-quota.test.ts tests/kimi-code-cli-credential-resolver.test.ts --reporter=verbose`
- `pnpm test`
- <code>Removed the transient `.no-mistakes/base-negative-control/` fixture and verified only the dedicated evidence artifact remains untracked</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
