### PR TITLE
fix: gate macOS releases until verification

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,17 @@ jobs:
         with:
           ref: ${{ env.TAG_NAME }}
 
+      - name: Verify release is still draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          RELEASE_DRAFT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft)"
+          if [ "$RELEASE_DRAFT" != "true" ]; then
+            echo "Refusing to build artifacts for a release that is already public: $TAG_NAME" >&2
+            exit 1
+          fi
+
       - name: Verify macOS release tools
         run: |
           set -euo pipefail
@@ -264,36 +275,31 @@ jobs:
           verify_entitlements() {
             local code_object="$1"
             local architecture="${2:-}"
+            local require_jit="${3:-false}"
             local entitlements_file
+            local -a parser_args
             entitlements_file="$(mktemp "$RUNNER_TEMP/baby-menu-entitlements.XXXXXX")"
+            parser_args=("$entitlements_file" "$code_object")
             if [ -n "$architecture" ]; then
-              codesign -d --arch "$architecture" --entitlements :- "$code_object" \
-                >"$entitlements_file" 2>/dev/null
+              parser_args+=(--architecture "$architecture")
+              if ! codesign -d --arch "$architecture" --entitlements - --xml "$code_object" \
+                >"$entitlements_file"; then
+                rm -f "$entitlements_file"
+                return 1
+              fi
             else
-              codesign -d --entitlements :- "$code_object" \
-                >"$entitlements_file" 2>/dev/null
+              if ! codesign -d --entitlements - --xml "$code_object" >"$entitlements_file"; then
+                rm -f "$entitlements_file"
+                return 1
+              fi
             fi
-            python3 - "$entitlements_file" "$code_object" "$architecture" <<'PY'
-          import plistlib
-          import sys
-
-          path, code_object, architecture = sys.argv[1:]
-          with open(path, "rb") as stream:
-              entitlements = plistlib.load(stream)
-          if not isinstance(entitlements, dict):
-              raise SystemExit(f"Invalid entitlements for {code_object} ({architecture or 'default architecture'})")
-          unexpected = sorted(set(entitlements) - {"com.apple.security.cs.allow-jit"})
-          if unexpected:
-              raise SystemExit(
-                  f"Unexpected entitlements for {code_object} ({architecture or 'default architecture'}): "
-                  + ", ".join(unexpected)
-              )
-          if "com.apple.security.cs.allow-jit" in entitlements and entitlements["com.apple.security.cs.allow-jit"] is not True:
-              raise SystemExit(
-                  f"com.apple.security.cs.allow-jit must be true for {code_object} "
-                  f"({architecture or 'default architecture'})"
-              )
-          PY
+            if [ "$require_jit" = "true" ]; then
+              parser_args+=(--require-jit)
+            fi
+            if ! python3 scripts/verify-macos-entitlements.py "${parser_args[@]}"; then
+              rm -f "$entitlements_file"
+              return 1
+            fi
             rm -f "$entitlements_file"
           }
 
@@ -304,13 +310,20 @@ jobs:
             local expected_architecture
             local counterpart
             local counterpart_architecture
