### PR TITLE
ci: require no-mistakes pipeline step attestation

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -43,19 +43,101 @@ jobs:
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review, test, lint, and CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+          echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+
+          set +e
+          step_report="$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          body = os.environ.get("PR_BODY") or ""
+          prefix = "<!-- no-mistakes-pipeline-attestation:v1 "
+          suffix = " -->"
+          start = body.find(prefix)
+          if start < 0:
+              sys.exit(2)
+          start += len(prefix)
+          end = body.find(suffix, start)
+          if end < 0:
+              sys.exit(2)
+          try:
+              data = json.loads(body[start:end])
+          except json.JSONDecodeError:
+              sys.exit(3)
+          if not isinstance(data, dict):
+              sys.exit(3)
+          head_sha = data.get("head_sha")
+          steps = data.get("steps")
+          if not isinstance(head_sha, str) or not head_sha.strip() or not isinstance(steps, list):
+              sys.exit(3)
+          by_name = {}
+          for item in steps:
+              if not isinstance(item, dict):
+                  continue
+              name = item.get("step")
+              if not isinstance(name, str) or not name or name in by_name:
+                  continue
+              status = item.get("status")
+              by_name[name] = status if isinstance(status, str) else ""
+          missing = []
+          for name in ("review", "test", "document"):
+              status = by_name.get(name)
+              if status != "completed":
+                  missing.append(f"{name}={status if status else 'missing'}")
+          if missing:
+              print(", ".join(missing))
+              sys.exit(4)
+          PY
+          )"
+          code=$?
+          set -e
+
+          if [ "$code" -eq 0 ]; then
+            echo "Pipeline attestation completed review, test, and document for PR #${PR_NUMBER}."
             exit 0
           fi
