### PR TITLE
fix: make draft macOS releases safely recoverable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing draft release tag to rebuild and publish
+        required: true
+        type: string
+      version:
+        description: Existing release version without the tag prefix
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,6 +22,7 @@ permissions:
 
 jobs:
   release-please:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     outputs:
       baby-menu-release-created: ${{ steps.release.outputs.release_created }}
@@ -25,14 +36,14 @@ jobs:
 
   macos:
     needs: release-please
-    if: ${{ needs.release-please.outputs.baby-menu-release-created == 'true' }}
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.release-please.outputs.baby-menu-release-created == 'true') }}
     runs-on: macos-latest
     timeout-minutes: 75
     env:
       TEAM_ID: 9T2J7MNUP9
       BUNDLE_ID: com.kunchenguid.baby-menu
-      TAG_NAME: ${{ needs.release-please.outputs.baby-menu-tag-name }}
-      VERSION: ${{ needs.release-please.outputs.baby-menu-version }}
+      TAG_NAME: ${{ inputs.tag_name || needs.release-please.outputs.baby-menu-tag-name }}
+      VERSION: ${{ inputs.version || needs.release-please.outputs.baby-menu-version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,11 +54,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          RELEASE_DRAFT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft)"
-          if [ "$RELEASE_DRAFT" != "true" ]; then
-            echo "Refusing to build artifacts for a release that is already public: $TAG_NAME" >&2
+          if ! RELEASE_DRAFT="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name == env.TAG_NAME) | .draft' 2>&1)"; then
+            echo "Unable to verify draft status for $TAG_NAME; GitHub release query failed: $RELEASE_DRAFT" >&2
             exit 1
           fi
+          case "$RELEASE_DRAFT" in
+            true) ;;
+            false)
+              echo "Refusing to build artifacts for a release that is already public: $TAG_NAME" >&2
+              exit 1
+              ;;
+            "")
+              echo "No GitHub release exists for tag $TAG_NAME; refusing to build artifacts." >&2
+              exit 1
+              ;;
+            *)
+              echo "Unable to verify draft status for $TAG_NAME; expected one release, got: $RELEASE_DRAFT" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Verify macOS release tools
         run: |
@@ -440,11 +466,26 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          RELEASE_DRAFT="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft)"
-          if [ "$RELEASE_DRAFT" != "true" ]; then
-            echo "Refusing to publish a release that is not draft: $TAG_NAME" >&2
+          if ! RELEASE_DRAFT="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.tag_name == env.TAG_NAME) | .draft' 2>&1)"; then
+            echo "Unable to verify draft status before publishing $TAG_NAME; GitHub release query failed: $RELEASE_DRAFT" >&2
             exit 1
           fi
+          case "$RELEASE_DRAFT" in
+            true) ;;
+            false)
+              echo "Refusing to publish a release that is already public: $TAG_NAME" >&2
+              exit 1
+              ;;
+            "")
+              echo "No GitHub release exists for tag $TAG_NAME; refusing to publish." >&2
+              exit 1
+              ;;
+            *)
+              echo "Unable to verify draft status before publishing $TAG_NAME; expected one release, got: $RELEASE_DRAFT" >&2
+              exit 1
+              ;;
+          esac
           gh release edit "$TAG_NAME" --draft=false
 
       - name: Update Homebrew Cask

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,15 +39,38 @@ jobs:
     if: ${{ always() && (github.event_name == 'workflow_dispatch' || needs.release-please.outputs.baby-menu-release-created == 'true') }}
     runs-on: macos-latest
     timeout-minutes: 75
+    concurrency:
+      group: ${{ github.workflow }}-macos-${{ inputs.tag_name || needs.release-please.outputs.baby-menu-tag-name }}
+      cancel-in-progress: false
     env:
       TEAM_ID: 9T2J7MNUP9
       BUNDLE_ID: com.kunchenguid.baby-menu
       TAG_NAME: ${{ inputs.tag_name || needs.release-please.outputs.baby-menu-tag-name }}
       VERSION: ${{ inputs.version || needs.release-please.outputs.baby-menu-version }}
     steps:
