### PR TITLE
Windows port milestone 1: platform-safe PATH, adapter launch, .cmd spawn, tree kill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,39 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+  windows:
+    # Headless Windows runtime foundation coverage. This proves the TypeScript
+    # compiles, the three app bundles build, and the new platform-safe units
+    # (PATH, adapter-launch quoting, PATHEXT/.cmd spawn, process-tree
+    # cancellation, pnpm.cmd dev launcher) pass on a real Windows host. The full
+    # test suite is intentionally NOT run here: many specs execute /bin/bash,
+    # /bin/sh, or Unix-only fixtures and skip on win32 - porting that suite is
+    # tracked separately. See docs/windows-port-validation.md.
+    name: windows / typecheck / build / platform units
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.1.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Platform-safe unit tests
+        run: pnpm vitest run tests/shell-path.test.ts tests/launch-command.test.ts tests/platform-spawn.test.ts tests/process-tree.test.ts tests/dev-launcher.test.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,17 @@ When files did change, the renderer summarizes one changed extension, multiple c
 Packaged runtime state lives under `~/.baby-menu` and is not git-backed.
 Do not write generated extension files, the local extension database, compiled modules, preferences, logs, snapshots, or ACP session state into the `.app` bundle.
 
+### Platform services (macOS and Windows)
+
+The app is a macOS tray app today, but its platform-adjacent seams are factored into platform-aware helpers so a Windows port preserves the Electron architecture instead of forking it. Keep these seams narrow and tested on both platforms:
+
+- `src/main/shell-path.ts` - PATH expansion for a GUI launch. POSIX-only merge of common Unix directories + the login-shell PATH; on Windows it returns the inherited PATH unchanged (no Unix delimiter/directory corruption). Never append Unix syntax on `win32`.
+- `src/main/launch-command.ts` - builds acpx registry-override command strings. acpx's override is a single **string** that acpx reparses with its own `splitCommandLine` (which strips backslashes inside double quotes); `quoteLaunchToken`/`joinLaunchCommand` produce parser-safe strings (forward-slash normalization on Windows), and `splitAcpxCommand` is a faithful port of the pinned acpx parser used by tests to prove round-trips. `buildAdapterLauncherTokens` scopes `ELECTRON_RUN_AS_NODE` to the adapter child via an `env` prefix on POSIX; on Windows the env prefix is omitted (there is no `env` command and acpx cannot inject env via the string).
+- `src/adapters/shared/platform-spawn.ts` - `resolveDriverCommand` (PATHEXT-aware) + `driverSpawnOptions` (`shell: true` for `.cmd`/`.bat`) so the claude/codex drivers spawn native Windows shims. Resolution uses the `node:path` win32 module so it is correct regardless of the host running it (and deterministic on a non-Windows CI host).
+- `src/adapters/shared/process-tree.ts` - `createChildTerminator` keeps exact POSIX `SIGTERM`->`SIGKILL` behavior and, on Windows, runs a bounded `taskkill /T /F /PID <pid>` with a numeric pid (no shell interpolation). Both adapter drivers cancel and dispose through it.
+
+The Windows port status, the exact remaining clean-Windows validation steps (bundled-adapter `ELECTRON_RUN_AS_NODE` delivery via a launcher, real `.cmd` cancellation, `shell: true` + prompt-as-argv hardening), and what this milestone deliberately does not claim are documented in `docs/windows-port-validation.md`. The roadmap is the feasibility report at `data/baby-menu-windows-scout/report.md`.
+
 ### Recipes and extensions
 
 - Recipes are HTML files in `recipes/` inside the active extension workspace. `recipe-loader.ts` discovers `*.html`, sorts them, and extracts the title from `<title>` or first `<h1>`. They are intentionally HTML so the embedded agent can read them from its cwd and use embedded interactive demos.

--- a/docs/windows-port-validation.md
+++ b/docs/windows-port-validation.md
@@ -1,0 +1,137 @@
+# Windows port: current state and remaining validation
+
+This document records what the **first Windows-port milestone** (PR) implements,
+what it deliberately proves, and - crucially - what it does **not** claim to
+prove, because those proofs require a real Windows host that is not available in
+the development environment. It is the honest companion to the spike work; treat
+anything in this list marked "needs clean-Windows validation" as **not yet
+shipped for Windows**, even though the host-side plumbing is in place.
+
+The roadmap source of truth is the feasibility report at
+`data/baby-menu-windows-scout/report.md` (outside the repo copy); the staged
+plan there is authoritative. This document only covers the first milestone.
+
+## What this milestone implements and validates automatically
+
+All of the following are covered by automated tests that pass on the current
+host and on the `windows-latest` CI job added in `.github/workflows/ci.yml`:
+
+1. **Platform-safe PATH handling** (`src/main/shell-path.ts`)
+   - `mergeShellPath` no longer appends Unix directories or a `:` delimiter on
+     Windows; it returns the inherited PATH unchanged (Windows already inherits
+     the merged system+user PATH from the registry). Regression test in
+     `tests/shell-path.test.ts` covers the final-entry-corruption defect,
+     multiple drive letters, and preserved POSIX behavior.
+
+2. **Correctly-quoted bundled-adapter launch path** (`src/main/launch-command.ts`)
+   - `quoteLaunchToken` / `joinLaunchCommand` build a launch-command string that
+     round-trips through acpx's own `splitCommandLine` parser for Windows
+     install paths containing spaces, backslashes, `&`, parentheses, and
+     non-ASCII text. Backslashes are normalized to forward slashes
+     (parser-safe and Windows-usable by `spawn`/`fs`/acpx).
+   - `splitAcpxCommand` is a faithful port of the pinned acpx parser, exported
+     so tests prove the constructed string reparses into the exact intended
+     tokens - without needing a Windows host. Covered by
+     `tests/launch-command.test.ts`, including the confirmed backslash-stripping
+     defect as a regression anchor.
+
+3. **PATHEXT / `.cmd`-aware native agent launching** (`src/adapters/shared/platform-spawn.ts`)
+   - `resolveDriverCommand` resolves a bare command to its `.cmd` shim via
+     PATHEXT and PATH search (mirrors acpx's own resolution); `driverSpawnOptions`
+     sets `shell: true` for `.cmd`/`.bat` shims so Node can launch them. Both
+     drivers (`claude`, `codex`) now resolve and spawn through these helpers.
+     Covered by `tests/platform-spawn.test.ts`.
+
+4. **Bounded Windows process-tree cancellation** (`src/adapters/shared/process-tree.ts`)
+   - `createChildTerminator` keeps the exact POSIX `SIGTERM` -> `SIGKILL` behavior
+     (so existing driver tests are unchanged) and, on Windows, runs
+     `taskkill /T /F /PID <pid>` with a numeric pid (no shell interpolation of
+     untrusted text). Both drivers cancel and dispose through the terminator.
+     Covered by `tests/process-tree.test.ts`.
+
+5. **`pnpm.cmd`-safe dev launcher** (`scripts/dev.mjs`)
+   - Package-manager invocations run through `shell: true` so `pnpm.cmd` resolves
+     on Windows. Covered by `tests/dev-launcher.test.ts`.
+
+6. **Windows CI** (`.github/workflows/ci.yml`, `windows` job)
+   - Runs `pnpm typecheck`, `pnpm build`, and the five platform-portable test
+     files above on `windows-latest`.
+
+## What this milestone does NOT prove (needs clean-Windows validation)
+
+These items require a real, packaged Windows runtime and are the documented
+remaining steps for the full port. The spike intentionally does not pretend they
+passed.
+
+### A. Delivering `ELECTRON_RUN_AS_NODE` to the bundled adapter on Windows
+
+On POSIX, `buildAdapterLauncherTokens` scopes `ELECTRON_RUN_AS_NODE=1` to the
+adapter child via a leading `env KEY=VALUE` prefix in the command string. There
+is no `env` command on Windows, and acpx's registry override is a single command
+**string** that acpx reparses - it has no structured `{ executable, args, env }`
+surface and it builds the child environment from the host's `process.env`
+(plus auth), so env cannot be injected through the command string either.
+
+Consequence: on Windows, `buildAdapterLauncherTokens` omits the env and the
+launch command is just `<executable> <adapter-path>` (correctly quoted). The
+command string is correct, but running the bundled Electron binary as Node
+requires the env var, which means a small launcher is needed.
+
+**Remaining clean-Windows validation step (report Milestone 0):**
+1. Author a minimal Windows launcher (a `.cmd` shim that sets
+   `ELECTRON_RUN_AS_NODE=1` and execs the bundled Electron with the adapter
+   path, OR a tiny signed executable), pointed at by `buildAdapterLauncherTokens`
+   on `win32`.
+2. On a clean Windows 11 x64 VM, build a temporary packaged Electron app under a
+   `C:\Program Files\...` path with spaces/non-ASCII, and prove
+   Electron-as-Node launches one bundled ACP adapter with the env set safely and
+   ACP stdout uncontaminated.
+3. Prove `splitAcpxCommand` of the produced `launchCommand` reparses to the exact
+   launcher + adapter tokens (extend `tests/launch-command.test.ts`).
+
+Do not claim the Windows adapter launch works until this passes on a real
+packaged install. Setting `ELECTRON_RUN_AS_NODE` globally in the Electron main
+process was considered and rejected as too broad: it would propagate to every
+host child (git, taskkill probes, background-task shells) even though most ignore
+it, and it could not be validated here.
+
+### B. Real `.cmd` cancellation leaves zero descendants
+
+`taskkill /T /F /PID <pid>` is the correct, bounded tree kill, but its
+effectiveness against a real `claude.cmd`/`codex.cmd` shim and the CLI's tool
+children must be observed on Windows.
+
+**Remaining clean-Windows validation step:**
+1. On the clean VM, drive one real prompt through each adapter and cancel/timeout
+   it mid-turn.
+2. Assert no `claude*`, `codex*`, `node`, or tool-process descendant survives
+   (e.g. via `tasklist` after the turn settles).
+
+### C. `shell: true` + prompt-as-argv hardening
+
+The drivers pass the user prompt as a trailing positional argv
+(`claude -p <prompt>`, `codex exec <prompt>`). On Windows, `.cmd` shims require
+`shell: true`, under which Node's argv quoting is not fully injection-proof
+against cmd.exe metacharacters (`&`, `|`, `%`). This is a pre-existing driver
+design surfaced by the Windows port.
+
+**Remaining hardening step (full port):** move prompt delivery off the argv
+(over stdin, mirroring how acpx itself carries prompts), or sanitize/quoting-
+harden the prompt path. Out of scope for this first milestone; flagged here so it
+is not lost.
+
+### D. The broader test suite on Windows
+
+The `windows` CI job intentionally runs only the five platform-portable unit
+files. Many other specs execute `/bin/bash`/`/bin/sh`, rely on Unix fixtures
+(shebangs, `chmod`, symlinks), or are explicitly `skipIf(win32)`. Porting the
+core ACP/change-session e2e to Windows (removing the win32 skips in
+`tests/e2e-acp-runtime.test.ts`) is report Milestone 1's exit criterion and is
+not done here.
+
+### E. Out of scope for this milestone entirely
+
+Per the task scope, none of the following are in this PR: tray polish/assets,
+`.ico`, AppUserModelID, single-instance lock, NSIS installer, Authenticode
+signing, update copy, recipe platform-filtering/parity, or any greenfield
+rewrite. See the report's staged plan (Milestones 2-5).

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -13,6 +13,11 @@ function commandStatus(result) {
   return typeof result.status === "number" ? result.status : 1;
 }
 
+// pnpm is `pnpm.cmd` on Windows; Node cannot spawn a `.cmd`/`.bat` without a
+// shell, so package-manager invocations run through a shell on every platform
+// (harmless on POSIX, required on Windows).
+const SPAWN_SHELL = { shell: true };
+
 function gitRoot(cwd, execFileSyncFn) {
   return String(execFileSyncFn("git", ["rev-parse", "--show-toplevel"], { cwd })).trim();
 }
@@ -43,7 +48,7 @@ export function runDev({
   cpSync: cpSyncFn = cpSync,
 } = {}) {
   if (env[ACTIVE_ENV] === "1") {
-    return commandStatus(spawnSyncFn("pnpm", ["exec", "electron-vite", "dev"], { cwd, env, stdio: "inherit" }));
+    return commandStatus(spawnSyncFn("pnpm", ["exec", "electron-vite", "dev"], { cwd, env, stdio: "inherit", ...SPAWN_SHELL }));
   }
 
   const rootDir = gitRoot(cwd, execFileSyncFn);
@@ -62,6 +67,7 @@ export function runDev({
         [EXTENSIONS_DIR_ENV]: devExtensionsDir,
       },
       stdio: "inherit",
+      ...SPAWN_SHELL,
     }),
   );
 }