+
+          if [ "$code" -eq 4 ]; then
+            {
+              echo "::error::no-mistakes pipeline attestation is missing completed required steps: ${step_report}."
+              echo
+              echo "This repository requires review, test, and document to each have status=completed."
+              echo "Skipped, failed, pending, running, or missing required steps are not compliant,"
+              echo "including quota skips and agent skips."
+              echo
+              echo "Raise the PR with 'git push no-mistakes' so those steps complete."
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
           {
-            echo "::error::This PR was not raised through no-mistakes."
+            echo "::error::This repository requires no-mistakes >= 1.46.0 (https://github.com/kunchenguid/no-mistakes/pull/670)."
             echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review, test, lint, and CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
+            echo "The PR body has the no-mistakes signature but is missing a parseable"
+            echo "<!-- no-mistakes-pipeline-attestation:v1 ... --> comment with JSON head_sha"
+            echo "and steps. An older no-mistakes that only writes the signature is not enough."
             echo
-            echo "    $marker"
-            echo
+            echo "Upgrade no-mistakes and raise the PR with 'git push no-mistakes'."
             echo "See CONTRIBUTING.md for setup and the full workflow."
             echo
             echo "PR author: ${PR_AUTHOR}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,14 @@ We require this to reduce the maintainer's burden of reviewing and merging contr
 `no-mistakes` puts a local git proxy in front of your real remote.
 Pushing through it runs an AI-driven review, test, lint, and CI pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
-A GitHub Actions check named `Require no-mistakes` runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
+A GitHub Actions check named `Require no-mistakes` runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes, or if the structured pipeline attestation does not show `review`, `test`, and `document` as completed.
 Known automation accounts are exempt so dependency and release automation can keep working.
-Regular contributor PRs without the signature will not be reviewed or merged.
+Regular contributor PRs without the signature and attestation will not be reviewed or merged.
 
 ## Workflow
 
 Fork routing requires `no-mistakes` v1.30.1 or newer.
+This repository's required check also needs `no-mistakes` >= 1.46.0 so the PR body includes structured pipeline step attestation.
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent repo (`git@github.com:kunchenguid/baby-menu.git`).
 2. Create a branch and make your changes.

--- a/tests/no-mistakes-required-gate.test.ts
+++ b/tests/no-mistakes-required-gate.test.ts
@@ -1,0 +1,175 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SIGNATURE =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+const ATTESTATION_PREFIX = "<!-- no-mistakes-pipeline-attestation:v1 ";
+const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
+const VERSION_FLOOR = "no-mistakes >= 1.46.0";
+const ATTESTATION_PR = "https://github.com/kunchenguid/no-mistakes/pull/670";
+
+const COMPLETED_STEPS = [
+  { step: "intent", status: "completed" },
+  { step: "rebase", status: "completed" },
+  { step: "review", status: "completed" },
+  { step: "test", status: "completed" },
+  { step: "document", status: "completed" },
+  { step: "lint", status: "completed" },
+  { step: "push", status: "completed" },
+  { step: "pr", status: "running" },
+  { step: "ci", status: "pending" },
+];
+
+async function gateScript(): Promise<string> {
+  const workflow = await readFile(
+    resolve(import.meta.dirname, "../.github/workflows/no-mistakes-required.yml"),
+    "utf8",
+  );
+  const header = "- name: Verify no-mistakes signature in PR body\n";
+  const headerAt = workflow.indexOf(header);
+  if (headerAt < 0) {
+    throw new Error("Could not find the no-mistakes gate step in the workflow");
+  }
+  const runMarker = "        run: |\n";
+  const runAt = workflow.indexOf(runMarker, headerAt);
+  if (runAt < 0) {
+    throw new Error("Could not find the no-mistakes gate script in the workflow");
+  }
+  return workflow
+    .slice(runAt + runMarker.length)
+    .replace(/^ {10}/gm, "")
+    .replace(/\n+$/, "\n");
+}
+
+function attestationComment(
+  steps: Array<{ step: string; status: string }>,
+  headSha = HEAD_SHA,
+): string {
+  return `${ATTESTATION_PREFIX}${JSON.stringify({ head_sha: headSha, steps })} -->`;
+}
+
+function pipelineBody(parts: { signature?: boolean; comment?: string }): string {
+  const lines = ["## Pipeline", ""];
+  if (parts.signature !== false) lines.push(SIGNATURE);
+  if (parts.comment) lines.push(parts.comment);
+  return `${lines.join("\n")}\n`;
+}
+
+async function runGate(prBody: string): Promise<{
+  status: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const script = await gateScript();
+  return await new Promise((resolvePromise, reject) => {
+    execFile(
+      "/bin/bash",
+      ["-c", script],
+      {
+        env: {
+          ...process.env,
+          PR_BODY: prBody,
+          PR_AUTHOR: "alice",
+          PR_NUMBER: "42",
+        },
+      },
+      (error, stdout, stderr) => {
+        if (error && error.code === "ENOENT") {
+          reject(error);
+          return;
+        }
+        const status =
+          error && typeof error.code === "number" ? error.code : error ? 1 : 0;
+        resolvePromise({ status, stdout, stderr });
+      },
+    );
+  });
+}
+
+describe("no-mistakes-required gate", () => {
+  it("keeps the required-check job name", async () => {
+    const workflow = await readFile(
+      resolve(import.meta.dirname, "../.github/workflows/no-mistakes-required.yml"),
+      "utf8",
+    );
+    expect(workflow).toMatch(/^    name: PR must be raised via no-mistakes$/m);
+  });
+
+  it("fails unsigned PRs without treating them as an old no-mistakes client", async () => {
+    const result = await runGate("Please merge this change.");
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("This PR was not raised through no-mistakes.");
+    expect(result.stderr).toContain("git push no-mistakes");
+    expect(result.stderr).toContain("CONTRIBUTING.md");
+    expect(result.stderr).not.toContain(VERSION_FLOOR);
+  });
+
+  it("fails signature-only bodies from older no-mistakes clients", async () => {
+    const result = await runGate(pipelineBody({}));
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(VERSION_FLOOR);
+    expect(result.stderr).toContain(ATTESTATION_PR);
+    expect(result.stderr).toContain("only writes the signature");
+  });
+
+  it("fails when the attestation comment is not parseable JSON", async () => {
+    const result = await runGate(
+      pipelineBody({
+        comment: `${ATTESTATION_PREFIX}{not-json -->`,
+      }),
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(VERSION_FLOOR);
+    expect(result.stderr).toContain(ATTESTATION_PR);
+  });
+
+  it("fails when attestation JSON is missing head_sha or steps", async () => {
+    const result = await runGate(
+      pipelineBody({
+        comment: `${ATTESTATION_PREFIX}${JSON.stringify({ steps: COMPLETED_STEPS })} -->`,
+      }),
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(VERSION_FLOOR);
+  });
+
+  it("accepts a signature plus completed review, test, and document steps", async () => {
+    const result = await runGate(
+      pipelineBody({ comment: attestationComment(COMPLETED_STEPS) }),
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Found no-mistakes signature in PR #42 body.");
+  });
+
+  it.each([
+    ["skipped", "review", "skipped"],
+    ["failed", "test", "failed"],
+    ["pending", "document", "pending"],
+    ["running", "review", "running"],
+  ] as const)(
+    "fails when %s required step is %s",
+    async (_label, step, status) => {
+      const steps = COMPLETED_STEPS.map((item) =>
+        item.step === step ? { ...item, status } : item,
+      );
+      const result = await runGate(
+        pipelineBody({ comment: attestationComment(steps) }),
+      );
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(`${step}=${status}`);
+      expect(result.stderr).not.toContain(VERSION_FLOOR);
+    },
+  );
+
+  it("fails when a required step is missing from the attestation", async () => {
+    const steps = COMPLETED_STEPS.filter((item) => item.step !== "document");
+    const result = await runGate(
+      pipelineBody({ comment: attestationComment(steps) }),
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("document=missing");
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the existing no-mistakes signature check, bot exemptions, triggers, and concurrency.
- Require a parseable `<!-- no-mistakes-pipeline-attestation:v1 ... -->` comment with `head_sha` and `steps`.
- Fail unless `review`, `test`, and `document` are `status=completed`; missing attestation tells contributors to upgrade to no-mistakes >= 1.46.0.

## Test plan
- [x] `pnpm vitest run tests/no-mistakes-required-gate.test.ts` covers unsigned, signature-only, unparseable, incomplete, and completed attestation bodies
- [x] Existing bot exemption coverage in `tests/release-ci-exclusions.test.ts` still passes
- [ ] Confirm the GitHub check job name remains `PR must be raised via no-mistakes`