+      - name: Validate manual recovery target
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          if [ "$TAG_NAME" != "baby-menu-v0.1.23" ] || [ "$VERSION" != "0.1.23" ]; then
+            echo "Manual recovery is restricted to baby-menu-v0.1.23 at version 0.1.23." >&2
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
-          ref: ${{ env.TAG_NAME }}
+          ref: refs/tags/${{ env.TAG_NAME }}
+
+      - name: Verify manual recovery commit
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          EXPECTED_COMMIT="a8fd9cf3cda01277358a8b5e225e2ace7b0c0593"
+          ACTUAL_COMMIT="$(git rev-parse HEAD)"
+          if [ "$ACTUAL_COMMIT" != "$EXPECTED_COMMIT" ]; then
+            echo "Manual recovery tag $TAG_NAME resolved to untrusted commit $ACTUAL_COMMIT." >&2
+            exit 1
+          fi
 
       - name: Verify release is still draft
         env:

--- a/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/manual-recovery-contract.md
+++ b/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/manual-recovery-contract.md
@@ -1,0 +1,53 @@
+# 0.1.23 manual recovery contract
+
+The recovery path was inspected and exercised without dispatching the release, which would mutate the real GitHub release before this fix is merged.
+
+## Existing target identity
+
+```text
+$ git ls-remote --tags origin refs/tags/baby-menu-v0.1.23 refs/tags/baby-menu-v0.1.23^{}
+a8fd9cf3cda01277358a8b5e225e2ace7b0c0593	refs/tags/baby-menu-v0.1.23
+```
+
+This matches the workflow's pinned `EXPECTED_COMMIT`.
+
+## Operator entry point and fail-closed restrictions
+
+The `workflow_dispatch` entry point requires both:
+
+```text
+tag_name = baby-menu-v0.1.23
+version  = 0.1.23
+```
+
+Any other pair exits before checkout with:
+
+```text
+Manual recovery is restricted to baby-menu-v0.1.23 at version 0.1.23.
+```
+
+Direct execution of the workflow condition produced:
+
+```text
+accepted: baby-menu-v0.1.23 0.1.23
+Manual recovery is restricted to baby-menu-v0.1.23 at version 0.1.23.
+```
+
+After checkout, the workflow compares `git rev-parse HEAD` with the pinned commit above and exits before loading credentials if they differ.
+
+## Recovery sequence retained
+
+The focused workflow contract test verifies this order:
+
+1. Check out `refs/tags/baby-menu-v0.1.23`.
+2. Verify the pinned release commit.
+3. Confirm the existing GitHub release is still a draft.
+4. Restore signing and notarization credentials.
+5. Build the universal app and DMG.
+6. Submit for notarization and staple the DMG.
+7. Verify codesign identity, hardened runtime, architectures, entitlements, Gatekeeper acceptance, app and DMG stapled tickets, and packaged-app launch.
+8. Compute a non-empty artifact checksum.
+9. Upload the DMG to the existing draft with `--clobber`.
+10. Recheck draft state and publish that same release.
+
+There is no release-creation step in manual recovery, so the path cannot create a new version or substitute a hand-upload flow.