--- a/src/adapters/claude/driver.ts
+++ b/src/adapters/claude/driver.ts
@@ -4,6 +4,8 @@ import { AdapterTurnError, type SessionDriver, type UpdateSink } from "../shared
 import { LineReader } from "../shared/line-reader.js";
 import { logDebug, logError } from "../shared/log.js";
 import { childEnv } from "../shared/child-env.js";
+import { resolveDriverCommand, driverSpawnOptions } from "../shared/platform-spawn.js";
+import { createChildTerminator } from "../shared/process-tree.js";
 import { mapClaudeEvent, type ClaudeEvent } from "./mapper.js";
 
 const SCOPE = "claude-adapter";
@@ -75,8 +77,19 @@ export class ClaudeDriver implements SessionDriver {
       : ["-p", ...flags, text];
 
     logDebug(SCOPE, "spawn", this.command, this.sessionId ? "(resume)" : "(new)");
-    const child = spawn(this.command, args, { cwd, stdio: ["pipe", "pipe", "pipe"], env: childEnv() });
+    // On Windows the agent CLI is usually a `.cmd` shim; resolveDriverCommand
+    // applies PATHEXT and driverSpawnOptions sets `shell: true` for `.cmd`/`.bat`
+    // so Node can launch it. All other platforms (and Windows `.exe`) spawn
+    // directly, keeping signal-based termination exact.
+    const command = resolveDriverCommand(this.command);
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: childEnv(),
+      ...driverSpawnOptions(this.command),
+    });
     this.child = child;
+    const terminator = createChildTerminator(child);
     // claude reads stdin until EOF before producing output; the prompt is passed
     // as an arg, so close stdin immediately.
     child.stdin.end();
@@ -114,8 +127,8 @@ export class ClaudeDriver implements SessionDriver {
         if (settled || cancelled) return;
         cancelled = true;
         logDebug(SCOPE, "cancel: killing claude");
-        child.kill("SIGTERM");
-        forceKillTimer = setTimeout(() => child.kill("SIGKILL"), TERMINATION_GRACE_MS);
+        terminator.terminate();
+        forceKillTimer = setTimeout(() => terminator.force(), TERMINATION_GRACE_MS);
       };
       this.activeCancel = onAbort;
 
@@ -175,7 +188,7 @@ export class ClaudeDriver implements SessionDriver {
       return;
     }
     if (this.child) {
-      this.child.kill("SIGTERM");
+      createChildTerminator(this.child).terminate();
     }
   }
 }

--- a/src/adapters/codex/driver.ts
+++ b/src/adapters/codex/driver.ts
@@ -4,6 +4,8 @@ import { AdapterTurnError, type SessionDriver, type UpdateSink } from "../shared
 import { LineReader } from "../shared/line-reader.js";
 import { logDebug, logError } from "../shared/log.js";
 import { childEnv } from "../shared/child-env.js";
+import { resolveDriverCommand, driverSpawnOptions } from "../shared/platform-spawn.js";
+import { createChildTerminator } from "../shared/process-tree.js";
 import { mapCodexEvent, type CodexExecEvent } from "./mapper.js";
 
 const SCOPE = "codex-adapter";
@@ -80,10 +82,21 @@ export class CodexDriver implements SessionDriver {
       : ["exec", ...common, "--color", "never", text];
 
     logDebug(SCOPE, "spawn", this.command, args.slice(0, -1).join(" "), "<prompt>");
+    // On Windows the agent CLI is usually a `.cmd` shim; resolveDriverCommand
+    // applies PATHEXT and driverSpawnOptions sets `shell: true` for `.cmd`/`.bat`
+    // so Node can launch it. All other platforms (and Windows `.exe`) spawn
+    // directly, keeping signal-based termination exact.
+    const command = resolveDriverCommand(this.command);
     // codex exec takes the prompt as an arg and ignores stdin, but we pipe all
     // three streams so the handle types as ChildProcessWithoutNullStreams.
-    const child = spawn(this.command, args, { cwd, stdio: ["pipe", "pipe", "pipe"], env: childEnv() });
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: childEnv(),
+      ...driverSpawnOptions(this.command),
+    });
     this.child = child;
+    const terminator = createChildTerminator(child);
     // Close stdin immediately: codex exec reads stdin to EOF before finishing,
     // so leaving the pipe open makes it hang (and exit non-zero on teardown).
     child.stdin.end();
@@ -121,8 +134,8 @@ export class CodexDriver implements SessionDriver {
         if (settled || cancelled) return;
         cancelled = true;
         logDebug(SCOPE, "cancel: killing codex exec");
-        child.kill("SIGTERM");
-        forceKillTimer = setTimeout(() => child.kill("SIGKILL"), TERMINATION_GRACE_MS);
+        terminator.terminate();
+        forceKillTimer = setTimeout(() => terminator.force(), TERMINATION_GRACE_MS);
       };
       this.activeCancel = onAbort;
 
@@ -191,7 +204,7 @@ export class CodexDriver implements SessionDriver {
       return;
     }
     if (this.child) {
-      this.child.kill("SIGTERM");
+      createChildTerminator(this.child).terminate();
     }
   }
 }

