### PR TITLE
chore: gitignore no-mistakes evidence dir (contributor safety)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ Thumbs.db
 # macOS signing and credentials
 *.p12
 *.mobileprovision
+.no-mistakes/evidence/


### PR DESCRIPTION
Adds a single line to `.gitignore`:

```
.no-mistakes/evidence/
```

## Why

no-mistakes versions before 1.47 wrote test-evidence artifacts *into* the worktree at `.no-mistakes/evidence/`, which made it easy to accidentally commit generated evidence into a branch. Current no-mistakes writes evidence outside the worktree, so this repo's own fleet is already safe.

This is contributor-safety insurance: an external contributor running an older or differently configured no-mistakes binary can no longer stage and commit an evidence directory by accident.

## Scope

- Only `.gitignore` changes; one added line.
- Ignores **only** the `evidence/` subdirectory, not all of `.no-mistakes/`, so gate config intentionally tracked there stays tracked.
- Verified no currently tracked file becomes ignored by this rule.
