### PR TITLE
docs: define project vision and acceptance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 This file provides guidance for developing baby-menu itself.
 Embedded agents launched from baby-menu should work from the active extension workspace and follow the copied `AGENTS.md` there for extension authoring.
+`VISION.md` at the repo root is the project's acceptance policy; use its aligns/resisted tests when judging whether a change belongs here.
 
 ## Commands
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,70 @@
+# Vision
+
+`baby-menu` exists so that a person can grow their own menu bar by asking for it, instead of waiting for someone else to ship the widget they wanted.
+It serves one person on their own machine, running an authenticated coding agent CLI, and it turns a plain-English request into a live widget in their own menu.
+It owns exactly one thing: the tray popover surface and the safe loop that lets an embedded agent edit it while it is running.
+
+## The extension workspace is the product
+
+The agent edits extensions, never the host.
+Widgets, root layouts, settings sections, server actions, and background tasks all live in the active extension workspace, and new capability arrives as a new extension.
+The core stays immutable at runtime, because that immutability is what keeps baseline behavior stable and the security posture enforced.
+`src/main`, `src/preload`, and the IPC wiring stay boring infrastructure, and growing them to serve one widget is the wrong shape.
+Everything an extension can reach arrives through the stable `window.babyMenu` bridge and the generated `@babymenu/contracts` surface.
+Per-widget IPC channels and per-capability preload methods are refused.
+Widgets may reach past `react` and `@babymenu/ui`, but never by lengthening a hardcoded in-bundle allowlist, so that capability has to arrive as its own explicit mechanism.
+Privileged work - filesystem, shell, network, credentials, tokens - lives in extension server actions in the main process, and only normalized non-secret data crosses into the renderer.
+
+## The user can always undo
+
+An agent that edits running software is only acceptable if the user can take it back.
+Every accepted turn runs inside a change session, and the diff that session records is what the Keep/Undo bar reports.
+Ultimate control sits with the user, so the guarantee is the ability to undo rather than a mandatory confirmation: a user may opt into keeping turns automatically, and may never be opted out of being able to undo them.
+The tracked-source path refuses to start on a dirty tree and refuses to save or roll back once `HEAD` has moved, because rollback runs `git reset --hard` and `git clean -fd`.
+A guard like that may be made more precise about which paths a turn can touch, and it is not removed for convenience.
+Overlapping turns are rejected rather than queued or interleaved.
+Managed defaults self-heal on every launch, and that repair never deletes an extension the user created.
+
+## The interface tells the truth
+
+What the menu says happened is derived from what actually happened on disk, never from what the agent said it did.
+A turn that changed nothing says so, and a turn that failed says it failed instead of reporting a clean no-op.
+Live-data widgets show real data or an explicit unavailable or sign-in-required state, and fabricated, mocked, or silently substituted data is refused.
+A cached value is shown only when its provenance is trusted, and an untrusted cache is deleted rather than rendered.
+Failure text is actionable and sanitized, and it never carries raw provider payloads or credentials.
+
+## Guidance is code
+
+The embedded agent's prompt and the bundled recipes are a shipped surface held to the same standard as the runtime.
+When a generated widget lands wrong, the fix belongs in the guidance that misled the agent, in every place that wording appears, not in a special case for one provider.
+Recipes are self-contained implementation specs, and a recipe that sends the agent to another repo, site, or CLI to learn its own contract is unfinished.
+Recipes require inspecting the real source before writing a parser, and verifying the finished widget against that same source before reporting done.
+Reasoning about a response shape on paper is not verification.
+Recipes exist to close the agent's knowledge gaps, and they never shape what a fresh install shows.
+
+## The default is empty
+
+A new install ships the starter sample widget and nothing else.
+Every other widget exists because a person asked for it, so no provider-specific widget joins the shipped default inventory.
+Community-shared extensions are welcome as a baseline the user's own agent then customizes, while a fixed catalog the user cannot change is not.
+Telemetry is anonymous, carries no user id, device id, prompt text, or file contents, fails silently, and can be turned off.
+Anything richer than that is strictly opt-in and off by default, because users own their data.
+
+## Only what was proven ships
+
+The macOS release stays a draft until it is signed, notarized, verified on the mounted DMG, and launched as a packaged app.
+Missing or malformed signing credentials fail the release closed rather than producing an unverified artifact.
+Packaging defects are fixed at the cause: real Intel slices rather than a silenced universal merge error, build-only binaries excluded rather than shipped dead.
+A bug fix starts by reproducing the real user-visible failure, and lands a regression test at the boundary that actually broke.
+Human pull requests to `main` come through the `no-mistakes` gate, with no lower bar for an outside contributor than for the maintainer.
+
+## Scope
+
+It is not a general app platform, not an agent harness, not a chat client, and not a dashboard product.
+It is not a provider quota suite, and no shipped default makes it one.
+What it offers is not tied to one operating system, so more hosts are welcome for the reach they give it, and each one earns the same class of proof before it ships.
+The expected way to use it is the popover, so a terminal or scripted entrypoint is not the product.
+User extensions, agent sessions, caches, and preferences live under `~/.baby-menu`, never inside the app bundle.
+
+A change aligns when it makes the ask-and-it-appears loop safer, more honest, or more reversible, when it lands in the extension workspace or in the guidance that shapes it, and when it is proven against the real surface it claims to fix.
+A change should be resisted when it lets the agent edit the host, adds a bridge method a server action could have handled, puts a widget in front of a user who never asked for it, shows a value the system did not verify, or takes away the user's ability to undo.