--- a/src/adapters/shared/platform-spawn.ts
+++ b/src/adapters/shared/platform-spawn.ts
@@ -1,0 +1,91 @@
+// Windows-aware spawning for the bundled adapter drivers.
+//
+// The claude/codex drivers spawn the real CLI by bare name (`claude`/`codex`).
+// On Windows an npm global install is almost always a `claude.cmd`/`codex.cmd`
+// shim, and Node cannot launch a `.cmd`/`.bat` without a shell (since
+// CVE-2024-27980, Node rejects `.bat`/`.cmd` spawns without `shell: true`).
+// acpx already handles this for ITS spawns; these helpers give the drivers the
+// same PATHEXT-aware resolution and `.cmd` shell selection.
+import { existsSync } from "node:fs";
+import { win32 as win32Path } from "node:path";
+
+export type ResolveCommandOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  /** Injectable for tests; defaults to fs.existsSync. */
+  existsSync?: (path: string) => boolean;
+};
+
+const DEFAULT_PATHEXT = ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC";
+
+function readEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const matchedKey = Object.keys(env).find((entry) => entry.toUpperCase() === key.toUpperCase());
+  return matchedKey ? env[matchedKey] : undefined;
+}
+
+function pathextCandidates(command: string, env: NodeJS.ProcessEnv): string[] {
+  const extensions =
+    (readEnvValue(env, "PATHEXT") ?? DEFAULT_PATHEXT)
+      .split(";")
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0);
+  return win32Path.extname(command).length > 0 ? [command] : extensions.map((extension) => `${command}${extension}`);
+}
+
+/**
+ * Resolves a bare command to a launchable path on Windows using PATHEXT, mirroring
+ * acpx's `resolveWindowsCommand`. On POSIX the command is returned unchanged
+ * (spawn resolves it via the inherited PATH). Returns the original command when
+ * nothing is found so spawn surfaces the real ENOENT instead of a silent skip.
+ */
+export function resolveDriverCommand(command: string, options: ResolveCommandOptions = {}): string {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return command;
+
+  const env = options.env ?? process.env;
+  const exists = options.existsSync ?? existsSync;
+  // Resolution is FOR Windows, so use the win32 path module (backslash joins,
+  // drive-letter isAbsolute) regardless of the host running this code. This
+  // also keeps the unit tests deterministic on a non-Windows CI host.
+  const win = win32Path;
+  const candidates =
+    win.extname(command).length > 0 ? [command] : pathextCandidates(command, env);
+
+  if (win.isAbsolute(command) || command.includes("/") || command.includes("\\")) {
+    return candidates.find((candidate) => exists(candidate)) ?? command;
+  }
+
+  const pathValue = readEnvValue(env, "PATH");
+  if (!pathValue) return command;
+  for (const directory of pathValue.split(";")) {
+    const trimmed = directory.trim();
+    if (trimmed.length === 0) continue;
+    for (const candidate of candidates) {
+      const resolved = win.join(trimmed, candidate);
+      if (exists(resolved)) return resolved;
+    }
+  }
+  return command;
+}
+
+export type DriverSpawnOptionsResult = {
+  /** Set to true so Node launches a .cmd/.bat shim through cmd.exe on Windows. */
+  shell?: boolean;
+};
+
+/**
+ * Returns the spawn options needed to launch `command` on the current platform.
+ * `.cmd`/`.bat` shims require `shell: true` on Windows; everything else (native
+ * `.exe`, the bundled Electron, and all POSIX commands) spawns directly so the
+ * process-tree terminator and signal handling stay exact.
+ */
+export function driverSpawnOptions(
+  command: string,
+  options: { platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv; existsSync?: (path: string) => boolean } = {},
+): DriverSpawnOptionsResult {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") return {};
+  const resolved = resolveDriverCommand(command, options);
+  const ext = win32Path.extname(resolved).toLowerCase();
+  return ext === ".cmd" || ext === ".bat" ? { shell: true } : {};
+}

--- a/src/adapters/shared/process-tree.ts
+++ b/src/adapters/shared/process-tree.ts
@@ -1,0 +1,90 @@
+// Bounded, platform-aware child-process termination for the bundled adapter drivers.
+//
+// The drivers cancel a running CLI turn with SIGTERM, then SIGKILL after a grace
+// period. That works on POSIX, where the signal reaches the process and the
+// adapter CLIs install handlers. On Windows:
+//   - Node's `child.kill("SIGTERM")` maps to TerminateProcess on the IMMEDIATE
+//     child only; it is not graceful and it does not reach descendants.
+//   - npm `claude.cmd`/`codex.cmd` shims spawn the real CLI (and its tool
+//     children) as descendants, so killing the shim leaves the agent alive.
+//
+// `taskkill /T /F /PID <pid>` is the bounded, injection-safe tree kill: `/T`
+// terminates the whole process tree under the pid, `/F` forces it (console CLIs
+// have no graceful WM_CLOSE path), and the pid is always a number emitted by
+// `String(child.pid)` so no untrusted text reaches the shell. `shell: false`
+// (the spawn default) keeps taskkill.exe launched directly, not via cmd.exe.
+
+import { spawnSync, type ChildProcess, type SpawnSyncReturns } from "node:child_process";
+
+export type TerminationStrategy = "posix-signals" | "windows-taskkill";
+
+/** The slowest acceptable grace between a soft and a hard termination, in ms. */
+export const TERMINATION_GRACE_MS = 1000;
+
+export function selectTerminationStrategy(platform: NodeJS.Platform = process.platform): TerminationStrategy {
+  return platform === "win32" ? "windows-taskkill" : "posix-signals";
+}
+
+/** Minimal child handle the terminator needs (works for real and fake children). */
+export type TerminableChild = Pick<ChildProcess, "pid" | "kill">;
+
+export type ChildTerminator = {
+  /** Request termination. On POSIX sends SIGTERM; on Windows runs a bounded tree kill. */
+  terminate(): void;
+  /** Force termination after the grace period (POSIX SIGKILL; Windows repeats the tree kill). */
+  force(): void;
+};
+
+export type TaskkillResult = Pick<SpawnSyncReturns<unknown>, "status">;
+
+export type CreateTerminatorOptions = {
+  strategy?: TerminationStrategy;
+  /**
+   * Runs `taskkill` with the given args. Injectable so tests can capture the args
+   * without a real Windows host. Defaults to `spawnSync("taskkill", args,
+   * { windowsHide: true, shell: false })`.
+   */
+  runTaskkill?: (args: string[]) => TaskkillResult;
+};
+
+/** Builds the `taskkill` argv for a bounded, injection-safe process-tree kill. */
+export function taskkillArgs(pid: number): string[] {
+  return ["/PID", String(pid), "/T", "/F"];
+}
+
+/**
+ * Creates a platform-aware terminator for a single child. POSIX behavior is
+ * byte-for-byte the historical `child.kill("SIGTERM")` then `child.kill("SIGKILL")`,
+ * so existing driver cancellation/disposal tests are unchanged. Windows routes
+ * through `taskkill /T /F /PID <pid>` so the whole CLI tree is torn down.
+ */
+export function createChildTerminator(child: TerminableChild, options: CreateTerminatorOptions = {}): ChildTerminator {
+  const strategy = options.strategy ?? selectTerminationStrategy();
+
+  if (strategy === "windows-taskkill") {
+    const runTaskkill =
+      options.runTaskkill ??
+      ((args: string[]) => spawnSync("taskkill", args, { windowsHide: true, shell: false }) as TaskkillResult);
+    const killTree = (): void => {
+      if (child.pid == null) return;
+      runTaskkill(taskkillArgs(child.pid));
+    };
+    return {
+      // Console CLI trees have no graceful-shutdown path on Windows, so the soft
+      // and hard attempts are the same bounded `/T /F` kill. force() still runs
+      // after the grace period as a safety net in case the first attempt raced
+      // a late-spawned descendant.
+      terminate: killTree,
+      force: killTree,
+    };
+  }
+
+  return {
+    terminate: () => {
+      child.kill("SIGTERM");
+    },
+    force: () => {
+      child.kill("SIGKILL");
+    },
+  };
+}

--- a/src/main/agent-catalog-controller.ts
+++ b/src/main/agent-catalog-controller.ts
@@ -19,6 +19,8 @@ export type AgentCatalogControllerOptions = {
   agentsJsonPath: string;
   resolveAdapterPath: (adapter: "claude" | "codex") => string;
   adapterLauncher: string[];
+  /** Platform to build launch commands for; defaults to process.platform. */
+  platform?: NodeJS.Platform;
   commandExists: (command: string) => boolean;
   /** The currently selected agent name; removal of the active agent is refused. */
   getActiveAgentName: () => string;
@@ -53,6 +55,7 @@ export function createAgentCatalogController(options: AgentCatalogControllerOpti
       resolveAgentCatalog({ config: customs }),
       options.resolveAdapterPath,
       options.adapterLauncher,
+      { platform: options.platform },
     );
     overrides = agentRegistryOverrides(catalog);
   }