+            local require_jit=false
+
+            case "$relative_path" in
+              Contents/MacOS/*|Contents/Frameworks/*.app/Contents/MacOS/*)
+                require_jit=true
+                ;;
+            esac
 
             architectures="$(lipo -archs "$candidate" | tr ' ' '\n' | LC_ALL=C sort | xargs)"
             if [ "$architectures" = "arm64 x86_64" ]; then
               verify_code_object "$candidate" arm64
               verify_code_object "$candidate" x86_64
-              verify_entitlements "$candidate" arm64
-              verify_entitlements "$candidate" x86_64
+              verify_entitlements "$candidate" arm64 "$require_jit"
+              verify_entitlements "$candidate" x86_64 "$require_jit"
               return
             fi
 
@@ -366,13 +379,16 @@ jobs:
               exit 1
             fi
             verify_code_object "$candidate" "$expected_architecture"
-            verify_entitlements "$candidate" "$expected_architecture"
+            verify_entitlements "$candidate" "$expected_architecture" "$require_jit"
           }
 
           BUNDLE_COUNT=0
           while IFS= read -r -d '' code_bundle; do
             verify_code_object "$code_bundle"
-            verify_entitlements "$code_bundle"
+            case "$code_bundle" in
+              *.app) verify_entitlements "$code_bundle" "" true ;;
+              *) verify_entitlements "$code_bundle" ;;
+            esac
             BUNDLE_COUNT=$((BUNDLE_COUNT + 1))
           done < <(find "$APP_PATH" -type d \( -name '*.app' -o -name '*.framework' \) -print0)
           if [ "$BUNDLE_COUNT" -eq 0 ]; then
@@ -404,15 +420,32 @@ jobs:
           hdiutil detach "$MOUNT_POINT" -quiet
           trap - EXIT
 
-      - name: Upload DMG to release
+      - name: Compute SHA256
+        run: |
+          set -euo pipefail
+          SHA256="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
+          if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Could not compute a valid SHA256 for $DMG_PATH" >&2
+            exit 1
+          fi
+          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
+
+      - name: Upload DMG to draft release
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "$TAG_NAME" "$DMG_PATH" --clobber
 
-      - name: Compute SHA256
+      - name: Publish verified release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-          echo "SHA256=${SHA256}" >> "$GITHUB_ENV"
+          set -euo pipefail
+          RELEASE_DRAFT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft)"
+          if [ "$RELEASE_DRAFT" != "true" ]; then
+            echo "Refusing to publish a release that is not draft: $TAG_NAME" >&2
+            exit 1
+          fi
+          gh release edit "$TAG_NAME" --draft=false
 
       - name: Update Homebrew Cask
         env:

--- a/.no-mistakes/evidence/fm/baby-menu-release-failure-repair-r3/release-repair-validation.md
+++ b/.no-mistakes/evidence/fm/baby-menu-release-failure-repair-r3/release-repair-validation.md
@@ -1,0 +1,61 @@
+# Signed release failure repair - focused validation
+
+Validated on macOS against target commit `dc5a59cc83db0f47aebb87a1c3187676d85a3ac9`.
+
+## Real Electron Framework output
+
+The verifier was fed the output of the same `codesign` command used by the release workflow, run against the installed Electron 42.2.0 framework:
+
+```text
+$ codesign -d --arch arm64 --entitlements - --xml \
+    "node_modules/.pnpm/electron@42.2.0/node_modules/electron/dist/Electron.app/Contents/Frameworks/Electron Framework.framework" \
+    > framework-arm64.plist
+$ wc -c framework-arm64.plist
+0
+$ python3 scripts/verify-macos-entitlements.py framework-arm64.plist \
+    "Electron Framework.framework" --architecture arm64
+PASS real Electron Framework codesign output: arch=arm64 bytes=0 accepted as no entitlements
+```
+
+This directly reproduces and accepts the zero-byte output that broke the first signed release. The locally installed Electron binary contains only an arm64 slice, so x86_64 slice behavior is covered with exact parser fixtures in the focused automated test.
+
+## Strict entitlement behavior
+
+`pnpm vitest run tests/macos-entitlements-verifier.test.ts tests/release-config.test.ts --reporter=verbose` exercised these observable cases:
+
+```text
+PASS accepts the exact empty output emitted for Electron Framework
+PASS accepts the exact XML output emitted for a JIT-only code object
+PASS rejects malformed non-empty codesign output
+PASS rejects unexpected effective entitlements
+PASS rejects the allowed JIT entitlement unless its value is exactly true
+PASS rejects a no-entitlement object when JIT is required
+PASS rejects unreadable entitlement data
+```
+
+The release workflow contract test also proves that each universal process executable invokes entitlement verification separately for `arm64` and `x86_64` with JIT required.
+
+## Draft-until-verified publication path
+
+The focused release contract test verified this order in `.github/workflows/release-please.yml`:
+
+```text
+release-please creates draft release and tag
+  -> refuse to proceed unless release is draft
+  -> sign and notarize app
+  -> create, notarize, and staple DMG
+  -> mount final DMG and verify signatures, identity, runtime, architecture,
+     entitlements, Gatekeeper, and staples
+  -> run packaged app E2E from mounted DMG
+  -> compute and validate SHA256
+  -> upload DMG to draft release
+  -> refuse to publish unless release is still draft
+  -> publish stable release
+  -> update Homebrew cask
+```
+
+The changed-file and workflow checks found no reference that edits or deletes `baby-menu-v0.1.22`, no tag deletion or force-update command, and no new cleanup automation. Release Please's supported `draft: true` and `force-tag-creation: true` settings are used so future draft releases receive their own tag immediately.
+
+The read-only repository check `gh-axi release view baby-menu-v0.1.22` still returned the existing published release authored by `github-actions[bot]`, with its original `0.1.22` notes and `caa901a` release commit.
+
+Production Developer ID signing and Apple notarization were not rerun locally because they require the protected release credentials and GitHub release mutation. The workflow itself retains those release-equivalent checks before publication.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,9 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 Baby Menu releases are proposed by release-please after conventional commits land on `main`.
 Use prefixes such as `feat:` and `fix:` so release-please can choose the version bump and release notes.
 Mark breaking changes with `!` in the commit type or a `BREAKING CHANGE:` footer.
-Merging the release-please PR creates the version tag and GitHub Release.
-The release-please workflow builds the universal macOS app, signs every code object with `Developer ID Application: Kun Chen (9T2J7MNUP9)`, notarizes and staples the app and DMG, verifies the publication-ready DMG, uploads it, and then updates `kunchenguid/homebrew-tap` with that DMG's SHA.
-Any credential, identity, notarization, signature, Gatekeeper, architecture, bundle-id, or staple failure stops before artifact upload and tap publication.
+Merging the release-please PR creates the version tag and a draft GitHub Release.
+The release-please workflow builds the universal macOS app, signs every code object with `Developer ID Application: Kun Chen (9T2J7MNUP9)`, notarizes and staples the app and DMG, verifies the publication-ready DMG, computes its checksum, uploads it to the draft, and only then publishes the release before updating `kunchenguid/homebrew-tap`.
+Any credential, identity, notarization, signature, entitlement, Gatekeeper, architecture, bundle-id, staple, packaged runtime, checksum, or upload failure leaves the release as a draft and stops before stable publication and tap publication.
 The generated Homebrew Cask quits Baby Menu during upgrade and relaunches it after installation only when the app was already running before uninstall started.
 
 Maintainers must keep these repository secrets provisioned from the canonical secure owners:
@@ -62,7 +62,7 @@ Maintainers must keep these repository secrets provisioned from the canonical se
 Never commit or print credential contents. Missing or malformed secrets fail the real release job; pull-request CI remains secret-free and validates the release config through `tests/release-config.test.ts`.
 Maintainers must also keep the `BABY_MENU_UMAMI_WEBSITE_ID` GitHub Actions repository variable configured for packaged-release telemetry; it is intentionally a variable rather than a secret because the id is baked into the app and sent in Umami payloads.
 
-To release, merge the release-please PR and require the `release-please` workflow's macOS job to pass. Do not upload a replacement DMG or update the tap by hand unless repairing a failed release.
+To release, merge the release-please PR and require the `release-please` workflow's macOS job to pass. The release remains a draft until the signed artifact passes verification and runtime E2E, receives a valid checksum, and uploads successfully. Do not upload a replacement DMG or update the tap by hand unless repairing a failed release.
 For a post-release check of exactly the downloaded artifact on macOS:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Use prefixes such as `feat:` and `fix:` so release-please can choose the version
 Mark breaking changes with `!` in the commit type or a `BREAKING CHANGE:` footer.
 Merging the release-please PR creates the version tag and a draft GitHub Release.
 The release-please workflow builds the universal macOS app, signs every code object with `Developer ID Application: Kun Chen (9T2J7MNUP9)`, notarizes and staples the app and DMG, verifies the publication-ready DMG, computes its checksum, uploads it to the draft, and only then publishes the release before updating `kunchenguid/homebrew-tap`.
-Any credential, identity, notarization, signature, entitlement, Gatekeeper, architecture, bundle-id, staple, packaged runtime, checksum, or upload failure leaves the release as a draft and stops before stable publication and tap publication.
+Any signing, notarization, verification, packaged runtime, checksum, or GitHub upload failure leaves the release as a draft and stops before stable publication and tap publication. A missing or invalid `HOMEBREW_TAP_TOKEN`, or another tap update failure, occurs after stable publication and fails the workflow without updating Homebrew.
 The generated Homebrew Cask quits Baby Menu during upgrade and relaunches it after installation only when the app was already running before uninstall started.
 
 Maintainers must keep these repository secrets provisioned from the canonical secure owners:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
+  "draft": true,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "release-type": "node",

--- a/scripts/verify-macos-entitlements.py
+++ b/scripts/verify-macos-entitlements.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Validate the effective entitlements emitted by macOS codesign."""
+
+import argparse
+import plistlib
+from pathlib import Path
+
+ALLOWED_ENTITLEMENTS = {"com.apple.security.cs.allow-jit"}
+JIT_ENTITLEMENT = "com.apple.security.cs.allow-jit"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(message)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("entitlements_path")
+    parser.add_argument("code_object")
+    parser.add_argument("--architecture", default="")
+    parser.add_argument("--require-jit", action="store_true")
+    args = parser.parse_args()
+
+    architecture = args.architecture or "default architecture"
+    subject = f"{args.code_object} ({architecture})"
+    try:
+        data = Path(args.entitlements_path).read_bytes()
+    except OSError as error:
+        fail(f"Could not read entitlements for {subject}: {error}")
+
+    if data == b"":
+        # codesign exits successfully and writes no bytes when a code object has
+        # no effective entitlements. Electron frameworks use this exact shape.
+        entitlements: object = {}
+    else:
+        try:
+            entitlements = plistlib.loads(data)
+        except Exception as error:
+            fail(f"Malformed entitlements for {subject}: {error}")
+
+    if not isinstance(entitlements, dict) or any(
+        not isinstance(key, str) for key in entitlements
+    ):
+        fail(f"Invalid entitlements for {subject}: expected a string-keyed dictionary")
+
+    unexpected = sorted(set(entitlements) - ALLOWED_ENTITLEMENTS)
+    if unexpected:
+        fail(f"Unexpected entitlements for {subject}: {', '.join(unexpected)}")
+
+    if JIT_ENTITLEMENT in entitlements and entitlements[JIT_ENTITLEMENT] is not True:
+        fail(f"{JIT_ENTITLEMENT} must be true for {subject}")
+
+    if args.require_jit and entitlements.get(JIT_ENTITLEMENT) is not True:
+        fail(f"Missing required {JIT_ENTITLEMENT} entitlement for {subject}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/macos-entitlements-verifier.test.ts
+++ b/tests/macos-entitlements-verifier.test.ts
@@ -1,0 +1,74 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const verifier = resolve(import.meta.dirname, "../scripts/verify-macos-entitlements.py");
+const jitOnlyCodesignOutput = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd"><plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key><true/></dict></plist>`;
+
+async function verifyEntitlements(
+  contents: string | Buffer,
+  options: { requireJit?: boolean; codeObject?: string } = {},
+) {
+  const directory = await mkdtemp(join(tmpdir(), "baby-menu-entitlements-"));
+  const entitlementsPath = join(directory, "entitlements.plist");
+  await writeFile(entitlementsPath, contents);
+  try {
+    return await execFileAsync("python3", [
+      verifier,
+      entitlementsPath,
+      options.codeObject ?? "/Baby Menu.app/Contents/MacOS/Baby Menu",
+      ...(options.requireJit ? ["--require-jit"] : []),
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe("macOS effective entitlement verifier", () => {
+  it("accepts the exact empty output emitted for Electron Framework", async () => {
+    await expect(verifyEntitlements(Buffer.alloc(0), {
+      codeObject: "/Baby Menu.app/Contents/Frameworks/Electron Framework.framework",
+    })).resolves.toBeDefined();
+  });
+
+  it("accepts the exact XML output emitted for a JIT-only code object", async () => {
+    await expect(verifyEntitlements(jitOnlyCodesignOutput, { requireJit: true })).resolves.toBeDefined();
+  });
+
+  it("rejects malformed non-empty codesign output", async () => {
+    await expect(verifyEntitlements("not a plist")).rejects.toMatchObject({
+      stderr: expect.stringContaining("Malformed entitlements"),
+    });
+  });
+
+  it("rejects unexpected effective entitlements", async () => {
+    const unexpected = jitOnlyCodesignOutput.replace(
+      "</dict>",
+      "<key>com.apple.security.cs.disable-library-validation</key><true/></dict>",
+    );
+
+    await expect(verifyEntitlements(unexpected)).rejects.toMatchObject({
+      stderr: expect.stringContaining("Unexpected entitlements"),
+    });
+  });
+
+  it("rejects a no-entitlement object when JIT is required", async () => {
+    await expect(verifyEntitlements(Buffer.alloc(0), { requireJit: true })).rejects.toMatchObject({
+      stderr: expect.stringContaining("Missing required com.apple.security.cs.allow-jit entitlement"),
+    });
+  });
+
+  it("rejects unreadable entitlement data", async () => {
+    await expect(execFileAsync("python3", [
+      verifier,
+      "/path/that/does/not/exist",
+      "/Baby Menu.app/Contents/MacOS/Baby Menu",
+    ])).rejects.toMatchObject({
+      stderr: expect.stringContaining("Could not read entitlements"),
+    });
+  });
+});

--- a/tests/macos-entitlements-verifier.test.ts
+++ b/tests/macos-entitlements-verifier.test.ts
@@ -56,6 +56,14 @@ describe("macOS effective entitlement verifier", () => {
     });
   });
 
+  it("rejects the allowed JIT entitlement unless its value is exactly true", async () => {
+    const disabledJit = jitOnlyCodesignOutput.replace("<true/>", "<false/>");
+
+    await expect(verifyEntitlements(disabledJit)).rejects.toMatchObject({
+      stderr: expect.stringContaining("com.apple.security.cs.allow-jit must be true"),
+    });
+  });
+
   it("rejects a no-entitlement object when JIT is required", async () => {
     await expect(verifyEntitlements(Buffer.alloc(0), { requireJit: true })).rejects.toMatchObject({
       stderr: expect.stringContaining("Missing required com.apple.security.cs.allow-jit entitlement"),

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -123,8 +123,12 @@ describe("distribution config", () => {
     expect(workflow).toContain('verify_code_object "$candidate" x86_64');
     expect(workflow).toContain('verify_code_object "$candidate" "$expected_architecture"');
     expect(workflow).toContain("verify_entitlements");
-    expect(workflow).toContain('set(entitlements) - {"com.apple.security.cs.allow-jit"}');
-    expect(workflow).toContain("--arch \"$architecture\" --entitlements :-");
+    expect(workflow).toContain('python3 scripts/verify-macos-entitlements.py');
+    expect(workflow).toContain('--arch "$architecture" --entitlements - --xml');
+    expect(workflow).toContain("--require-jit");
+    expect(workflow).toContain('Contents/MacOS/*|Contents/Frameworks/*.app/Contents/MacOS/*)');
+    expect(workflow).toContain('verify_entitlements "$candidate" arm64 "$require_jit"');
+    expect(workflow).toContain('verify_entitlements "$candidate" x86_64 "$require_jit"');
     expect(workflow).toContain("verify_macho_architectures");
     expect(workflow).toContain('if [ "$architectures" = "arm64 x86_64" ]');
     expect(workflow).toContain("node_modules/@esbuild/darwin-arm64/bin/esbuild");
@@ -142,15 +146,22 @@ describe("distribution config", () => {
     expect(workflow).toContain('lipo "$APP_EXECUTABLE" -verify_arch arm64 x86_64');
     expect(workflow).toContain('ARCHITECTURES" != "arm64 x86_64"');
 
+    expect(workflow).toContain("Verify release is still draft");
+    expect(workflow).toContain('gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft');
+
     const verifyIndex = workflow.indexOf("Verify publication-ready signed and notarized DMG");
     const runtimeE2eIndex = workflow.indexOf('node scripts/e2e-packaged-mac-app.mjs "$APP_PATH"');
-    const uploadIndex = workflow.indexOf("Upload DMG to release");
+    const checksumIndex = workflow.indexOf("Compute SHA256");
+    const uploadIndex = workflow.indexOf("Upload DMG to draft release");
+    const publishIndex = workflow.indexOf("Publish verified release");
     const caskIndex = workflow.indexOf("Update Homebrew Cask");
     expect(verifyIndex).toBeGreaterThan(-1);
     expect(runtimeE2eIndex).toBeGreaterThan(verifyIndex);
-    expect(uploadIndex).toBeGreaterThan(runtimeE2eIndex);
-    expect(uploadIndex).toBeGreaterThan(verifyIndex);
-    expect(caskIndex).toBeGreaterThan(uploadIndex);
+    expect(checksumIndex).toBeGreaterThan(runtimeE2eIndex);
+    expect(uploadIndex).toBeGreaterThan(checksumIndex);
+    expect(publishIndex).toBeGreaterThan(uploadIndex);
+    expect(caskIndex).toBeGreaterThan(publishIndex);
+    expect(workflow).toContain('gh release edit "$TAG_NAME" --draft=false');
     expect(packagedRuntimeE2e).toContain('join(testAppDataRoot, "preferences.json")');
     expect(packagedRuntimeE2e).toContain("openAtLogin: false");
     expect(packagedRuntimeE2e.indexOf("openAtLogin: false")).toBeLessThan(packagedRuntimeE2e.indexOf("spawn(executablePath"));
@@ -213,6 +224,8 @@ describe("distribution config", () => {
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": true,
+      draft: true,
+      "force-tag-creation": true,
       packages: {
         ".": {
           "release-type": "node",


### PR DESCRIPTION
## Intent

Repair the two concrete failures exposed by Baby Menu's first signed release: make the macOS entitlement verifier correctly accept the exact zero-byte no-entitlement output emitted for Electron Framework while strictly allowing only JIT=true and requiring JIT on every process architecture slice, failing on malformed, unreadable, unexpected, or missing-required data; and change release publication to use the repository's supported draft-until-verified flow so signing, notarization, final mounted-DMG verification, packaged runtime E2E, checksum, and upload must all succeed before the stable release becomes public, without mutating baby-menu-v0.1.22, adding cleanup automation, or broadening into unrelated release refactors. Include focused regression tests, release documentation, and complete release-equivalent validation.

## What Changed

- Accept zero-byte `codesign` entitlement output while rejecting malformed, unreadable, unexpected, or invalid entitlement data and requiring JIT on every applicable architecture slice.
- Keep macOS releases as drafts until signing, notarization, mounted-DMG verification, packaged runtime checks, checksum generation, and artifact upload succeed.
- Add focused entitlement and release workflow regression coverage, plus updated release documentation and validation evidence.

## Risk Assessment

✅ Low: The follow-up accurately documents the post-publication Homebrew failure behavior, and the complete change remains well-bounded while satisfying the entitlement and draft-until-verified release invariants.

## Testing

Both focused test files passed, including exact zero-byte acceptance, strict JIT=true enforcement, all required failure modes, per-slice workflow verification, and draft publication ordering. A real Electron Framework reproduced the zero-byte output and passed the verifier; the published v0.1.22 release remained unchanged. Reviewer evidence was captured as Markdown because this change has no UI surface. Credentialed signing, notarization, upload, and publication were not mutated or rerun locally.

- Evidence: [Focused release repair validation](https://github.com/kunchenguid/baby-menu/blob/771ca04128e4cefe66ec0c5ca089d51dedf95721/.no-mistakes/evidence/fm/baby-menu-release-failure-repair-r3/release-repair-validation.md)
- Outcome: ⚠️ 1 warning across 1 run (3m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `CONTRIBUTING.md:52` - This states that any credential failure leaves the release as a draft, but `HOMEBREW_TAP_TOKEN` is first used after `gh release edit &#34;$TAG_NAME&#34; --draft=false`. A missing or invalid tap token therefore fails the job after publication. Narrow this claim to pre-publication credentials or explicitly document that Homebrew publication can fail after the GitHub release becomes public.

🔧 Fix: Clarify post-publication Homebrew failure behavior
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ A real draft-to-public release was not executed because it requires protected Developer ID, Apple notarization, and GitHub release credentials plus external mutation. Decide whether the focused workflow-contract evidence is sufficient or require a credentialed release run before acceptance.
- <code>Inspected `git diff c16b29309c5b1341a05f1bad5c7a6be4a115246b..dc5a59cc83db0f47aebb87a1c3187676d85a3ac9` and relevant workflow, parser, documentation, and tests.</code>
- `pnpm vitest run tests/macos-entitlements-verifier.test.ts tests/release-config.test.ts`
- `pnpm vitest run tests/macos-entitlements-verifier.test.ts tests/release-config.test.ts --reporter=verbose`
- <code>Ran the workflow&#39;s real `codesign -d --arch arm64 --entitlements - --xml` command against Electron 42.2.0&#39;s Electron Framework and verified its zero-byte output with `scripts/verify-macos-entitlements.py`.</code>
- <code>Confirmed the installed Electron artifact is arm64-only with `lipo -archs`; both architecture paths remain covered by focused fixtures and workflow-contract assertions.</code>
- <code>Read-only check: `gh-axi release view baby-menu-v0.1.22` confirmed the existing published release remains present.</code>
- `Checked changed files for tag deletion, force-update, targeted v0.1.22 mutation, or newly added cleanup automation.`
- `Verified testing left no transient entitlement fixture directories in the worktree.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