### PR DESCRIPTION
## Intent

Co-author baby-menu's first VISION.md WITH THE REPO OWNER (kunchenguid), interactively, using the user-level /vision skill. The repo has 50+ stars and no VISION.md; the owner wanted one and wanted to co-author it rather than receive a generated document.

Process actually followed (this is why the diff looks the way it does):
- FROM-SCRATCH mode: confirmed no VISION.md exists on the default branch.
- Evidence over vibes: mined the REAL history - 72 merged PRs by kunchenguid (#1..#108), read 25 full PR bodies spread across the range, plus README.md, AGENTS.md, CONTRIBUTING.md and docs/. Every principle line traces to named PRs or files. Nothing about the owner's values was invented.
- Drafted to the /vision skill's fixed anatomy: identity opener (exists so that / serves / owns exactly one thing), 3-6 principle sections of testable present-tense commitments and refusals, an explicit Scope section of concrete non-goals, and a closing pair of 'A change aligns when ...' / 'A change should be resisted when ...' tests.
- Stress-tested the draft with 11 hard fault-line hypotheticals (no softballs; both sides steelmanned) on the /vision skill's SHIPPED lavish-axi review board template, used as-is with only its marked slots filled.
- The owner recorded all 11 verdicts on the board and closed the session with: 'refine the content with my feedback considered, and then merge it.' Every verdict was folded back into the text with a traced changelog line.

Owner verdicts that directly shaped the committed wording:
- H-1 Linux port, IN VISION ('our vision doesn't constrain the value prop to mac. more platforms will help the project reach and serve more people') -> the identity opener no longer says 'macOS user', and Scope says the value is not tied to one operating system and more hosts are welcome, each earning the same class of proof before shipping. Deliberate: do NOT flag the absence of a macOS-only non-goal as a mistake.
- H-2 bundled Claude quota widget, OFF MISSION ('default should be empty. everything should be asked by the user. recipes are there to fill in knowledge gaps, never influencing the default experience') -> the section is titled 'The default is empty'.
- H-3 always-keep mode, IN VISION ('ultimate control should be with the user. an opt-in convenience control should be okay') -> the reversibility guarantee is deliberately the ability to undo, NOT a mandatory Keep/Undo confirmation. This is an intentional softening, not an oversight.
- H-4 community registry, IN VISION -> community-shared extensions welcome as a baseline the user then customizes.
- H-5 agent editing the host, OFF MISSION ('the core has to be immutable to ensure baseline behavior is stable and security posture is enforced') -> stated as an immutable core.
- H-6 narrowing the dirty-tree refusal, IN VISION -> the guard may be made more precise about which paths a turn can touch, but is not removed for convenience. Deliberate: it is no longer phrased as absolutely unchangeable.
- H-7 sample widget, IN VISION ('we already have a hello world widget which is the sample') -> 'A new install ships the starter sample widget and nothing else'; the no-fabricated-data rule was intentionally left intact.
- H-8 npm imports in widgets, IN VISION but conditional ('we should not be supporting it by extending the hard coded list in-bundle. we will need a separate carve out') -> stated exactly that way.
- H-9 terminal entrypoint, OFF MISSION ('the expected usage is through the GUI').
- H-10 relaxing the no-mistakes gate for outside contributors, OFF MISSION -> 'with no lower bar for an outside contributor than for the maintainer'.
- H-11 richer telemetry, IN VISION but strictly opt-in ('users own their data').

Constraints the owner and the task imposed:
- Documentation only. No code changes, no test changes, no behavior changes. VISION.md is prose, not a machine-consumed artifact, so it needs no unit test; do not ask for one.
- Formatting is part of the contract: one sentence per line, plain hyphens only (never em dashes), no roadmap, no feature list, no marketing voice, 40-70 lines. The file is 70 lines. Long single-sentence lines are intentional.
- The committed text is the owner-approved board text with his verdicts folded in; do not reword, soften, or 'improve' the owner's stated positions.

Diff contents: adds VISION.md at the repo root (70 lines), plus a one-line pointer in AGENTS.md naming VISION.md as the project's acceptance policy so future sessions apply its aligns/resisted tests. That AGENTS.md line follows the repo's own 'Maintaining this file' rule of pointing at the authoritative file rather than repeating it.

## What Changed

- Add `VISION.md` defining baby-menu's product principles, scope, safety commitments, and change acceptance tests.
- Point contributors and agents to the vision as the authoritative policy for evaluating changes.

## Risk Assessment

✅ Low: The change is documentation-only, matches the owner-approved intent and required vision anatomy, and introduces no source-verifiable behavioral risk.

## Testing

Validated the documentation-only diff against the owner's required vision anatomy and formatting, manually reviewed the complete wording, and rendered the public document for visual inspection; all checks succeeded without modifying the worktree.

- Evidence: [Rendered VISION.md preview](https://github.com/kunchenguid/baby-menu/blob/f787336a8b8129393a3693e0c2be611bec133413/.no-mistakes/evidence/fm/vision-baby-menu-r1/vision-rendered.html.png)
<details>
<summary>Evidence: Complete rendered VISION.md</summary>

Source: [Complete rendered VISION.md](https://github.com/kunchenguid/baby-menu/blob/f787336a8b8129393a3693e0c2be611bec133413/.no-mistakes/evidence/fm/vision-baby-menu-r1/vision-rendered.html)

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
<title>baby-menu Vision</title><style>
:root { color-scheme: light; }
body { margin: 0; background: #f4f2ed; color: #191919; font: 18px/1.65 ui-serif, Georgia, serif; }
main { max-width: 860px; margin: 48px auto; padding: 56px 72px; background: white; box-shadow: 0 10px 40px #00000012; }
h1 { margin: 0 0 30px; font: 700 48px/1.1 ui-sans-serif, system-ui; letter-spacing: -0.03em; }
h2 { margin: 46px 0 16px; padding-top: 18px; border-top: 1px solid #d8d3ca; font: 700 27px/1.2 ui-sans-serif, system-ui; letter-spacing: -0.015em; }
p { margin: 0 0 12px; }
code { font: .88em ui-monospace, SFMono-Regular, monospace; background: #f1eee8; padding: .12em .3em; border-radius: 4px; }
</style></head><body><main><h1>Vision</h1><p><code>baby-menu</code> exists so that a person can grow their own menu bar by asking for it, instead of waiting for someone else to ship the widget they wanted.</p><p>It serves one person on their own machine, running an authenticated coding agent CLI, and it turns a plain-English request into a live widget in their own menu.</p><p>It owns exactly one thing: the tray popover surface and the safe loop that lets an embedded agent edit it while it is running.</p><h2>The extension workspace is the product</h2><p>The agent edits extensions, never the host.</p><p>Widgets, root layouts, settings sections, server actions, and background tasks all live in the active extension workspace, and new capability arrives as a new extension.</p><p>The core stays immutable at runtime, because that immutability is what keeps baseline behavior stable and the security posture enforced.</p><p><code>src/main</code>, <code>src/preload</code>, and the IPC wiring stay boring infrastructure, and growing them to serve one widget is the wrong shape.</p><p>Everything an extension can reach arrives through the stable <code>window.babyMenu</code> bridge and the generated <code>@babymenu/contracts</code> surface.</p><p>Per-widget IPC channels and per-capability preload methods are refused.</p><p>Widgets may reach past <code>react</code> and <code>@babymenu/ui</code>, but never by lengthening a hardcoded in-bundle allowlist, so that capability has to arrive as its own explicit mechanism.</p><p>Privileged work - filesystem, shell, network, credentials, tokens - lives in extension server actions in the main process, and only normalized non-secret data crosses into the renderer.</p><h2>The user can always undo</h2><p>An agent that edits running software is only acceptable if the user can take it back.</p><p>Every accepted turn runs inside a change session, and the diff that session records is what the Keep/Undo bar reports.</p><p>Ultimate control sits with the user, so the guarantee is the ability to undo rather than a mandatory confirmation: a user may opt into keeping turns automatically, and may never be opted out of being able to undo them.</p><p>The tracked-source path refuses to start on a dirty tree and refuses to save or roll back once <code>HEAD</code> has moved, because rollback runs <code>git reset --hard</code> and <code>git clean -fd</code>.</p><p>A guard like that may be made more precise about which paths a turn can touch, and it is not removed for convenience.</p><p>Overlapping turns are rejected rather than queued or interleaved.</p><p>Managed defaults self-heal on every launch, and that repair never deletes an extension the user created.</p><h2>The interface tells the truth</h2><p>What the menu says happened is derived from what actually happened on disk, never from what the agent said it did.</p><p>A turn that changed nothing says so, and a turn that failed says it failed instead of reporting a clean no-op.</p><p>Live-data widgets show real data or an explicit unavailable or sign-in-required state, and fabricated, mocked, or silently substituted data is refused.</p><p>A cached value is shown only when its provenance is trusted, and an untrusted cache is deleted rather than rendered.</p><p>Failure text is actionable and sanitized, and it never carries raw provider payloads or credentials.</p><h2>Guidance is code</h2><p>The embedded agent&#x27;s prompt and the bundled recipes are a shipped surface held to the same standard as the runtime.</p><p>When a generated widget lands wrong, the fix belongs in the guidance that misled the agent, in every place that wording appears, not in a special case for one provider.</p><p>Recipes are self-contained implementation specs, and a recipe that sends the agent to another repo, site, or CLI to learn its own contract is unfinished.</p><p>Recipes require inspecting the real source before writing a parser, and verifying the finished widget against that same source before reporting done.</p><p>Reasoning about a response shape on paper is not verification.</p><p>Recipes exist to close the agent&#x27;s knowledge gaps, and they never shape what a fresh install shows.</p><h2>The default is empty</h2><p>A new install ships the starter sample widget and nothing else.</p><p>Every other widget exists because a person asked for it, so no provider-specific widget joins the shipped default inventory.</p><p>Community-shared extensions are welcome as a baseline the user&#x27;s own agent then customizes, while a fixed catalog the user cannot change is not.</p><p>Telemetry is anonymous, carries no user id, device id, prompt text, or file contents, fails silently, and can be turned off.</p><p>Anything richer than that is strictly opt-in and off by default, because users own their data.</p><h2>Only what was proven ships</h2><p>The macOS release stays a draft until it is signed, notarized, verified on the mounted DMG, and launched as a packaged app.</p><p>Missing or malformed signing credentials fail the release closed rather than producing an unverified artifact.</p><p>Packaging defects are fixed at the cause: real Intel slices rather than a silenced universal merge error, build-only binaries excluded rather than shipped dead.</p><p>A bug fix starts by reproducing the real user-visible failure, and lands a regression test at the boundary that actually broke.</p><p>Human pull requests to <code>main</code> come through the <code>no-mistakes</code> gate, with no lower bar for an outside contributor than for the maintainer.</p><h2>Scope</h2><p>It is not a general app platform, not an agent harness, not a chat client, and not a dashboard product.</p><p>It is not a provider quota suite, and no shipped default makes it one.</p><p>What it offers is not tied to one operating system, so more hosts are welcome for the reach they give it, and each one earns the same class of proof before it ships.</p><p>The expected way to use it is the popover, so a terminal or scripted entrypoint is not the product.</p><p>User extensions, agent sessions, caches, and preferences live under <code>~/.baby-menu</code>, never inside the app bundle.</p><p>A change aligns when it makes the ask-and-it-appears loop safer, more honest, or more reversible, when it lands in the extension workspace or in the guidance that shapes it, and when it is proven against the real surface it claims to fix.</p><p>A change should be resisted when it lets the agent edit the host, adds a bridge method a server action could have handled, puts a widget in front of a user who never asked for it, shows a value the system did not verify, or takes away the user&#x27;s ability to undo.</p></main></body></html>
```
</details>
<details>
<summary>Evidence: VISION.md acceptance-contract validation</summary>

Source: [VISION.md acceptance-contract validation](https://github.com/kunchenguid/baby-menu/blob/f787336a8b8129393a3693e0c2be611bec133413/.no-mistakes/evidence/fm/vision-baby-menu-r1/vision-contract-validation.txt)

```text
VISION.md acceptance-contract validation: PASS
- Changed files are documentation only: AGENTS.md and VISION.md
- VISION.md has exactly 70 lines
- No em dash character appears
- Six principle sections precede the explicit Scope section
- Every prose line ends as a complete sentence
- The final two lines are the required aligns/resisted decision tests
- git diff --check reports no whitespace errors
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2eb55c4785cd967fb0793ce324a425ed35a8086f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat --name-status b11e3800458b61c5c302a80d169be03f8637841d..2eb55c4785cd967fb0793ce324a425ed35a8086f` - confirmed the change is documentation-only</code>
- <code>`git diff --check b11e3800458b61c5c302a80d169be03f8637841d..2eb55c4785cd967fb0793ce324a425ed35a8086f` - checked whitespace integrity</code>
- `Focused Python acceptance-contract check - verified 70 lines, plain hyphens, six principle sections, explicit Scope, complete prose lines, and closing aligns/resisted tests`
- <code>Rendered `VISION.md` to reviewer-visible HTML and generated a Quick Look PNG preview</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