--- a/src/main/agent-catalog.ts
+++ b/src/main/agent-catalog.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import type { BabyMenuCustomAgentInput } from "../shared/contracts";
+import { joinLaunchCommand } from "./launch-command";
 
 export type AgentDefinition = {
   /** acpx agent name and registry key. */
@@ -138,26 +139,28 @@ export function resolveAgentCatalog(options: ResolveAgentCatalogOptions = {}): A
  * `resolveAdapterPath("claude")` returns the absolute path to the adapter's
  * bundled entry; the host resolves it differently in dev vs packaged mode.
  * `launcher` is the command + leading args that run the adapter as a Node
- * program (e.g. `["node"]`, or `["env", "ELECTRON_RUN_AS_NODE=1", electronPath]`
+ * program (e.g. `["node"]`, or `buildAdapterLauncherTokens({ executable, env })`
  * to run the bundled Electron as Node without depending on a separate install).
  * Agents that already carry an explicit `launchCommand` (custom agents) are left
  * untouched.
+ *
+ * The resulting string is built with `joinLaunchCommand`, which quotes each
+ * token so acpx's `splitCommandLine` reparses it verbatim on every platform -
+ * including Windows install paths containing spaces, backslashes, `&`,
+ * parentheses, and non-ASCII characters (see launch-command.ts).
  */
 export function withAdapterLaunchCommands(
   catalog: readonly AgentDefinition[],
   resolveAdapterPath: (adapter: "claude" | "codex") => string,
   launcher: string[] = ["node"],
+  options: { platform?: NodeJS.Platform } = {},
 ): AgentDefinition[] {
+  const platform = options.platform ?? process.platform;
   return catalog.map((agent) => {
     if (!agent.adapter || agent.launchCommand) return { ...agent };
     const adapterPath = resolveAdapterPath(agent.adapter);
-    return { ...agent, launchCommand: shellJoin([...launcher, adapterPath]) };
+    return { ...agent, launchCommand: joinLaunchCommand([...launcher, adapterPath], platform) };
   });
-}
-
-/** Joins command tokens into a single string, quoting tokens with whitespace. */
-function shellJoin(tokens: string[]): string {
-  return tokens.map((token) => (/\s/.test(token) ? `"${token}"` : token)).join(" ");
 }
 
 export function toAgentOptions(

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -23,6 +23,7 @@ import { createPreferencesService } from "./preferences";
 import { createBackgroundTaskSource, createServerActionRegistry } from "./server-action-registry";
 import { getDefaultTelemetry, initDefaultTelemetry } from "./telemetry";
 import { expandProcessPathForGuiLaunch } from "./shell-path";
+import { buildAdapterLauncherTokens } from "./launch-command";
 import { createUpdateChecker } from "./update-checker";
 import { createBabyMenuTray, type BabyMenuTray } from "./tray";
 import { createLayoutModuleRegistry, createWidgetModuleRegistry } from "./widget-module-registry";
@@ -186,7 +187,14 @@ export async function startBabyMenuApp(): Promise<void> {
   // adapters. Run them with the bundled Electron as Node (ELECTRON_RUN_AS_NODE)
   // so there is no dependency on a separately-installed `node` - the same class
   // of PATH fragility that made the agent look "unavailable" before.
-  const adapterLauncher = ["env", "ELECTRON_RUN_AS_NODE=1", process.execPath];
+  // buildAdapterLauncherTokens scopes that env var to the child on POSIX via a
+  // leading `env` prefix. On Windows there is no `env` command, so the token is
+  // the executable only and `ELECTRON_RUN_AS_NODE` delivery is a documented
+  // clean-Windows validation step (a launcher); see launch-command.ts.
+  const adapterLauncher = buildAdapterLauncherTokens({
+    executable: process.execPath,
+    env: { ELECTRON_RUN_AS_NODE: "1" },
+  });
   // The catalog is a live runtime service: it owns agents.json and pushes
   // rebuilt registry overrides into the runtime so UI-added custom agents apply
   // immediately. agentRuntime is referenced through closures (assigned just below)

--- a/src/main/launch-command.ts
+++ b/src/main/launch-command.ts
@@ -1,0 +1,140 @@
+// Command-string construction for acpx registry overrides.
+//
+// acpx (pinned 0.7.0) consumes each agent's launch command as a SINGLE STRING
+// (`Record<agentName, string>`), then reparses it with its own `splitCommandLine`
+// state machine (node_modules/acpx/dist/prompt-turn-*.js) into `{ command, args }`
+// before spawning. That parser:
+//   - splits tokens on whitespace outside quotes,
+//   - treats `\` as an escape character UNLESS inside single quotes (so `\\` -> `\`
+//     and `\x` -> `x` inside double quotes, which strips every backslash from a
+//     quoted `C:\Program Files\...` path),
+//   - preserves everything literally inside single quotes.
+// There is no structured `{ executable, args, env }` override surface, so the only
+// way to carry a Windows install path (spaces, backslashes, `&`, parens, non-ASCII)
+// through to the spawn is to build a string this parser round-trips exactly.
+//
+// `splitAcpxCommand` below is a faithful port of that parser. It is exported so
+// tests can PROVE a constructed command string reparses into the exact tokens the
+// host intended - without needing a Windows host or a packaged runtime. Keep it in
+// lockstep with the pinned acpx parser.
+
+/** Splits a value on the configured delimiter, tolerating an empty string. */
+function splitOn(value: string, delimiter: string): string[] {
+  return value.length === 0 ? [] : value.split(delimiter);
+}
+
+/**
+ * Faithful port of acpx@0.7.0's `splitCommandLine`. Throws on an unterminated
+ * quote or an empty command, matching acpx exactly, so a misconstructed launch
+ * string fails loudly here instead of launching the wrong executable.
+ */
+export function splitAcpxCommand(value: string): { command: string; args: string[] } {
+  const parts: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let escaping = false;
+  for (const ch of value) {
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (escaping) current += "\\";
+  if (quote) throw new Error("Invalid --agent command: unterminated quote");
+  if (current.length > 0) parts.push(current);
+  if (parts.length === 0) throw new Error("Invalid --agent command: empty command");
+  return { command: parts[0]!, args: parts.slice(1) };
+}
+
+/** True when a token contains a character acpx's parser would treat specially. */
+function needsQuoting(token: string): boolean {
+  return /[\s"'\\]/.test(token);
+}
+
+/**
+ * Quotes a single command token so `splitAcpxCommand` reparses it to the exact
+ * original value. Bare tokens (no whitespace/quote/backslash) are returned as-is,
+ * which is why POSIX macOS paths without those characters stay unquoted and the
+ * existing macOS launch strings are byte-identical.
+ *
+ * Windows paths contain backslashes, which acpx strips inside double quotes.
+ * Rather than escape every backslash (`\\`), Windows backslashes are normalized
+ * to forward slashes first: Node `spawn`, `fs.existsSync`, and acpx's own PATHEXT
+ * resolution (`path.extname` + `fs.existsSync`) all accept forward slashes on
+ * Windows, and forward slashes have no escaping meaning to the parser.
+ */
+export function quoteLaunchToken(token: string, platform: NodeJS.Platform = process.platform): string {
+  if (platform === "win32") {
+    const normalized = token.replace(/\\/g, "/");
+    if (!needsQuoting(normalized)) return normalized;
+    // Inside double quotes the parser drops a `\` that precedes any char, so a
+    // literal `"` is emitted as `\"` (parser keeps the `"`). There are no other
+    // backslashes to escape because normalization already removed them.
+    return `"${normalized.replace(/"/g, '\\"')}"`;
+  }
+  if (!needsQuoting(token)) return token;
+  // POSIX: double-quote and escape `\` -> `\\` and `"` -> `\"` so the token
+  // round-trips through the parser verbatim.
+  return `"${token.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/** Joins command tokens into a single launch-command string, quoting each token as needed. */
+export function joinLaunchCommand(tokens: readonly string[], platform: NodeJS.Platform = process.platform): string {
+  return tokens.map((token) => quoteLaunchToken(token, platform)).join(" ");
+}
+
+export type AdapterLauncherSpec = {
+  /** Executable that runs the bundled adapter as a Node program (node, or the bundled Electron). */
+  executable: string;
+  /**
+   * Environment to scope to the adapter child. On POSIX this is delivered as a
+   * leading `env KEY=VALUE ...` prefix in the command string. Windows has no
+   * `env` command and acpx cannot inject env via the command string, so on
+   * Windows the env is omitted here and delivering `ELECTRON_RUN_AS_NODE` (to
+   * run the bundled Electron as Node) requires a Windows launcher - a documented
+   * clean-Windows validation step, not something this string can carry.
+   */
+  env?: Record<string, string>;
+  /** Platform to build for; defaults to process.platform. */
+  platform?: NodeJS.Platform;
+};
+
+/**
+ * Builds the prefix tokens that run the bundled adapter as a Node program.
+ *
+ * POSIX: `["env", "KEY=VALUE", ..., executable]` - the historical, proven
+ *   Electron-as-Node wiring that scopes `ELECTRON_RUN_AS_NODE` to the child.
+ * Windows: `[executable]` - the env prefix is dropped (no `env` command); the
+ *   command string still carries the executable + adapter path correctly quoted,
+ *   but `ELECTRON_RUN_AS_NODE` delivery needs the launcher (see AdapterLauncherSpec.env).
+ */
+export function buildAdapterLauncherTokens(spec: AdapterLauncherSpec): string[] {
+  const platform = spec.platform ?? process.platform;
+  const envEntries = spec.env ? Object.entries(spec.env).map(([key, value]) => `${key}=${value}`) : [];
+  if (platform === "win32") {
+    return [spec.executable];
+  }
+  return [...(envEntries.length > 0 ? ["env"] : []), ...envEntries, spec.executable];
+}

--- a/src/main/shell-path.ts
+++ b/src/main/shell-path.ts
@@ -1,26 +1,72 @@
-import { spawnSync } from "node:child_process";
+import { delimiter } from "node:path";
 import { homedir } from "node:os";
+import { spawnSync } from "node:child_process";
 
 type MergeShellPathOptions = {
+  /** Current PATH value to merge into. Defaults to process.env.PATH. */
   currentPath?: string;
+  /** Home directory used for `~/.local/bin`. Defaults to os.homedir(). */
   homeDir?: string;
+  /** Extra PATH captured from a login shell (macOS/Linux only). */
   shellPath?: string;
+  /** Platform to merge for; defaults to process.platform. */
+  platform?: NodeJS.Platform;
+  /** PATH delimiter (`:` POSIX / `;` Windows). Defaults to path.delimiter. */
+  pathDelimiter?: string;
 };
 
+// GUI-launched apps on macOS receive a minimal PATH (often just /usr/bin:/bin),
+// so the bundled agent CLIs (Homebrew, ~/.local/bin, asdf, etc.) are invisible.
+// These common Unix directories are appended so a tray-launched app still finds
+// `claude`/`codex`. They must never be merged on Windows: Windows uses `;`, a
+// different set of directories, and a trailing `:`-delimited segment silently
+// corrupts the final real PATH entry (see tests/shell-path.test.ts).
 const COMMON_GUI_PATHS = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
 
+/**
+ * Builds a PATH that lets a GUI-launched app find the bundled agent CLIs.
+ *
+ * POSIX (darwin/linux): appends the common Unix GUI directories, the user's
+ * `~/.local/bin`, and any PATH captured from a login shell, then de-duplicates
+ * while preserving order. This is the historical behavior.
+ *
+ * Windows: the inherited PATH is returned unchanged. A GUI-launched Win32 app
+ * already inherits the merged system+user PATH from the registry, and merging
+ * Unix directories or a Unix delimiter would corrupt the final usable entry.
+ * If a future packaged GUI launch proves a user/machine PATH merge is needed,
+ * add it here as a Windows-specific branch that reads the registry - never as a
+ * Unix-style append.
+ */
 export function mergeShellPath(options: MergeShellPathOptions = {}): string {
+  const platform = options.platform ?? process.platform;
+  const pathDelimiter = options.pathDelimiter ?? delimiter;
+  const currentPath = options.currentPath ?? process.env.PATH ?? "";
+
+  if (platform === "win32") {
+    return currentPath;
+  }
+
   const homeDir = options.homeDir ?? homedir();
   const segments = [
-    ...(options.currentPath ?? "").split(":"),
+    ...splitPath(currentPath, pathDelimiter),
     ...COMMON_GUI_PATHS,
     `${homeDir}/.local/bin`,
-    ...(options.shellPath ?? "").split(":"),
+    ...splitPath(options.shellPath ?? "", pathDelimiter),
   ];
 
-  return [...new Set(segments.map((segment) => segment.trim()).filter(Boolean))].join(":");
+  return [...new Set(segments.map((segment) => segment.trim()).filter(Boolean))].join(pathDelimiter);
 }
 
+function splitPath(value: string, pathDelimiter: string): string[] {
+  return value.length === 0 ? [] : value.split(pathDelimiter);
+}
+
+/**
+ * Reads $PATH from a login zsh so a GUI launch picks up PATH additions the user
+ * made in their shell profile (Homebrew, asdf, Volta, etc.). Unix-only: there is
+ * no equivalent single-shell probe on Windows, and the inherited PATH is already
+ * complete there.
+ */
 export function readLoginShellPath(): string | undefined {
   if (process.platform === "win32") return undefined;
   const result = spawnSync("/bin/zsh", ["-lc", "print -r -- $PATH"], {
@@ -32,6 +78,11 @@ export function readLoginShellPath(): string | undefined {
   return result.stdout.trim() || undefined;
 }
 
+/**
+ * Expands process.env.PATH for a GUI launch in place and returns the new value.
+ * No-op on Windows (the inherited PATH is already complete); merges common Unix
+ * directories plus the login-shell PATH on macOS/Linux.
+ */
 export function expandProcessPathForGuiLaunch(): string {
   process.env.PATH = mergeShellPath({ currentPath: process.env.PATH, shellPath: readLoginShellPath() });
   return process.env.PATH;

--- a/tests/dev-launcher.test.ts
+++ b/tests/dev-launcher.test.ts
@@ -13,7 +13,7 @@ async function loadLauncher() {
 
 function createHarness() {
   const execCalls: Array<{ command: string; args: string[]; cwd?: string }> = [];
-  const spawnCalls: Array<{ command: string; args: string[]; cwd?: string; env?: NodeJS.ProcessEnv }> = [];
+  const spawnCalls: Array<{ command: string; args: string[]; cwd?: string; env?: NodeJS.ProcessEnv; shell?: boolean }> = [];
   const createdDirs: string[] = [];
   const removedDirs: string[] = [];
   const copiedFiles: Array<{ source: string; destination: string }> = [];
@@ -35,8 +35,8 @@ function createHarness() {
       if (args.join(" ") === "rev-parse --show-toplevel") return "/repo\n";
       return "";
     }),
-    spawnSync: vi.fn((command: string, args: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
-      spawnCalls.push({ command, args, cwd: options?.cwd, env: options?.env });
+    spawnSync: vi.fn((command: string, args: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv; shell?: boolean }) => {
+      spawnCalls.push({ command, args, cwd: options?.cwd, env: options?.env, shell: options?.shell });
       return { status: 0 };
     }),
   };
@@ -66,6 +66,7 @@ describe("dev launcher", () => {
         args: ["exec", "electron-vite", "dev"],
         cwd: "/repo",
         env: expect.objectContaining({ [ACTIVE_ENV]: "1" }),
+        shell: true,
       },
     ]);
   });
@@ -103,6 +104,7 @@ describe("dev launcher", () => {
           [ACTIVE_ENV]: "1",
           [EXTENSIONS_DIR_ENV]: join("/repo", "extensions-dev"),
         }),
+        shell: true,
       },
     ]);
   });
@@ -130,6 +132,18 @@ describe("dev launcher", () => {
     expect(harness.spawnCalls[0]?.env).toEqual(expect.objectContaining({
       [EXTENSIONS_DIR_ENV]: "/tmp/baby-menu-dev-extensions",
     }));
+  });
+
+  it("launches pnpm through a shell so pnpm.cmd resolves on Windows", async () => {
+    // Node cannot spawn a `.cmd`/`.bat` without `shell: true`; pnpm is `pnpm.cmd`
+    // on Windows. The dev launcher must invoke pnpm through a shell on every
+    // platform so the Windows developer workflow works out of the box.
+    const { ACTIVE_ENV, runDev } = await loadLauncher();
+    const harness = createHarness();
+
+    runDev({ cwd: "/repo", env: { [ACTIVE_ENV]: "1" }, ...harness });
+
+    expect(harness.spawnCalls[0]?.shell).toBe(true);
   });
 
   it("removes extensions-dev before running dev on reset", async () => {
@@ -163,6 +177,7 @@ describe("dev launcher", () => {
           [ACTIVE_ENV]: "1",
           [EXTENSIONS_DIR_ENV]: devExtensionsDir,
         }),
+        shell: true,
       },
     ]);
   });

--- a/tests/launch-command.test.ts
+++ b/tests/launch-command.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAdapterLauncherTokens,
+  joinLaunchCommand,
+  quoteLaunchToken,
+  splitAcpxCommand,
+} from "../src/main/launch-command";
+import { withAdapterLaunchCommands, DEFAULT_AGENTS } from "../src/main/agent-catalog";
+
+// The whole point of this file: a constructed launch command MUST round-trip
+// through acpx's own splitCommandLine into the exact tokens the host intended.
+// acpx strips backslashes inside double quotes, which silently breaks a quoted
+// `C:\Program Files\...` path. These tests prove the quoting survives.
+function expectRoundTrip(tokens: string[], platform: NodeJS.Platform) {
+  const command = joinLaunchCommand(tokens, platform);
+  const parsed = splitAcpxCommand(command);
+  expect(parsed).toEqual({ command: tokens[0]!, args: tokens.slice(1) });
+  return command;
+}
+
+describe("splitAcpxCommand (acpx parser port)", () => {
+  it("splits a bare command string", () => {
+    expect(splitAcpxCommand("node /o/claude.js")).toEqual({ command: "node", args: ["/o/claude.js"] });
+  });
+
+  it("strips backslashes inside double quotes (the confirmed defect)", () => {
+    // This is the exact failure the report reproduced: a naive double-quoted
+    // Windows path loses every backslash. The port must reproduce acpx's
+    // behavior so round-trip tests are meaningful.
+    expect(splitAcpxCommand('"C:\\Program Files\\App\\App.exe"')).toEqual({
+      command: "C:Program FilesAppApp.exe",
+      args: [],
+    });
+  });
+
+  it("preserves backslashes inside single quotes", () => {
+    expect(splitAcpxCommand("'C:\\Program Files\\App\\App.exe'")).toEqual({
+      command: "C:\\Program Files\\App\\App.exe",
+      args: [],
+    });
+  });
+
+  it("throws on an unterminated quote", () => {
+    expect(() => splitAcpxCommand('node "oops')).toThrow("unterminated quote");
+  });
+});
+
+describe("quoteLaunchToken round-trips through the acpx parser", () => {
+  const WINDOWS_PATHS = [
+    "C:\\Program Files\\Baby Menu\\Baby Menu.exe",
+    "C:\\Program Files\\Baby Menu\\resources\\app\\out\\adapters\\claude\\index.mjs",
+    "D:\\tools\\agent.cmd",
+    "C:\\Users\\José\\AppData\\Roaming\\npm\\claude.cmd",
+    "C:\\Users\\Müller\\Résumé\\bin\\codex.cmd",
+    "C:\\a & b\\path (x86)\\node.exe",
+  ];
+
+  it("round-trips every nasty Windows path (spaces, backslashes, &, parens, non-ASCII)", () => {
+    for (const path of WINDOWS_PATHS) {
+      const quoted = quoteLaunchToken(path, "win32");
+      // Backslashes are normalized to forward slashes (parser-safe and
+      // Windows-usable by spawn/fs/acpx), so the reparsed token equals the
+      // forward-slash form of the original verbatim - no backslashes stripped,
+      // no spaces split, no &/()/non-ASCII mangled.
+      expect(splitAcpxCommand(quoted).command).toBe(path.replace(/\\/g, "/"));
+    }
+  });
+
+  it("normalizes backslashes to forward slashes on Windows (parser-safe)", () => {
+    const quoted = quoteLaunchToken("C:\\Program Files\\App\\App.exe", "win32");
+    // Forward slashes (no escaping) inside double quotes survive the parser.
+    expect(quoted).toBe('"C:/Program Files/App/App.exe"');
+  });
+
+  it("leaves a bare token without special characters unquoted on Windows", () => {
+    expect(quoteLaunchToken("node", "win32")).toBe("node");
+    expect(quoteLaunchToken("C:/bin/node.exe", "win32")).toBe("C:/bin/node.exe");
+  });
+
+  it("quotes a token containing & or parentheses only when it also has spaces on Windows", () => {
+    // &/() are not special to the acpx parser (only whitespace, quotes, and
+    // backslash are), so a path with no spaces round-trips bare.
+    expect(quoteLaunchToken("C:/a&b/x.exe", "win32")).toBe("C:/a&b/x.exe");
+    expect(quoteLaunchToken("C:/a(x86)/x.exe", "win32")).toBe("C:/a(x86)/x.exe");
+    // The same content WITH a space gets quoted and still round-trips.
+    const spaced = "C:/a & b (x86)/x.exe";
+    expect(splitAcpxCommand(quoteLaunchToken(spaced, "win32")).command).toBe(spaced);
+  });
+
+  it("preserves the historical macOS double-quoting for paths with spaces", () => {
+    // A leading slash is not special to the parser, so it is preserved verbatim;
+    // only whitespace triggers double-quoting, matching the historical shellJoin.
+    expect(quoteLaunchToken("/Apps/Baby Menu.app/Contents/MacOS/Baby Menu", "darwin")).toBe(
+      '"/Apps/Baby Menu.app/Contents/MacOS/Baby Menu"',
+    );
+    expect(quoteLaunchToken("/Apps/Baby Menu.app", "darwin")).toBe('"/Apps/Baby Menu.app"');
+  });
+
+  it("escapes backslashes and quotes on POSIX so the token round-trips", () => {
+    const token = "/path/with\\backslash and \"quote";
+    expect(splitAcpxCommand(quoteLaunchToken(token, "darwin")).command).toBe(token);
+  });
+});
+
+describe("joinLaunchCommand", () => {
+  it("produces the byte-identical macOS Electron-as-node string (no regression)", () => {
+    const command = joinLaunchCommand(
+      ["env", "ELECTRON_RUN_AS_NODE=1", "/Apps/Baby Menu.app/Contents/MacOS/Baby Menu", "/Apps/Baby Menu.app/out/adapters/claude/index.js"],
+      "darwin",
+    );
+    expect(command).toBe(
+      'env ELECTRON_RUN_AS_NODE=1 "/Apps/Baby Menu.app/Contents/MacOS/Baby Menu" "/Apps/Baby Menu.app/out/adapters/claude/index.js"',
+    );
+    // And it round-trips through acpx.
+    expectRoundTrip(
+      ["env", "ELECTRON_RUN_AS_NODE=1", "/Apps/Baby Menu.app/Contents/MacOS/Baby Menu", "/Apps/Baby Menu.app/out/adapters/claude/index.js"],
+      "darwin",
+    );
+  });
+
+  it("round-trips a full Windows install-path launch through acpx", () => {
+    const tokens = [
+      "C:\\Program Files\\Baby Menu\\Baby Menu.exe",
+      "C:\\Program Files\\Baby Menu\\resources\\app\\out\\adapters\\codex\\index.mjs",
+    ];
+    const command = joinLaunchCommand(tokens, "win32");
+    const parsed = splitAcpxCommand(command);
+    // Forward-slash-normalized, but each token is intact and unsplit.
+    expect(parsed).toEqual({
+      command: "C:/Program Files/Baby Menu/Baby Menu.exe",
+      args: ["C:/Program Files/Baby Menu/resources/app/out/adapters/codex/index.mjs"],
+    });
+  });
+});
+
+describe("buildAdapterLauncherTokens", () => {
+  it("scopes env to the child via an env prefix on POSIX", () => {
+    expect(
+      buildAdapterLauncherTokens({ executable: "/Apps/Baby Menu.app/MacOS/Baby Menu", env: { ELECTRON_RUN_AS_NODE: "1" }, platform: "darwin" }),
+    ).toEqual(["env", "ELECTRON_RUN_AS_NODE=1", "/Apps/Baby Menu.app/MacOS/Baby Menu"]);
+  });
+
+  it("omits the env prefix on Windows (no env command; launcher is a documented next step)", () => {
+    expect(
+      buildAdapterLauncherTokens({
+        executable: "C:\\Program Files\\Baby Menu\\Baby Menu.exe",
+        env: { ELECTRON_RUN_AS_NODE: "1" },
+        platform: "win32",
+      }),
+    ).toEqual(["C:\\Program Files\\Baby Menu\\Baby Menu.exe"]);
+  });
+
+  it("omits the env token entirely when no env is requested on POSIX", () => {
+    expect(buildAdapterLauncherTokens({ executable: "/usr/bin/node", platform: "linux" })).toEqual(["/usr/bin/node"]);
+  });
+});
+
+describe("withAdapterLaunchCommands (Windows quoting)", () => {
+  const resolve = (adapter: "claude" | "codex") =>
+    `C:\\Program Files\\Baby Menu\\resources\\app\\out\\adapters\\${adapter}\\index.mjs`;
+
+  it("builds a launchCommand that round-trips through acpx for a Windows install path", () => {
+    const wired = withAdapterLaunchCommands(
+      DEFAULT_AGENTS,
+      resolve,
+      ["C:\\Program Files\\Baby Menu\\Baby Menu.exe"],
+      { platform: "win32" },
+    );
+    for (const agent of wired) {
+      expect(agent.launchCommand).toBeDefined();
+      const parsed = splitAcpxCommand(agent.launchCommand!);
+      // The reparsed command/args are the forward-slash-normalized intended
+      // paths - no backslashes stripped, no spaces split, intact for spawn/fs.
+      expect(parsed.command).toBe("C:/Program Files/Baby Menu/Baby Menu.exe");
+      expect(parsed.args).toEqual([resolve(agent.adapter as "claude" | "codex").replace(/\\/g, "/")]);
+    }
+  });
+
+  it("keeps the macOS launchCommand byte-identical when platform is darwin", () => {
+    const wired = withAdapterLaunchCommands(
+      DEFAULT_AGENTS,
+      (adapter) => `/app/out/adapters/${adapter}/index.js`,
+      ["env", "ELECTRON_RUN_AS_NODE=1", "/usr/bin/node"],
+      { platform: "darwin" },
+    );
+    expect(wired.find((a) => a.name === "claude")?.launchCommand).toBe(
+      "env ELECTRON_RUN_AS_NODE=1 /usr/bin/node /app/out/adapters/claude/index.js",
+    );
+  });
+
+  it("does not override an explicit custom launchCommand on Windows", () => {
+    const custom = [{ name: "claude", label: "Claude", command: "claude", adapter: "claude" as const, launchCommand: "my-claude" }];
+    const wired = withAdapterLaunchCommands(custom, resolve, ["x.exe"], { platform: "win32" });
+    expect(wired[0]!.launchCommand).toBe("my-claude");
+  });
+});

--- a/tests/platform-spawn.test.ts
+++ b/tests/platform-spawn.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { resolveDriverCommand, driverSpawnOptions } from "../src/adapters/shared/platform-spawn";
+
+// A fake Windows filesystem: only the listed absolute paths "exist".
+function fakeExists(existing: Set<string>) {
+  return (path: string) => existing.has(path);
+}
+
+const WIN_ENV = {
+  PATHEXT: ".COM;.EXE;.BAT;.CMD",
+  PATH: "C:\\Windows\\System32;C:\\Program Files\\nodejs;C:\\Users\\dev\\AppData\\Roaming\\npm",
+};
+
+describe("resolveDriverCommand", () => {
+  it("returns the command unchanged on POSIX (spawn resolves PATH)", () => {
+    expect(resolveDriverCommand("claude", { platform: "darwin", env: { PATH: "/usr/bin" } })).toBe("claude");
+    expect(resolveDriverCommand("claude", { platform: "linux", env: { PATH: "/usr/bin" } })).toBe("claude");
+  });
+
+  it("resolves a bare command to its .cmd shim on Windows via PATHEXT", () => {
+    const exists = fakeExists(new Set(["C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd"]));
+    expect(resolveDriverCommand("claude", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe(
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd",
+    );
+  });
+
+  it("prefers an earlier PATHEXT extension when multiple exist", () => {
+    const exists = fakeExists(
+      new Set(["C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.exe", "C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd"]),
+    );
+    // .COM;.EXE;.BAT;.CMD -> .exe wins over .cmd in the same directory.
+    expect(resolveDriverCommand("claude", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe(
+      "C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.exe",
+    );
+  });
+
+  it("searches each PATH directory in order", () => {
+    const exists = fakeExists(new Set(["C:\\Program Files\\nodejs\\codex.cmd"]));
+    expect(resolveDriverCommand("codex", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe(
+      "C:\\Program Files\\nodejs\\codex.cmd",
+    );
+  });
+
+  it("resolves an absolute command directly using PATHEXT when it has no extension", () => {
+    const exists = fakeExists(new Set(["C:\\tools\\codex.exe"]));
+    expect(resolveDriverCommand("C:\\tools\\codex", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe(
+      "C:\\tools\\codex.exe",
+    );
+  });
+
+  it("keeps an absolute command with an extension as-is when it exists", () => {
+    const exists = fakeExists(new Set(["C:\\Program Files\\App\\app.exe"]));
+    expect(resolveDriverCommand("C:\\Program Files\\App\\app.exe", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe(
+      "C:\\Program Files\\App\\app.exe",
+    );
+  });
+
+  it("returns the original command when nothing resolves so spawn surfaces ENOENT", () => {
+    const exists = fakeExists(new Set());
+    expect(resolveDriverCommand("claude", { platform: "win32", env: WIN_ENV, existsSync: exists })).toBe("claude");
+  });
+
+  it("handles non-ASCII directory names", () => {
+    const env = { PATHEXT: ".CMD;.EXE", PATH: "C:\\Users\\José\\bin" };
+    const exists = fakeExists(new Set(["C:\\Users\\José\\bin\\claude.cmd"]));
+    expect(resolveDriverCommand("claude", { platform: "win32", env, existsSync: exists })).toBe(
+      "C:\\Users\\José\\bin\\claude.cmd",
+    );
+  });
+});
+
+describe("driverSpawnOptions", () => {
+  it("returns no shell on POSIX", () => {
+    expect(driverSpawnOptions("claude", { platform: "darwin" })).toEqual({});
+    expect(driverSpawnOptions("claude", { platform: "linux" })).toEqual({});
+  });
+
+  it("sets shell:true for a resolved .cmd shim on Windows", () => {
+    const exists = fakeExists(new Set(["C:\\Users\\dev\\AppData\\Roaming\\npm\\claude.cmd"]));
+    expect(driverSpawnOptions("claude", { platform: "win32", env: WIN_ENV, existsSync: exists })).toEqual({ shell: true });
+  });
+
+  it("sets shell:true for a .bat shim on Windows", () => {
+    const exists = fakeExists(new Set(["C:\\bin\\agent.bat"]));
+    expect(driverSpawnOptions("C:\\bin\\agent.bat", { platform: "win32", env: WIN_ENV, existsSync: exists })).toEqual({
+      shell: true,
+    });
+  });
+
+  it("does not set shell for a native .exe on Windows", () => {
+    const exists = fakeExists(new Set(["C:\\Program Files\\App\\app.exe"]));
+    expect(driverSpawnOptions("C:\\Program Files\\App\\app.exe", { platform: "win32", env: WIN_ENV, existsSync: exists })).toEqual(
+      {},
+    );
+  });
+
+  it("does not set shell when a bare command cannot be resolved (defer to spawn ENOENT)", () => {
+    const exists = fakeExists(new Set());
+    expect(driverSpawnOptions("claude", { platform: "win32", env: WIN_ENV, existsSync: exists })).toEqual({});
+  });
+});

--- a/tests/process-tree.test.ts
+++ b/tests/process-tree.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createChildTerminator,
+  selectTerminationStrategy,
+  taskkillArgs,
+  type TerminableChild,
+} from "../src/adapters/shared/process-tree";
+
+// A minimal stand-in for a Node ChildProcess: records the signals it received.
+function fakeChild(pid?: number) {
+  const kills: string[] = [];
+  const child: TerminableChild = {
+    pid,
+    kill: (signal?: NodeJS.Signals | number) => {
+      kills.push(signal === undefined ? "<none>" : String(signal));
+      return true;
+    },
+  };
+  return { child, kills };
+}
+
+describe("selectTerminationStrategy", () => {
+  it("uses posix signals on darwin/linux", () => {
+    expect(selectTerminationStrategy("darwin")).toBe("posix-signals");
+    expect(selectTerminationStrategy("linux")).toBe("posix-signals");
+  });
+
+  it("uses taskkill on win32", () => {
+    expect(selectTerminationStrategy("win32")).toBe("windows-taskkill");
+  });
+});
+
+describe("taskkillArgs", () => {
+  it("builds a bounded, numeric-PID tree kill (no untrusted text reaches a shell)", () => {
+    expect(taskkillArgs(4242)).toEqual(["/PID", "4242", "/T", "/F"]);
+  });
+
+  it("never interpolates the pid into a string (always a separate numeric arg)", () => {
+    // The pid comes from child.pid (a number), so String() of it is always a
+    // bare integer token - there is no shell into which untrusted text could be
+    // injected even if a future caller passed something odd.
+    expect(taskkillArgs(0)).toEqual(["/PID", "0", "/T", "/F"]);
+  });
+});
+
+describe("createChildTerminator (posix-signals)", () => {
+  it("sends SIGTERM on terminate and SIGKILL on force, byte-for-byte the historical behavior", () => {
+    const { child, kills } = fakeChild(111);
+    const terminator = createChildTerminator(child, { strategy: "posix-signals" });
+    terminator.terminate();
+    terminator.force();
+    expect(kills).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("defaults to the host strategy (posix on this test host)", () => {
+    const { child, kills } = fakeChild(222);
+    const terminator = createChildTerminator(child);
+    terminator.terminate();
+    expect(kills).toEqual(["SIGTERM"]);
+  });
+});
+
+describe("createChildTerminator (windows-taskkill)", () => {
+  it("runs taskkill /T /F with the numeric pid on terminate (injection-free)", () => {
+    const { child } = fakeChild(909);
+    const runTaskkill = vi.fn<(args: string[]) => { status: number | null }>(() => ({ status: 0 }));
+    const terminator = createChildTerminator(child, { strategy: "windows-taskkill", runTaskkill });
+    terminator.terminate();
+    expect(runTaskkill).toHaveBeenCalledTimes(1);
+    expect(runTaskkill).toHaveBeenCalledWith(["/PID", "909", "/T", "/F"]);
+  });
+
+  it("force repeats the bounded tree kill (no graceful path for console CLI trees)", () => {
+    const { child } = fakeChild(909);
+    const runTaskkill = vi.fn<(args: string[]) => { status: number | null }>(() => ({ status: 0 }));
+    const terminator = createChildTerminator(child, { strategy: "windows-taskkill", runTaskkill });
+    terminator.terminate();
+    terminator.force();
+    expect(runTaskkill).toHaveBeenCalledTimes(2);
+    // Every invocation uses the same safe numeric args.
+    for (const [args] of runTaskkill.mock.calls) {
+      expect(args).toEqual(["/PID", "909", "/T", "/F"]);
+    }
+  });
+
+  it("is a no-op when the child has no pid yet (spawn not complete)", () => {
+    const { child } = fakeChild(undefined);
+    const runTaskkill = vi.fn<(args: string[]) => { status: number | null }>(() => ({ status: 0 }));
+    const terminator = createChildTerminator(child, { strategy: "windows-taskkill", runTaskkill });
+    terminator.terminate();
+    terminator.force();
+    expect(runTaskkill).not.toHaveBeenCalled();
+  });
+});

--- a/tests/shell-path.test.ts
+++ b/tests/shell-path.test.ts
@@ -1,0 +1,72 @@
+import { delimiter } from "node:path";
+import { describe, expect, it } from "vitest";
+import { mergeShellPath } from "../src/main/shell-path";
+
+describe("mergeShellPath", () => {
+  it("merges common Unix directories and the login-shell PATH on macOS", () => {
+    const merged = mergeShellPath({
+      currentPath: "/usr/bin:/bin",
+      homeDir: "/Users/dev",
+      shellPath: "/opt/asdf/shims:/Users/dev/.cargo/bin",
+      platform: "darwin",
+      pathDelimiter: ":",
+    });
+    // Inherited entries are preserved and come first.
+    expect(merged.startsWith("/usr/bin:/bin")).toBe(true);
+    // Common GUI paths and ~/.local/bin are appended.
+    expect(merged).toContain("/opt/homebrew/bin");
+    expect(merged).toContain("/Users/dev/.local/bin");
+    // Login-shell PATH is merged in.
+    expect(merged).toContain("/opt/asdf/shims");
+    expect(merged).toContain("/Users/dev/.cargo/bin");
+    // All separators are POSIX colons.
+    expect(merged.includes(";")).toBe(false);
+    // Entries are de-duplicated.
+    expect(merged.split(":").filter((segment) => segment === "/usr/bin")).toEqual(["/usr/bin"]);
+  });
+
+  it("returns the inherited PATH unchanged on Windows", () => {
+    const inherited = "C:\\Windows\\System32;C:\\Program Files\\nodejs;C:\\Users\\dev\\AppData\\Roaming\\npm";
+    const merged = mergeShellPath({
+      currentPath: inherited,
+      homeDir: "C:\\Users\\dev",
+      shellPath: "/opt/homebrew/bin:/usr/local/bin",
+      platform: "win32",
+      pathDelimiter: ";",
+    });
+    // The exact inherited value is preserved - no Unix directory merged in, no
+    // delimiter corruption, and crucially the final usable entry stays intact.
+    expect(merged).toBe(inherited);
+  });
+
+  it("does not corrupt the final PATH entry with a Unix delimiter on Windows", () => {
+    // Regression for the confirmed defect: appending a colon-delimited segment
+    // to a semicolon PATH left a trailing `:`-segment that corrupted the last
+    // real entry. The Windows path must never append Unix syntax.
+    const inherited = "C:\\Program Files\\nodejs;C:\\Users\\dev\\AppData\\Roaming\\npm";
+    const merged = mergeShellPath({ currentPath: inherited, platform: "win32", pathDelimiter: ";" });
+    expect(merged).toBe(inherited);
+    // No segment is altered or appended: every entry is exactly one of the
+    // inherited semicolon-delimited entries (drive-letter colons are part of a
+    // segment, not a POSIX delimiter).
+    expect(merged.split(";")).toEqual(inherited.split(";"));
+  });
+
+  it("preserves multiple drive letters on Windows without joining them", () => {
+    const inherited = "C:\\bin;D:\\tools;E:\\dev\\bin";
+    const merged = mergeShellPath({ currentPath: inherited, platform: "win32", pathDelimiter: ";" });
+    expect(merged.split(";")).toEqual(["C:\\bin", "D:\\tools", "E:\\dev\\bin"]);
+  });
+
+  it("uses the path.delimiter default when not overridden", () => {
+    // Sanity that the default delimiter matches the host convention the rest of
+    // the app relies on (node:path.delimiter).
+    expect(delimiter).toBe(process.platform === "win32" ? ";" : ":");
+  });
+
+  it("handles an empty inherited PATH on POSIX by still offering the common directories", () => {
+    const merged = mergeShellPath({ currentPath: "", homeDir: "/h", platform: "linux", pathDelimiter: ":" });
+    expect(merged).toContain("/usr/bin");
+    expect(merged).toContain("/h/.local/bin");
+  });
+});


### PR DESCRIPTION
## Summary

First milestone of the **Windows port**: the smallest production-quality, testable foundation for the platform-adjacent seams, preserving the existing Electron architecture (no rewrite, no greenfield fork). macOS behavior is byte-for-byte unchanged - every change is a platform-aware branch. Based on the feasibility report at `data/baby-menu-windows-scout/report.md`.

This PR does **not** claim a packaged Windows runtime works. It implements what can be fully validated without pretending Linux is Windows, and documents the exact remaining clean-Windows validation steps in `docs/windows-port-validation.md`.

## What's implemented and proven by automated tests

| Area | File(s) | Test |
|---|---|---|
| Platform-safe PATH (`:`/`;` delimiter, no Unix-dir corruption on Windows) | `src/main/shell-path.ts` | `tests/shell-path.test.ts` |
| Correctly-quoted bundled-adapter launch string (spaces, backslashes, `&`, parens, non-ASCII) that round-trips through acpx's own parser | `src/main/launch-command.ts`, `agent-catalog.ts`, `app.ts` | `tests/launch-command.test.ts` |
| PATHEXT-aware `.cmd`/`.bat` resolution + `shell:true` for native agent CLIs | `src/adapters/shared/platform-spawn.ts`, both drivers | `tests/platform-spawn.test.ts` |
| Bounded Windows process-tree cancellation (`taskkill /T /F /PID <pid>`, numeric pid, no shell interpolation) | `src/adapters/shared/process-tree.ts`, both drivers | `tests/process-tree.test.ts` |
| `pnpm.cmd`-safe dev launcher | `scripts/dev.mjs` | `tests/dev-launcher.test.ts` |
| Windows CI (typecheck + build + the 5 platform-portable suites) | `.github/workflows/ci.yml` | - |

Key technique: acpx's registry override is a single **string** that acpx reparses with `splitCommandLine` (which strips backslashes inside double quotes - the confirmed defect for `C:\Program Files\...`). `launch-command.ts` exports `splitAcpxCommand`, a faithful port of the pinned acpx parser, so tests prove the constructed launch string reparses into the exact intended tokens **without needing a Windows host**. Backslashes are normalized to forward slashes (parser-safe and Windows-usable by `spawn`/`fs`/acpx).

POSIX driver cancellation is routed through `createChildTerminator`, which keeps the exact historical `SIGTERM` -> `SIGKILL` behavior, so existing driver tests are unchanged.

## What this does NOT claim (documented honestly)

These require a real Windows host and are the documented remaining steps - the spike is **not** reported as passed for them (see `docs/windows-port-validation.md`):

- **`ELECTRON_RUN_AS_NODE` delivery on Windows**: POSIX scopes it via an `env KEY=VALUE` prefix in the command string; there is no `env` command on Windows and acpx cannot inject env via the string. A minimal Windows launcher is the clean-Windows Milestone-0 step.
- **Real `.cmd` cancellation leaving zero descendants**: `taskkill /T /F` is the correct bounded kill, but must be observed against a real `claude.cmd`/`codex.cmd` tree on Windows.
- **`shell:true` + prompt-as-argv hardening**: the drivers pass the prompt as a trailing argv; under `shell:true` this is a cmd.exe injection surface the full port must address (likely by moving prompt delivery to stdin, as acpx does).

Explicitly **out of scope** for this PR (per task): tray polish/assets, `.ico`, AppUserModelID, single-instance lock, NSIS installer, Authenticode signing, update copy, recipe platform-filtering/parity, or any rewrite.

## Test evidence (local, Node 26 worktree)

- `tsc --noEmit`: clean.
- Full build (`electron-vite build` + `scripts/build-adapters.mjs`): clean.
- The 10 touched/new test files: **102 passed**.
- Full suite: **579 passed, 2 skipped**, with 2 suites (`app-paths`, `widget-protocol`) failing **only** because the worktree's Electron binary is a partial download (`electron/path.txt` missing) - the exact pre-existing environment issue the scout report documented. Neither imports any changed file; both fail at `import electron`, not on a source assertion. They pass on CI (Node 22 with a proper electron binary).
