### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-baby-menu-r1/body-compliance-event-replay.md
+++ b/.no-mistakes/evidence/fm/nm-body-events-baby-menu-r1/body-compliance-event-replay.md
@@ -1,0 +1,53 @@
+# PR body compliance event replay
+
+Target: `40c8967cdb780d2e766690b4c65bd27794f10133`  
+Base: `77be90c0a0daa7387371e6c314df48cde0352e3c`
+
+## End-user event replay
+
+The shell script below was extracted directly from the workflow's
+`Verify no-mistakes signature in PR body` step and executed for three body
+events on the same simulated PR head.
+
+```text
+Same-head PR #42 body-event replay using the workflow real shell step
+event=701 run=91001 action=opened group=no-mistakes-required-42-91001 terminal=SUCCESS
+  Found no-mistakes signature in PR #42 body.
+event=702 run=91002 action=edited group=no-mistakes-required-42-91002 terminal=FAILURE
+  ::error::This PR was not raised through no-mistakes.
+event=703 run=91003 action=edited group=no-mistakes-required-42-91003 terminal=SUCCESS
+  Found no-mistakes signature in PR #42 body.
+Replay result: PASS - all three independently grouped events reached expected terminal outcomes (success/failure/success).
+```
+
+This demonstrates the intended user-visible sequence: a signed opened event
+passes, an unsigned edited event fails, and a later signed edited event passes.
+Each event has its own immutable run-ID concurrency group, so none can replace
+or cancel another pending body event.
+
+## Preservation matrix
+
+| Invariant | Observed workflow behavior |
+| --- | --- |
+| Opened event isolation | `no-mistakes-required-42-91001` |
+| First edited event isolation | `no-mistakes-required-42-91002` |
+| Second edited event isolation | `no-mistakes-required-42-91003` |
+| Synchronize coalescing | `no-mistakes-required-42-head-change` |
+| Reopened coalescing | `no-mistakes-required-42-head-change` |
+| Fork security boundary | `pull_request` with `contents: read` |
+| Cancellation policy | `cancel-in-progress: true` |
+| Stable check name | `PR must be raised via no-mistakes` |
+| Signature policy | Canonical `Updates from [git push no-mistakes]...` marker unchanged |
+| Bot exemptions | GitHub Actions, Dependabot, and release-please exemptions unchanged |
+| Run identity | PR number, action, monotonic run number, and immutable run ID in `run-name` |
+
+An exact base-to-target comparison also passed after removing the canonical
+`run-name` addition and the documented concurrency-group replacement. This
+confirms the workflow job, trigger set, permissions, signature step, bot
+exemptions, and repository-specific behavior were otherwise unchanged.
+
+## Why there is no screenshot
+
+This change controls GitHub Actions scheduling and terminal check outcomes. It
+does not alter a rendered application surface. The transcript above is the
+product-level artifact for the behavior reviewers need to verify.


### PR DESCRIPTION
## Intent

Implement the captain-authorized PR-body compliance-event policy from kunchenguid/no-mistakes#558 in baby-menu. Apply only the exact two-hunk workflow change: add the canonical run-name and isolate every opened or edited event with github.run_id while preserving synchronize/reopened head-change coalescing, cancel-in-progress, the pull_request read-only fork boundary, stable check name, signature marker, bot exemptions, and all unrelated repository-specific behavior. Keep the PR minimal, title it 'fix: execute every PR body compliance event', validate the required event replay and preservation invariants, and stop at one green unmerged PR.

## What Changed

- Add a canonical workflow run name containing the PR, action, run number, and immutable run ID.
- Isolate every `opened` and `edited` body-compliance event by `github.run_id`, while preserving coalescing for `synchronize` and `reopened` head changes.
- Document the signed, unsigned, and re-signed event replay plus the preserved workflow invariants.

## Risk Assessment

✅ Low: The minimal two-hunk workflow change matches the canonical policy and preserves event triggers, head-change coalescing, cancellation, permissions, check identity, signature validation, and bot exemptions.

## Testing

No pre-supplied baseline results were available. Focused diff inspection and direct execution of the real workflow step demonstrated terminal success/failure/success for all three same-head body events, distinct immutable groups for opened/edited events, preserved synchronize/reopened coalescing, and unchanged security and signature invariants. Reviewer-visible transcript evidence was recorded; no screenshot was captured because this scheduling-only workflow change has no rendered UI.

- Evidence: [Three-event PR body compliance replay and preservation matrix](https://github.com/kunchenguid/baby-menu/blob/3bd1b94860e77d88a6ddf324c23d66d9e8d7c1f3/.no-mistakes/evidence/fm/nm-body-events-baby-menu-r1/body-compliance-event-replay.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 77be90c0a0daa7387371e6c314df48cde0352e3c..40c8967cdb780d2e766690b4c65bd27794f10133` and full workflow diff inspection</code>
- `Compared the target workflow with the base after removing the two authorized policy additions, confirming all unrelated behavior remained identical`
- `Extracted and executed the workflow’s real signature-check shell step for signed opened, unsigned edited, and re-signed edited events on the same simulated PR head`
- `Replayed concurrency-key evaluation for opened, edited, synchronize, and reopened events`
- <code>Verified the fork-safe `pull_request` boundary, `contents: read`, stable check name, signature marker, bot exemptions, `cancel-in-progress: true`, and event identity fields</code>
- <code>Inspected the authoritative `kunchenguid/no-mistakes#558` policy and confirmed target commit subject `fix: execute every PR body compliance event`</code>
- <code>Checked the remote branch PR state with `gh-axi pr list --repo kunchenguid/baby-menu --head fm/nm-body-events-baby-menu-r1`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