--- a/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/release-draft-guard-transcript.md
+++ b/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/release-draft-guard-transcript.md
@@ -1,0 +1,32 @@
+# Release draft guard - operator-visible behavior
+
+The exact `Verify release is still draft` script was extracted from `.github/workflows/release-please.yml` and executed with deterministic GitHub API responses for `baby-menu-v0.1.23`.
+
+## Draft release
+
+```text
+exit: 0
+Guard passed; signed build may proceed.
+```
+
+## Already published release
+
+```text
+exit: 1
+Refusing to build artifacts for a release that is already public: baby-menu-v0.1.23
+```
+
+## No release for tag
+
+```text
+exit: 1
+No GitHub release exists for tag baby-menu-v0.1.23; refusing to build artifacts.
+```
+
+## GitHub query unavailable
+
+```text
+exit: 1
+Unable to verify draft status for baby-menu-v0.1.23; GitHub release query failed: gh: API unavailable (HTTP 503)
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,8 @@ Maintainers must keep these repository secrets provisioned from the canonical se
 Never commit or print credential contents. Missing or malformed secrets fail the real release job; pull-request CI remains secret-free and validates the release config through `tests/release-config.test.ts`.
 Maintainers must also keep the `BABY_MENU_UMAMI_WEBSITE_ID` GitHub Actions repository variable configured for packaged-release telemetry; it is intentionally a variable rather than a secret because the id is baked into the app and sent in Umami payloads.
 
-To release, merge the release-please PR and require the `release-please` workflow's macOS job to pass. The release remains a draft until the signed artifact passes verification and runtime E2E, receives a valid checksum, and uploads successfully. Do not upload a replacement DMG or update the tap by hand unless repairing a failed release.
+To release, merge the release-please PR and require the `release-please` workflow's macOS job to pass. The release remains a draft until the signed artifact passes verification and runtime E2E, receives a valid checksum, and uploads successfully. Do not upload a replacement DMG or update the tap by hand.
+For the interrupted `0.1.23` release only, manually dispatch the `release-please` workflow with tag `baby-menu-v0.1.23` and version `0.1.23`. This recovery path checks out the existing trusted tag, requires its GitHub Release to remain a draft, and reruns the normal signed, notarized, verified build and publish flow. It refuses any other tag, version, commit, missing release, already-published release, or uncertain GitHub query result.
 For a post-release check of exactly the downloaded artifact on macOS:
 
 ```sh

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -146,7 +146,12 @@ describe("distribution config", () => {
     expect(workflow).toContain("baby-menu-version: ${{ steps.release.outputs.version }}");
     expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
     expect(workflow).toContain("needs.release-please.outputs.baby-menu-release-created == 'true'");
-    expect(workflow).toContain("ref: ${{ env.TAG_NAME }}");
+    expect(workflow).toContain("group: ${{ github.workflow }}-macos-${{ inputs.tag_name");
+    expect(workflow).toContain("cancel-in-progress: false");
+    expect(workflow).toContain("ref: refs/tags/${{ env.TAG_NAME }}");
+    expect(workflow).toContain('if [ "$TAG_NAME" != "baby-menu-v0.1.23" ] || [ "$VERSION" != "0.1.23" ]');
+    expect(workflow).toContain('EXPECTED_COMMIT="a8fd9cf3cda01277358a8b5e225e2ace7b0c0593"');
+    expect(workflow).toContain('ACTUAL_COMMIT="$(git rev-parse HEAD)"');
     expect(workflow).toContain("TEAM_ID: 9T2J7MNUP9");
     expect(workflow).toContain("BUNDLE_ID: com.kunchenguid.baby-menu");
     for (const secret of [
@@ -209,6 +214,15 @@ describe("distribution config", () => {
     expect(workflow).toContain("workflow_dispatch:");
     expect(workflow).toContain("tag_name:");
     expect(workflow).toContain("version:");
+
+    const recoveryTargetIndex = workflow.indexOf("Validate manual recovery target");
+    const checkoutIndex = workflow.indexOf("actions/checkout@v6");
+    const recoveryCommitIndex = workflow.indexOf("Verify manual recovery commit");
+    const credentialsIndex = workflow.indexOf("Restore App Store Connect API key");
+    expect(recoveryTargetIndex).toBeGreaterThan(-1);
+    expect(checkoutIndex).toBeGreaterThan(recoveryTargetIndex);
+    expect(recoveryCommitIndex).toBeGreaterThan(checkoutIndex);
+    expect(credentialsIndex).toBeGreaterThan(recoveryCommitIndex);
 
     const verifyIndex = workflow.indexOf("Verify publication-ready signed and notarized DMG");
     const runtimeE2eIndex = workflow.indexOf('node scripts/e2e-packaged-mac-app.mjs "$APP_PATH"');

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -17,12 +17,12 @@ async function releaseDraftGuard(): Promise<string> {
   return match.groups.script.replace(/^ {10}/gm, "");
 }
 
-async function runReleaseDraftGuard(releaseState: "true" | "false" | "missing") {
+async function runReleaseDraftGuard(releaseState: "true" | "false" | "missing" | "query-error") {
   const tempDirectory = await mkdtemp(join(tmpdir(), "baby-menu-release-guard-"));
   const ghPath = join(tempDirectory, "gh");
   await writeFile(
     ghPath,
-    `#!/bin/sh\ncase "$*" in\n  *releases/tags/*) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;\nesac\nif [ "$GH_RELEASE_STATE" != "missing" ]; then printf '%s\\n' "$GH_RELEASE_STATE"; fi\n`,
+    `#!/bin/sh\ncase "$*" in\n  *releases/tags/*) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;\nesac\nif [ "$GH_RELEASE_STATE" = "query-error" ]; then echo "gh: API unavailable (HTTP 503)" >&2; exit 1; fi\nif [ "$GH_RELEASE_STATE" != "missing" ]; then printf '%s\\n' "$GH_RELEASE_STATE"; fi\n`,
   );
   await chmod(ghPath, 0o755);
 
@@ -58,6 +58,14 @@ describe("release draft guard", () => {
     await expect(runReleaseDraftGuard("missing")).rejects.toMatchObject({
       stderr: expect.stringContaining(
         "No GitHub release exists for tag baby-menu-v0.1.23; refusing to build artifacts.",
+      ),
+    });
+  });
+
+  it("fails explicitly when GitHub release state cannot be queried", async () => {
+    await expect(runReleaseDraftGuard("query-error")).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        "Unable to verify draft status for baby-menu-v0.1.23; GitHub release query failed: gh: API unavailable (HTTP 503)",
       ),
     });
   });

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -1,11 +1,67 @@
 import { execFile } from "node:child_process";
-import { readFile, stat } from "node:fs/promises";
-import { resolve } from "node:path";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import packageJson from "../package.json";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+
+async function releaseDraftGuard(): Promise<string> {
+  const workflow = await readFile(resolve(import.meta.dirname, "../.github/workflows/release-please.yml"), "utf8");
+  const match = workflow.match(/- name: Verify release is still draft\n[\s\S]*?        run: \|\n(?<script>(?: {10}.*\n)+)/);
+  if (!match?.groups?.script) {
+    throw new Error("Could not find the release draft guard in the release workflow");
+  }
+  return match.groups.script.replace(/^ {10}/gm, "");
+}
+
+async function runReleaseDraftGuard(releaseState: "true" | "false" | "missing") {
+  const tempDirectory = await mkdtemp(join(tmpdir(), "baby-menu-release-guard-"));
+  const ghPath = join(tempDirectory, "gh");
+  await writeFile(
+    ghPath,
+    `#!/bin/sh\ncase "$*" in\n  *releases/tags/*) echo "gh: Not Found (HTTP 404)" >&2; exit 1 ;;\nesac\nif [ "$GH_RELEASE_STATE" != "missing" ]; then printf '%s\\n' "$GH_RELEASE_STATE"; fi\n`,
+  );
+  await chmod(ghPath, 0o755);
+
+  try {
+    return await execFileAsync("/bin/bash", ["-c", await releaseDraftGuard()], {
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: "kunchenguid/baby-menu",
+        TAG_NAME: "baby-menu-v0.1.23",
+        GH_RELEASE_STATE: releaseState,
+        PATH: `${tempDirectory}:${process.env.PATH ?? ""}`,
+      },
+    });
+  } finally {
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+describe("release draft guard", () => {
+  it("passes when the tagged release exists as a draft", async () => {
+    await expect(runReleaseDraftGuard("true")).resolves.toBeDefined();
+  });
+
+  it("refuses when the tagged release is already published", async () => {
+    await expect(runReleaseDraftGuard("false")).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        "Refusing to build artifacts for a release that is already public: baby-menu-v0.1.23",
+      ),
+    });
+  });
+
+  it("fails distinctly when no release exists for the tag", async () => {
+    await expect(runReleaseDraftGuard("missing")).rejects.toMatchObject({
+      stderr: expect.stringContaining(
+        "No GitHub release exists for tag baby-menu-v0.1.23; refusing to build artifacts.",
+      ),
+    });
+  });
+});
 
 describe("distribution config", () => {
   it("adds mac packaging scripts and keeps TypeScript available at runtime for extension compilation", () => {
@@ -88,7 +144,8 @@ describe("distribution config", () => {
     expect(workflow).toContain("baby-menu-release-created: ${{ steps.release.outputs.release_created }}");
     expect(workflow).toContain("baby-menu-tag-name: ${{ steps.release.outputs.tag_name }}");
     expect(workflow).toContain("baby-menu-version: ${{ steps.release.outputs.version }}");
-    expect(workflow).toContain("if: ${{ needs.release-please.outputs.baby-menu-release-created == 'true' }}");
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain("needs.release-please.outputs.baby-menu-release-created == 'true'");
     expect(workflow).toContain("ref: ${{ env.TAG_NAME }}");
     expect(workflow).toContain("TEAM_ID: 9T2J7MNUP9");
     expect(workflow).toContain("BUNDLE_ID: com.kunchenguid.baby-menu");
@@ -147,7 +204,11 @@ describe("distribution config", () => {
     expect(workflow).toContain('ARCHITECTURES" != "arm64 x86_64"');
 
     expect(workflow).toContain("Verify release is still draft");
-    expect(workflow).toContain('gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG_NAME}" --jq .draft');
+    expect(workflow).toContain('gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100"');
+    expect(workflow).not.toContain('releases/tags/${TAG_NAME}');
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("tag_name:");
+    expect(workflow).toContain("version:");
 
     const verifyIndex = workflow.indexOf("Verify publication-ready signed and notarized DMG");
     const runtimeE2eIndex = workflow.indexOf('node scripts/e2e-packaged-mac-app.mjs "$APP_PATH"');


### PR DESCRIPTION
## Intent

Fix the draft-until-verified macOS release guard that permanently blocked release 0.1.23 because GitHub's get-release-by-tag REST endpoint is blind to draft releases. Preserve fail-closed safety and distinguish draft (proceed), already published (refuse with the existing dangerous-case message), no release (distinct refusal), and query uncertainty (explicit refusal). Add regression coverage proving both draft success and published refusal, plus a supported manual-dispatch recovery path that rebuilds and publishes the existing baby-menu-v0.1.23 tag with signed, notarized, non-empty assets rather than creating a new version or hand-uploading artifacts. Record in PR intent that this defect is exactly what a real credentialed release run would have caught and contract-level evidence did not. After merge, use the supported path to finish 0.1.23 and verify published state, assets, codesign, Gatekeeper, and stapled tickets. Leave the broken 0.1.22 release alone.

## What Changed

- Make the macOS release guard detect draft releases through the paginated releases API while refusing published, missing, ambiguous, or unqueryable states.
- Add a serialized manual recovery path restricted to the trusted `baby-menu-v0.1.23` tag and commit, reusing the signed and notarized release flow.
- Add regression coverage and maintainer documentation for the draft guard and 0.1.23 recovery procedure.

## Risk Assessment

✅ Low: The updated change safely constrains recovery to the trusted 0.1.23 tag commit, serializes same-tag release jobs, and preserves distinct fail-closed handling for draft, published, missing, and uncertain release states.

## Testing

The focused workflow contract passes, all four release-state branches produced the expected operator-visible results, and the restricted 0.1.23 recovery path was validated against the real remote tag identity. A real dispatch was not run because publishing is explicitly an after-merge operation. No screenshot applies because this is a text-based GitHub Actions operator workflow, not an app UI.

- Evidence: [Four-state release guard transcript](https://github.com/kunchenguid/baby-menu/blob/ad533945c9d87c764221a350d4656d7e605f255b/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/release-draft-guard-transcript.md)
- Evidence: [0.1.23 manual recovery contract](https://github.com/kunchenguid/baby-menu/blob/ad533945c9d87c764221a350d4656d7e605f255b/.no-mistakes/evidence/fm/baby-menu-draft-guard-fix-r1/manual-recovery-contract.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `.github/workflows/release-please.yml:39` - The new manual-dispatch path has no per-tag concurrency guard. Two dispatches for the same draft can both pass the initial check; after the first uploads and publishes, the second can execute `gh release upload --clobber` against the now-public release before its later draft check refuses. This can replace the public DMG with different bytes and invalidate the Homebrew checksum, contradicting the required &#34;Preserve fail-closed safety&#34; behavior. Serialize release jobs by tag at the job boundary so the later run rechecks state before building or uploading.
- 🚨 `.github/workflows/release-please.yml:45` - The dispatch-controlled `TAG_NAME` is passed directly to `actions/checkout`, which accepts branches as well as tags, and the checked-out code is subsequently run while signing credentials are present. A writer can create a draft plus a same-named branch or arbitrary tag containing modified package scripts, then dispatch the workflow to execute that code with release credentials. Fully qualify the checkout as `refs/tags/...` and, before restoring credentials, restrict this recovery path to the authorized 0.1.23 tag/version and verify its commit against a trusted immutable SHA or trusted main ancestry.

🔧 Fix: Harden manual release recovery trust and concurrency
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm vitest run tests/release-config.test.ts`
- `Executed the exact extracted release guard for draft, published, missing, and GitHub-query-error responses`
- <code>Executed the manual recovery target condition with accepted `baby-menu-v0.1.23` / `0.1.23` and rejected `baby-menu-v0.1.24` / `0.1.24`</code>
- `git ls-remote --tags origin 'refs/tags/baby-menu-v0.1.23' 'refs/tags/baby-menu-v0.1.23^{}'`
- `gh-axi release view baby-menu-v0.1.23 --full`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
