### PR TITLE
fix: probe an interactive login shell for the GUI PATH

### DIFF
--- a/src/adapters/claude/driver.ts
+++ b/src/adapters/claude/driver.ts
@@ -141,7 +141,13 @@ export class ClaudeDriver implements SessionDriver {
       child.stderr.on("data", (chunk: string) => logDebug(SCOPE, "stderr", chunk.trimEnd()));
       child.on("error", () => {
         if (cancelled) settle("cancelled");
-        else fail(new AdapterTurnError("CLI_START_FAILED", "Claude CLI could not be started."));
+        else
+          fail(
+            new AdapterTurnError(
+              "CLI_START_FAILED",
+              `Claude CLI could not be started: "${this.command}" was not found on PATH.`,
+            ),
+          );
       });
       child.on("exit", (code) => {
         logDebug(SCOPE, "claude exited", code);

--- a/src/adapters/codex/driver.ts
+++ b/src/adapters/codex/driver.ts
@@ -155,7 +155,13 @@ export class CodexDriver implements SessionDriver {
       child.stderr.on("data", (chunk: string) => logDebug(SCOPE, "stderr", chunk.trimEnd()));
       child.on("error", () => {
         if (cancelled) settle("cancelled");
-        else fail(new AdapterTurnError("CLI_START_FAILED", "Codex CLI could not be started."));
+        else
+          fail(
+            new AdapterTurnError(
+              "CLI_START_FAILED",
+              `Codex CLI could not be started: "${this.command}" was not found on PATH.`,
+            ),
+          );
       });
       child.on("exit", (code) => {
         logDebug(SCOPE, "codex exec exited", code);

--- a/src/main/shell-path.ts
+++ b/src/main/shell-path.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { basename } from "node:path";
 import { homedir } from "node:os";
 
 type MergeShellPathOptions = {
@@ -7,7 +8,41 @@ type MergeShellPathOptions = {
   shellPath?: string;
 };
 
+type SpawnSyncLike = (
+  command: string,
+  args: string[],
+  options: { encoding: "utf8"; timeout: number; stdio: ["ignore", "pipe", "ignore"] },
+) => { status: number | null; stdout: string | null; error?: Error };
+
+type ReadLoginShellPathOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  spawn?: SpawnSyncLike;
+  timeoutMs?: number;
+};
+
 const COMMON_GUI_PATHS = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"];
+
+const DEFAULT_SHELL = "/bin/zsh";
+/**
+ * Shells whose `-i -l -c` behavior and `$PATH` scalar semantics we rely on.
+ * Deliberately excludes fish, where `$PATH` is a list and expands
+ * space-separated.
+ */
+const SUPPORTED_PROBE_SHELLS = new Set(["zsh", "bash", "sh", "ksh", "ksh93", "dash"]);
+/**
+ * Interactive rc files routinely print to stdout (prompt tools, version manager
+ * banners), so the value is delimited instead of assuming stdout is only PATH.
+ */
+const PROBE_MARKER = "__BABY_MENU_PATH_PROBE__";
+// `${PATH}` must be braced: bare `$PATH` followed by the marker would parse as
+// one (unset) variable name and silently yield an empty value.
+const PROBE_COMMAND = `printf '%s\\n' "${PROBE_MARKER}\${PATH}${PROBE_MARKER}"`;
+/**
+ * An interactive shell that initializes several version managers can take
+ * seconds on a cold start; a timeout here silently costs us the real PATH.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
 
 export function mergeShellPath(options: MergeShellPathOptions = {}): string {
   const homeDir = options.homeDir ?? homedir();
@@ -21,15 +56,52 @@ export function mergeShellPath(options: MergeShellPathOptions = {}): string {
   return [...new Set(segments.map((segment) => segment.trim()).filter(Boolean))].join(":");
 }
 
-export function readLoginShellPath(): string | undefined {
-  if (process.platform === "win32") return undefined;
-  const result = spawnSync("/bin/zsh", ["-lc", "print -r -- $PATH"], {
-    encoding: "utf8",
-    timeout: 2000,
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  if (result.status !== 0) return undefined;
-  return result.stdout.trim() || undefined;
+export function resolveProbeShell(shell: string | undefined): string {
+  const candidate = (shell ?? "").trim();
+  if (!candidate.startsWith("/")) return DEFAULT_SHELL;
+  return SUPPORTED_PROBE_SHELLS.has(basename(candidate)) ? candidate : DEFAULT_SHELL;
+}
+
+function extractProbePath(stdout: string | null): string | undefined {
+  const start = stdout?.indexOf(PROBE_MARKER) ?? -1;
+  if (start < 0) return undefined;
+  const valueStart = start + PROBE_MARKER.length;
+  const end = stdout!.indexOf(PROBE_MARKER, valueStart);
+  if (end < 0) return undefined;
+  const value = stdout!.slice(valueStart, end).trim();
+  // Anything that is not recognizably a PATH must be rejected, not merged.
+  if (!value.split(":").some((segment) => segment.trim().startsWith("/"))) return undefined;
+  return value;
+}
+
+/**
+ * Reads the PATH of an *interactive* login shell. A non-interactive login shell
+ * never sources `~/.zshrc` (or `~/.bashrc`), which is where version managers
+ * such as asdf, nvm, mise, rbenv, volta, and fnm install their shims - so the
+ * non-interactive probe returns a PATH without them and GUI launches cannot
+ * find the agent CLIs. Never throws and never blocks startup: any failure
+ * returns `undefined` and the caller merges what it already has.
+ */
+export function readLoginShellPath(options: ReadLoginShellPathOptions = {}): string | undefined {
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") return undefined;
+  const env = options.env ?? process.env;
+  const spawn = options.spawn ?? (spawnSync as unknown as SpawnSyncLike);
+  const shell = resolveProbeShell(env.SHELL);
+
+  let result: { status: number | null; stdout: string | null; error?: Error };
+  try {
+    result = spawn(shell, ["-i", "-l", "-c", PROBE_COMMAND], {
+      encoding: "utf8",
+      timeout: options.timeoutMs ?? PROBE_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return undefined;
+  }
+  // A timeout leaves `status` null (and sets `error`), which this rejects too.
+  if (result.error || result.status !== 0) return undefined;
+  return extractProbePath(result.stdout);
 }
 
 export function expandProcessPathForGuiLaunch(): string {

--- a/tests/shell-path.test.ts
+++ b/tests/shell-path.test.ts
@@ -1,0 +1,133 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { mergeShellPath, readLoginShellPath, resolveProbeShell } from "../src/main/shell-path";
+
+type ProbeCall = { command: string; args: string[]; timeout: number };
+
+function recordingSpawn(result: { status: number | null; stdout: string | null; error?: Error }) {
+  const calls: ProbeCall[] = [];
+  const spawn = (command: string, args: string[], options: { timeout: number }) => {
+    calls.push({ command, args, timeout: options.timeout });
+    return result;
+  };
+  return { calls, spawn };
+}
+
+function probeStdout(pathValue: string): string {
+  return `__BABY_MENU_PATH_PROBE__${pathValue}__BABY_MENU_PATH_PROBE__\n`;
+}
+
+describe("mergeShellPath", () => {
+  it("dedupes segments and preserves first-seen order", () => {
+    expect(
+      mergeShellPath({
+        currentPath: "/usr/bin:/bin",
+        homeDir: "/Users/me",
+        shellPath: "/Users/me/.asdf/shims:/opt/homebrew/bin:/usr/bin",
+      }),
+    ).toBe(
+      [
+        "/usr/bin",
+        "/bin",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/sbin",
+        "/Users/me/.local/bin",
+        "/Users/me/.asdf/shims",
+      ].join(":"),
+    );
+  });
+
+  it("still yields the common GUI paths when nothing is passed in", () => {
+    expect(mergeShellPath({ homeDir: "/Users/me" }).split(":")).toContain("/opt/homebrew/bin");
+  });
+});
+
+describe("resolveProbeShell", () => {
+  it("prefers the user's own shell when it is a recognized POSIX shell", () => {
+    expect(resolveProbeShell("/bin/bash")).toBe("/bin/bash");
+    expect(resolveProbeShell("/opt/homebrew/bin/zsh")).toBe("/opt/homebrew/bin/zsh");
+  });
+
+  it("falls back to /bin/zsh for unset, relative, or unsupported shells", () => {
+    expect(resolveProbeShell(undefined)).toBe("/bin/zsh");
+    expect(resolveProbeShell("zsh")).toBe("/bin/zsh");
+    expect(resolveProbeShell("/opt/homebrew/bin/fish")).toBe("/bin/zsh");
+  });
+});
+
+describe("readLoginShellPath", () => {
+  it("probes an interactive login shell so rc files (and version manager shims) are sourced", () => {
+    const { calls, spawn } = recordingSpawn({
+      status: 0,
+      stdout: probeStdout("/Users/me/.asdf/shims:/usr/bin:/bin"),
+    });
+
+    const result = readLoginShellPath({ platform: "darwin", env: { SHELL: "/bin/zsh" }, spawn });
+
+    expect(result).toBe("/Users/me/.asdf/shims:/usr/bin:/bin");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe("/bin/zsh");
+    expect(calls[0].args.slice(0, 3)).toEqual(["-i", "-l", "-c"]);
+    expect(calls[0].timeout).toBeGreaterThan(2000);
+  });
+
+  it("extracts the delimited PATH even when interactive rc files pollute stdout", () => {
+    const { spawn } = recordingSpawn({
+      status: 0,
+      stdout: [
+        "mise: activating",
+        "welcome back!",
+        probeStdout("/Users/me/.local/share/mise/shims:/usr/bin").trimEnd(),
+        "some trailing rc chatter",
+      ].join("\n"),
+    });
+
+    expect(readLoginShellPath({ platform: "darwin", env: {}, spawn })).toBe(
+      "/Users/me/.local/share/mise/shims:/usr/bin",
+    );
+  });
+
+  it("returns undefined on a non-zero exit", () => {
+    const { spawn } = recordingSpawn({ status: 1, stdout: probeStdout("/usr/bin") });
+    expect(readLoginShellPath({ platform: "darwin", env: {}, spawn })).toBeUndefined();
+  });
+
+  it("returns undefined when the probe times out", () => {
+    const { spawn } = recordingSpawn({ status: null, stdout: "", error: new Error("ETIMEDOUT") });
+    expect(readLoginShellPath({ platform: "darwin", env: {}, spawn })).toBeUndefined();
+  });
+
+  it("rejects junk output instead of merging it", () => {
+    for (const stdout of [null, "", "no shell here", probeStdout("not-a-path"), "__BABY_MENU_PATH_PROBE__/usr/bin"]) {
+      const { spawn } = recordingSpawn({ status: 0, stdout });
+      expect(readLoginShellPath({ platform: "darwin", env: {}, spawn })).toBeUndefined();
+    }
+  });
+
+  it("never throws when spawning the probe fails outright", () => {
+    const spawn = () => {
+      throw new Error("EACCES");
+    };
+    expect(readLoginShellPath({ platform: "darwin", env: {}, spawn })).toBeUndefined();
+  });
+
+  it("returns undefined on win32 without spawning anything", () => {
+    const { calls, spawn } = recordingSpawn({ status: 0, stdout: probeStdout("/usr/bin") });
+    expect(readLoginShellPath({ platform: "win32", env: {}, spawn })).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
+  // Guards the probe command itself: a bare `$PATH` before the marker would
+  // parse as one unset variable name and return an empty value.
+  it.skipIf(process.platform === "win32" || !existsSync("/bin/zsh"))(
+    "reads a plausible PATH out of a real interactive login zsh",
+    () => {
+      const result = readLoginShellPath({ env: { ...process.env, SHELL: "/bin/zsh" } });
+      expect(result).toBeDefined();
+      expect(result).not.toContain("\n");
+      expect(result).toContain("/usr/bin");
+    },
+  );
+});


### PR DESCRIPTION
## Symptom

On a GUI-launched (Dock / login-item) Baby Menu, every agent turn fails immediately with:

> Agent unavailable / Internal error: Claude CLI could not be started.

It works fine when the app is started from a terminal, which is what makes it look like an adapter bug rather than an environment one.

## Root cause

`readLoginShellPath()` in `src/main/shell-path.ts` probed the user's PATH with:

```
/bin/zsh -lc "print -r -- $PATH"
```

That is a **non-interactive login** shell. It sources `/etc/zprofile`, `~/.zprofile` and `~/.zlogin` - but **never `~/.zshrc`**, which is where essentially every version manager (asdf, nvm, mise, rbenv, volta, fnm) installs its shim directory. So:

1. The probe returns a PATH without the shims.
2. `mergeShellPath()` has nothing useful to merge on top of the bare GUI PATH.
3. `ClaudeDriver` spawns the bare command `claude` and gets ENOENT. `CodexDriver` has the identical exposure.

Evidence from the reporting machine (macOS 15, zsh, asdf-managed node):

- `claude` exists only at `~/.asdf/shims/claude`; asdf is initialised in `~/.zshrc` only.
- The Dock-launched app process had `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin`.
- `zsh -lc 'print -r -- $PATH'` -> exit 0, **no** `~/.asdf/shims`.
- `zsh -ilc 'print -r -- $PATH'` -> exit 0, **includes** `~/.asdf/shims`.
- Running the driver's exact argv under a reconstructed GUI environment succeeds once the shims are on PATH.

## What this changes

`src/main/shell-path.ts`:

- Probes an **interactive** login shell (`-i -l -c`) so rc files are sourced. Prefers `$SHELL` when it is a recognised POSIX shell (`zsh`, `bash`, `sh`, `ksh`, `ksh93`, `dash`), otherwise falls back to `/bin/zsh`. fish is deliberately excluded, because its `$PATH` is a list and would expand space-separated.
- Parses defensively. An interactive rc file writes to stdout (prompt tools, version-manager banners), so the value is delimited with a marker and extracted from between the markers rather than assuming stdout *is* the PATH. A value that does not look like a PATH is rejected rather than merged. (`${PATH}` is braced deliberately - a bare `$PATH` immediately followed by the marker parses as one unset variable name and silently yields an empty value.)
- Raises the probe timeout from 2s to a still-bounded 10s.
- Failure behaviour is unchanged: return `undefined` and merge what we already have. It never throws (the `spawnSync` call is wrapped too) and never blocks past the timeout. `win32` still returns `undefined` without spawning.
- Adds an exported `resolveProbeShell()` and injectable `{platform, env, spawn, timeoutMs}` options so the behaviour is unit-testable without mocking `node:child_process`.

Also, in `src/adapters/{claude,codex}/driver.ts`, the `CLI_START_FAILED` message now names the command and mentions PATH:

> Claude CLI could not be started: "claude" was not found on PATH.

The old message gave the reporting user nothing to act on. This is a two-line change per driver, no refactor.

`COMMON_GUI_PATHS` policy is untouched, no dependency changes.

## Tradeoff you may want to weigh

`expandProcessPathForGuiLaunch()` runs **synchronously before `app.whenReady()`** (`src/main/app.ts:147-148`), and this PR raises the probe ceiling from 2s to 10s. So a pathologically slow interactive shell startup could now delay app launch by up to 10s where it previously capped at 2s.

The reason for raising it: an rc file that initialises several version managers routinely exceeds 2s on a cold start, and a timeout there degrades **silently** back to the broken PATH - which is exactly the failure this PR is fixing, just intermittently instead of always. Measured cost on the reporting machine was 0.17s.

I'm happy to make the probe non-blocking, or lower the ceiling, if you'd prefer a different balance - just say which and I'll push the change.

## Verification

- New `tests/shell-path.test.ts`, 12 tests: the interactive flags are passed; a polluted-stdout probe still yields the PATH; non-zero exit, timeout, junk output and a spawn-throw each fall back to `undefined`; `win32` returns `undefined` without spawning; `mergeShellPath` still dedupes and preserves order; `resolveProbeShell` selection and fallbacks. Plus one test that runs a real `/bin/zsh -i -l -c` probe (skipped where `/bin/zsh` is absent) - that one exists specifically to pin the `${PATH}` quoting, which an earlier draft of this fix got wrong.
- `pnpm test`: 72 files passed, 1 skipped; 568 tests passed, 2 skipped.
- `pnpm typecheck` and `pnpm lint`: clean.
